### PR TITLE
Subtile snackbar messages

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,11 +1,11 @@
 <template>
   <v-app>
-    <v-content>
+    <v-main>
       <nav-bar></nav-bar>
       <snackbar ref="global-snackbar"></snackbar>
       <router-view />
       <theme-selector @useDarkTheme="setDarkTheme"></theme-selector>
-    </v-content>
+    </v-main>
   </v-app>
 </template>
 

--- a/frontend/src/axios-config-userdata.d.ts
+++ b/frontend/src/axios-config-userdata.d.ts
@@ -24,7 +24,7 @@ declare module 'axios' {
      * @type {boolean}
      * @memberof AxiosRequestConfig
      */
-    hideSuccessSnackbar?: boolean
+    showSuccessSnackbar?: boolean
 
     /**
      * Whether to hide the error snackbar messages.
@@ -41,5 +41,13 @@ declare module 'axios' {
      * @memberof AxiosRequestConfig
      */
     snackbarTag?: string
+
+    /**
+     * A number uniquely identifying this request.
+     *
+     * @type {number}
+     * @memberof AxiosRequestConfig
+     */
+    randomTag?: number
   }
 }

--- a/frontend/src/components/Snackbar.vue
+++ b/frontend/src/components/Snackbar.vue
@@ -1,6 +1,15 @@
 <template>
-  <v-snackbar v-model="displaySnackbar" :timeout="timeout" :color="color">
-    <v-progress-circular v-if="loading" indeterminate></v-progress-circular>
+  <v-snackbar
+    shaped
+    v-model="displaySnackbar"
+    :timeout="timeout"
+    :color="color"
+  >
+    <v-progress-circular
+      class="mr-2"
+      v-if="loading"
+      indeterminate
+    ></v-progress-circular>
     {{ text }}
     <template v-slot:action="{ attrs }">
       <v-btn

--- a/frontend/src/components/Snackbar.vue
+++ b/frontend/src/components/Snackbar.vue
@@ -2,7 +2,16 @@
   <v-snackbar v-model="displaySnackbar" :timeout="timeout" :color="color">
     <v-progress-circular v-if="loading" indeterminate></v-progress-circular>
     {{ text }}
-    <v-btn dark color="ping" text @click="displaySnackbar = false">Close</v-btn>
+    <template v-slot:action="{ attrs }">
+      <v-btn
+        dark
+        color="ping"
+        text
+        v-bind="attrs"
+        @click="displaySnackbar = false"
+        >Close</v-btn
+      >
+    </template>
   </v-snackbar>
 </template>
 

