### PR TITLE
[frontend] Fix public path settings

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,3 +1,3 @@
 VUE_APP_BASE_URL="https://velcom.aaaaaaah.de:81"
 NODE_ENV="production"
-SITE="aaaaaaah"
+BASE_URL="/"

--- a/frontend/.env.production-kit-single-port
+++ b/frontend/.env.production-kit-single-port
@@ -1,3 +1,3 @@
 VUE_APP_BASE_URL="http://speedcenter.informatik.kit.edu/velcom/api/"
 NODE_ENV="production"
-SITE="kit"
+BASE_URL="/velcom/"

--- a/frontend/.env.production-single-port
+++ b/frontend/.env.production-single-port
@@ -1,3 +1,3 @@
 VUE_APP_BASE_URL="https://velcom.aaaaaaah.de/api/"
 NODE_ENV="production"
-SITE="aaaaaaah"
+BASE_URL="/"

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   transpileDependencies: ['vuetify', 'vue-echarts', 'resize-detector'],
-  publicPath: process.env.SITE === 'kit' ? '/velcom/' : '/'
+  publicPath: process.env.BASE_URL
 }


### PR DESCRIPTION
The router uses history mode and therefore needs to painfully aware of where the SPA is served from. In a previous commit support for deployment at a subpath was introduced, but the BASE_URL parameter in the router was missed.

This commit removes the "SITE" parameter introduced earlier and replaces it with BASE_URL. This ensures the router is kept in  sync with the publicPath.

Documentation for that should be added to the installation instructions.

Closes #31 