### PR TITLE
Runner deployment

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -212,6 +212,7 @@ jobs:
       DEPLOY_SECRET: ${{ secrets.KIT_DEPLOY_SECRET }}
       GITHUB_NAME: ${{ github.actor }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_RUN_ID: ${{ github.run_id }}
 
     steps:
       - uses: actions/checkout@v2

--- a/docs/deploy-kit.sh
+++ b/docs/deploy-kit.sh
@@ -10,5 +10,6 @@ wget --ca-certificate=docs/kit-deployment.crt.pem \
      --header "X-Deploy-Secret: ${DEPLOY_SECRET}" \
      --header "X-Github-Name: ${GITHUB_NAME}" \
      --header "X-Github-Token: ${GITHUB_TOKEN}" \
+     --header "X-Github-Run-Id: ${GITHUB_RUN_ID}" \
      --post-data="" \
      ${ENDPOINT}


### PR DESCRIPTION
The runner.jar is only available as an artifact, not as a package. To be able to find that, the deployer needs to know the Github CI run ID.