--- a/frontend/src/components/Snackbar.vue
+++ b/frontend/src/components/Snackbar.vue
@@ -70,12 +70,11 @@ export default class Snackbar extends Vue implements ISnackbar {
   }
 
   finishedLoading(tag: string, priority?: number) {
-    this.displayNormalText(
-      this.appendTag('Success', `'${tag}'`, ' for ') + '!',
-      'snackbarSuccess',
-      2 * 1000,
-      priority
-    )
+    let shouldHideExisting = this.currentPriority <= (priority || 1)
+
+    if (shouldHideExisting && this.displaySnackbar) {
+      this.displaySnackbar = false
+    }
   }
 
   private appendTag(text: string, tag: string, interpolation?: string): string {

--- a/frontend/src/components/overviews/QueueOverview.vue
+++ b/frontend/src/components/overviews/QueueOverview.vue
@@ -19,7 +19,8 @@
                   text
                   outlined
                   @click="cancelAllFetched()"
-                >Cancel all</v-btn>
+                  >Cancel all</v-btn
+                >
               </template>
               Cancels
               <strong>all</strong> tasks you can see in the queue.
@@ -37,30 +38,45 @@
           >
             <commit-overview-base :commit="commit">
               <template #body.top>
-                <v-progress-linear indeterminate v-if="inProgress(commit)" color="accent"></v-progress-linear>
+                <v-progress-linear
+                  indeterminate
+                  v-if="inProgress(commit)"
+                  color="accent"
+                ></v-progress-linear>
               </template>
               <template #avatar>
-                <v-list-item-avatar
-                  class="index-indicator"
-                >{{ (page - 1) * itemsPerPage + index + 1 }}</v-list-item-avatar>
+                <v-list-item-avatar class="index-indicator">{{
+                  (page - 1) * itemsPerPage + index + 1
+                }}</v-list-item-avatar>
               </template>
               <template #content v-if="getWorker(commit)">
                 <v-tooltip top>
                   <template #activator="{ on }">
                     <span style="flex: 0 0;" class="pt-3">
-                      <v-chip v-on="on" outlined label>Running on » {{ getWorker(commit).name }} «</v-chip>
+                      <v-chip v-on="on" outlined label
+                        >Running on » {{ getWorker(commit).name }} «</v-chip
+                      >
                     </span>
                   </template>
-                  <span
-                    style="white-space: pre; font-family: monospace;"
-                  >{{ getWorker(commit).osData }}</span>
+                  <span style="white-space: pre; font-family: monospace;">{{
+                    getWorker(commit).osData
+                  }}</span>
                 </v-tooltip>
               </template>
               <template #actions v-if="isAdmin">
-                <v-btn icon v-if="!inProgress(commit)" @click="liftToFront(commit, $event)">
+                <v-btn
+                  icon
+                  v-if="!inProgress(commit)"
+                  @click="liftToFront(commit, $event)"
+                >
                   <v-icon class="rocket">{{ liftToFrontIcon }}</v-icon>
                 </v-btn>
-                <v-progress-circular indeterminate color="accent" class="mx-1" v-else></v-progress-circular>
+                <v-progress-circular
+                  indeterminate
+                  color="accent"
+                  class="mx-1"
+                  v-else
+                ></v-progress-circular>
                 <v-btn icon @click="deleteCommit(commit)">
                   <v-icon color="red">{{ deleteIcon }}</v-icon>
                 </v-btn>
@@ -226,8 +242,7 @@ export default class QueueOverview extends Vue {
       vxm.queueModule.openTasks.map(it => {
         return vxm.queueModule.dispatchDeleteOpenTask({
           commit: it,
-          suppressRefetch: true,
-          suppressSnackbar: true
+          suppressRefetch: true
         })
       })
     )
@@ -246,7 +261,7 @@ export default class QueueOverview extends Vue {
         )
       })
       .finally(() => {
-        vxm.queueModule.fetchQueue({ hideFromSnackbar: true })
+        vxm.queueModule.fetchQueue()
       })
   }
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3,7 +3,7 @@ import './class-components-router-hooks' // Register custom hooks
 import App from './App.vue'
 import router from './router'
 import { store, vxm, restoreFromPassedSession } from './store'
-import axios from 'axios'
+import axios, { AxiosRequestConfig } from 'axios'
 import vuetify from './plugins/vuetify'
 import { extractErrorMessage } from './util/ErrorUtils'
 
