### PR TITLE
Respect site-url on manually updated pages

### DIFF
--- a/frontend/src/views/RepoComparison.vue
+++ b/frontend/src/views/RepoComparison.vue
@@ -439,10 +439,16 @@ export default class RepoComparison extends Vue {
       stop: this.stopTimeString
     }
 
+    let url: string = process.env.BASE_URL
+    if (url.endsWith('/')) {
+      url = url.substring(0, url.length - 1)
+    }
+    url += this.$route.path
+
     history.replaceState(
       {},
       document.title,
-      this.$route.path +
+      url +
         '?' +
         Object.keys(newQuery)
           .map(key => {

--- a/frontend/src/views/RepoDetail.vue
+++ b/frontend/src/views/RepoDetail.vue
@@ -465,10 +465,16 @@ export default class RepoDetail extends Vue {
       yScaleBeginsAtZero: this.yScaleBeginsAtZero ? 'true' : 'false'
     }
 
+    let url: string = process.env.BASE_URL
+    if (url.endsWith('/')) {
+      url = url.substring(0, url.length - 1)
+    }
+    url += this.$route.path
+
     history.replaceState(
       {},
       document.title,
-      this.$route.path +
+      url +
         '?' +
         Object.keys(newQuery)
           .map(key => {


### PR DESCRIPTION
In a previous patch vue-router was instructed to set the correct baseurl. Sadly that URL is not returned in the "path" property (which
returns the full path of the current route) and needs to be spliced together manually.

Finally closes: #31