### PR TITLE
Correct Echarts dag type on switch

### DIFF
--- a/frontend/src/components/graphs/ECharts-Detail.vue
+++ b/frontend/src/components/graphs/ECharts-Detail.vue
@@ -131,6 +131,8 @@ export default class EchartsDetailGraph extends Vue {
     itemInfo: ItemInfo
   } | null = null
   private allowSelectAsReference: boolean = true
+  private zoomStartPercent: number = 0
+  private zoomEndPercent: number = 1
 
   private numberFormat: Intl.NumberFormat = new Intl.NumberFormat(
     this.getLocaleString(),
@@ -283,7 +285,7 @@ export default class EchartsDetailGraph extends Vue {
   }
 
   private restored(e: any) {
-    this.updateGraphTyp(0, 1)
+    this.updateGraphType()
   }
 
   private zoomed(e: any) {
@@ -312,11 +314,14 @@ export default class EchartsDetailGraph extends Vue {
       return
     }
 
-    this.updateGraphTyp(startPercent, endPercent)
+    this.zoomStartPercent = startPercent
+    this.zoomEndPercent = endPercent
+    this.updateGraphType()
   }
 
-  private updateGraphTyp(startPercent: number, endPercent: number) {
-    let visibleCommits = (endPercent - startPercent) * this.amount
+  private updateGraphType() {
+    let visibleCommits =
+      (this.zoomEndPercent - this.zoomStartPercent) * this.amount
     let showSymbols = visibleCommits * this.groupedByMeasurement.size < 200
 
     if (this.showGraph !== showSymbols) {
@@ -392,6 +397,7 @@ export default class EchartsDetailGraph extends Vue {
   @Watch('amount')
   private updateData() {
     this.drawGraph()
+    this.updateGraphType()
   }
 
   private drawGraph() {
@@ -407,7 +413,9 @@ export default class EchartsDetailGraph extends Vue {
             title: {
               zoom: 'Zoom (brush)',
               back: 'Reset zoom'
-            }
+            },
+            start: this.zoomStartPercent * 100,
+            end: this.zoomEndPercent * 100
           }
         },
         tooltip: {

--- a/frontend/src/views/RepoDetail.vue
+++ b/frontend/src/views/RepoDetail.vue
@@ -35,15 +35,13 @@
             </v-col>
           </v-row>
           <v-card flat>
-            <keep-alive>
-              <component
-                v-bind:is="currentFlavour.component"
-                :measurements="selectedMeasurements"
-                :amount="Number.parseInt(amount)"
-                :beginYAtZero="this.yScaleBeginsAtZero"
-                @selectionChanged="updateSelection"
-              ></component>
-            </keep-alive>
+            <component
+              v-bind:is="currentFlavour.component"
+              :measurements="selectedMeasurements"
+              :amount="Number.parseInt(amount)"
+              :beginYAtZero="this.yScaleBeginsAtZero"
+              @selectionChanged="updateSelection"
+            ></component>
           </v-card>
         </v-card>
       </v-col>


### PR DESCRIPTION
#### First Problem

1. Be on the ECharts graph
2. Have few enough commits to see the DAG
3. Switch to Dygraphs
4. Change the amount to 1000 or sth
5. Go back

This was fixed by not keeping the components alive and instead recreating them, when the graph type is switched. That way echarts will receive the mounted hook and update properly.

#### Second Problem
The graph did not reconsider its type when more data became available.

Now it checks the amount of points in its zoom area when the amount of displayed data changes.