@@ -64,13 +64,8 @@ axios.interceptors.request.use(
 // Intercept responses to show errors
 axios.interceptors.response.use(
   function(response) {
-    if (
-      !response.config.hideSuccessSnackbar &&
-      !response.config.hideFromSnackbar
-    ) {
-      let prefix = response.config.snackbarTag || ''
-      vue.$globalSnackbar.finishedLoading(prefix)
-    }
+    let prefix = response.config.snackbarTag || ''
+    vue.$globalSnackbar.finishedLoading(prefix)
     return response
   },
   function(error) {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -42,16 +42,28 @@ axios.interceptors.request.use(function(config) {
   return config
 })
 
+let loadingElements: Set<number> = new Set()
+
 // Intercept requests and show a loading indicator / errors
 axios.interceptors.request.use(
   function(config) {
     if (!config.hideLoadingSnackbar && !config.hideFromSnackbar) {
       let prefix = config.snackbarTag || ''
-      vue.$globalSnackbar.setLoading(prefix)
+      let randomTag = Math.floor(Math.random() * Number.MAX_VALUE)
+      config.randomTag = randomTag
+      loadingElements.add(randomTag)
+
+      setTimeout(() => {
+        if (loadingElements.has(randomTag)) {
+          vue.$globalSnackbar.setLoading(prefix)
+        }
+      }, 1000)
     }
     return config
   },
   function(error) {
+    loadingElements.delete(error.config.randomTag)
+
     // Always display network errors
     if (!error.response) {
       let prefix = error.config.snackbarTag || ''
@@ -64,11 +76,20 @@ axios.interceptors.request.use(
 // Intercept responses to show errors
 axios.interceptors.response.use(
   function(response) {
+    loadingElements.delete(response.config.randomTag!)
+
     let prefix = response.config.snackbarTag || ''
     vue.$globalSnackbar.finishedLoading(prefix)
+
+    if (response.config.showSuccessSnackbar) {
+      vue.$globalSnackbar.setSuccess(prefix, 'Success!')
+    }
+
     return response
   },
   function(error) {
+    loadingElements.delete(error.config.randomTag)
+
     if (!error.config.hideFromSnackbar && !error.config.hideErrorSnackbar) {
       let prefix = error.config.snackbarTag || ''
       vue.$globalSnackbar.setError(prefix, extractErrorMessage(error))

--- a/frontend/src/store/modules/queueStore.ts
+++ b/frontend/src/store/modules/queueStore.ts
@@ -22,12 +22,8 @@ export class QueueStore extends VxModule {
    * @memberof QueueModuleStore
    */
   @action
-  async fetchQueue(payload?: {
-    hideFromSnackbar?: boolean
-  }): Promise<Commit[]> {
+  async fetchQueue(): Promise<Commit[]> {
     const response = await axios.get('/queue', {
-      hideLoadingSnackbar: payload && payload.hideFromSnackbar,
-      hideSuccessSnackbar: payload && payload.hideFromSnackbar,
       snackbarTag: 'queue'
     })
 
@@ -86,10 +82,14 @@ export class QueueStore extends VxModule {
   @action
   dispatchPrioritizeOpenTask(payload: Commit): Promise<void> {
     return axios
-      .post('/queue', {
-        repo_id: payload.repoID,
-        commit_hash: payload.hash
-      })
+      .post(
+        '/queue',
+        {
+          repo_id: payload.repoID,
+          commit_hash: payload.hash
+        },
+        { showSuccessSnackbar: true }
+      )
       .then(() => {
         this.prioritizeOpenTask(payload)
       })
@@ -105,11 +105,15 @@ export class QueueStore extends VxModule {
   @action
   dispatchQueueUpwardsOf(commit: Commit): Promise<void> {
     return axios
-      .post('/queue', {
-        repo_id: commit.repoID,
-        commit_hash: commit.hash,
-        include_all_commits_after: true
-      })
+      .post(
+        '/queue',
+        {
+          repo_id: commit.repoID,
+          commit_hash: commit.hash,
+          include_all_commits_after: true
+        },
+        { showSuccessSnackbar: true }
+      )
       .then(() => {
         this.prioritizeOpenTask(commit)
       })
@@ -130,12 +134,9 @@ export class QueueStore extends VxModule {
   dispatchDeleteOpenTask(payload: {
     commit: Commit
     suppressRefetch?: boolean
-    suppressSnackbar?: boolean
   }): Promise<void> {
     return axios
       .delete('/queue', {
-        hideSuccessSnackbar: payload.suppressSnackbar,
-        hideLoadingSnackbar: payload.suppressSnackbar,
         params: {
           repo_id: payload.commit.repoID,
           commit_hash: payload.commit.hash

--- a/frontend/src/store/modules/repoStore.ts
+++ b/frontend/src/store/modules/repoStore.ts
@@ -18,8 +18,7 @@ export class RepoStore extends VxModule {
   async fetchRepos() {
     const response = await axios.get('/all-repos', {
       snackbarTag: 'all repos',
-      hideLoadingSnackbar: true,
-      hideSuccessSnackbar: true
+      hideLoadingSnackbar: true
       // still show errors
     })
 


### PR DESCRIPTION
## Problem
The snackbar messages, while useful for debugging, were a bit annoying and probably the feature causing most complaints...

## Solution in this PR
1. Success messages are *never* automatically displayed -- users likely only care about errors or slow loading pages
2. The "loading" indicator is only shown when the requests takes longer than one second (this time is up for debate)
3. Some actions - like (Re)benchmark or "One Up" - always show a success message, as their success has no other visual indication in the UI
4. The "All repo" request does not show any indicator (except for errors) as it might be triggered quite frequently and *should* be fast

## References / Closes
#19 