### PR TITLE
Resize the detail echarts chart to take up ~80% of the viewport height

### DIFF
--- a/frontend/src/components/graphs/ECharts-Detail.vue
+++ b/frontend/src/components/graphs/ECharts-Detail.vue
@@ -15,12 +15,12 @@
           @selectCommitToCompare="commitToCompare = selectedDatapoint"
           @compareCommits="compareCommits"
         ></datapoint-dialog>
-        <div id="chart" :style="{ height: this.height + 'px' }">
+        <div id="chart-container">
           <v-chart
+            :autoresize="true"
             @click="chartClicked"
             @restore="restored"
             @datazoom="zoomed"
-            id="chart"
             :options="chartOptions"
           />
         </div>
@@ -117,8 +117,6 @@ export default class EchartsDetailGraph extends Vue {
   beginYAtZero!: boolean
 
   // dimensions
-  private width: number = 0
-  private height: number = 500
   private chartOptions: EChartOption = {}
   private showGraph: boolean = false
   private datapointDialogOpen = false
@@ -397,6 +395,11 @@ export default class EchartsDetailGraph extends Vue {
   private drawGraph() {
     this.chartOptions = {
       backgroundColor: this.graphBackgroundColor,
+      grid: {
+        left: 20,
+        right: 20,
+        containLabel: true
+      },
       toolbox: {
         show: true,
         showTitle: false, // hide the default text so they don't overlap each other
@@ -764,8 +767,9 @@ export default class EchartsDetailGraph extends Vue {
   stroke-dasharray: 5 5;
 }
 
-#chart {
+#chart-container {
   position: relative;
+  height: 80vh;
 }
 
 .datapointDialog .v-input .v-label {

--- a/frontend/src/components/graphs/ECharts-Detail.vue
+++ b/frontend/src/components/graphs/ECharts-Detail.vue
@@ -401,6 +401,7 @@ export default class EchartsDetailGraph extends Vue {
         containLabel: true
       },
       toolbox: {
+        left: 'center',
         show: true,
         showTitle: false, // hide the default text so they don't overlap each other
         feature: {
@@ -416,12 +417,6 @@ export default class EchartsDetailGraph extends Vue {
         tooltip: {
           show: true
         }
-      },
-      title: {
-        text: 'A graph',
-        left: '50%',
-        textAlign: 'center',
-        top: '20px'
       },
       xAxis: {
         type: 'value',


### PR DESCRIPTION
This PR will adjust the ECharts detail graph to take up 80% ov the viewport height, though that number might be adjusted.

It also removes the title, centers the toolbox and trims down the margins around the ECharts detail graph.

### Before
<hr>

![Before](https://user-images.githubusercontent.com/20284688/87412375-44b48100-c5c9-11ea-9624-6cee3dda4982.png)
<hr>

### After
<hr>

![After](https://user-images.githubusercontent.com/20284688/87412588-80e7e180-c5c9-11ea-8d9a-7174ff99a33c.png)
<hr>
