### PR TITLE
Cache available measurement names for all repos

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/ServerMain.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/ServerMain.java
@@ -110,7 +110,6 @@ public class ServerMain extends Application<GlobalConfig> {
 		DatabaseStorage databaseStorage = new DatabaseStorage(configuration);
 
 		// Access layer
-		BenchmarkWriteAccess benchmarkAccess = new BenchmarkWriteAccess(databaseStorage);
 		CommitReadAccess commitAccess = new CommitReadAccess(repoStorage);
 		KnownCommitWriteAccess knownCommitAccess = new KnownCommitWriteAccess(databaseStorage);
 		RepoWriteAccess repoAccess = new RepoWriteAccess(
@@ -124,6 +123,9 @@ public class ServerMain extends Application<GlobalConfig> {
 			new AuthToken(configuration.getWebAdminToken()),
 			configuration.getHashMemory(),
 			configuration.getHashIterations()
+		);
+		BenchmarkWriteAccess benchmarkAccess = new BenchmarkWriteAccess(
+			databaseStorage, repoAccess
 		);
 
 		// Data layer

--- a/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/access/BenchmarkAccessTest.java
+++ b/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/access/BenchmarkAccessTest.java
@@ -7,6 +7,9 @@ import static org.jooq.codegen.db.tables.Repository.REPOSITORY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import de.aaaaaaah.velcom.backend.access.entities.CommitHash;
 import de.aaaaaaah.velcom.backend.access.entities.Interpretation;
 import de.aaaaaaah.velcom.backend.access.entities.Measurement;
@@ -57,6 +60,7 @@ public class BenchmarkAccessTest {
 	@TempDir
 	Path testDir;
 	DatabaseStorage dbStorage;
+	RepoReadAccess repoAccess;
 	BenchmarkWriteAccess benchmarkAccess;
 
 	// All run lists will be ordered from most recent to least recent
@@ -69,7 +73,11 @@ public class BenchmarkAccessTest {
 	@BeforeEach
 	void setUp() throws SQLException {
 		dbStorage = new DatabaseStorage("jdbc:sqlite:file:" + testDir.resolve("data.db"));
-		benchmarkAccess = new BenchmarkWriteAccess(dbStorage);
+
+		repoAccess = mock(RepoReadAccess.class);
+		when(repoAccess.getAllRepoIds()).thenReturn(List.of(REPO_IDS));
+
+		benchmarkAccess = new BenchmarkWriteAccess(dbStorage, repoAccess);
 
 		Instant time = Instant.now();
 


### PR DESCRIPTION
Since getting the available measurements of a single repository takes way too long (about 350 milliseconds), measurement names are now cached in memory. This reduces the response time for `/all-repos/` to around 5 milliseconds while sacrificing almost no memory, since the amount of repositories and measurement names stored is probably quite low.

Additionally, every time we access any of the caches in BenchmarkReadAccess, we first check if we cache any data of repos that don't exist anymore and remove it.