### PR TITLE
Fix api inconsistencies

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/runcomparison/DimensionDifference.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/runcomparison/DimensionDifference.java
@@ -43,7 +43,7 @@ public class DimensionDifference {
 		return Optional.ofNullable(secondStddev);
 	}
 
-	public double getAbsdiff() {
+	public double getDiff() {
 		return second - first;
 	}
 
@@ -52,7 +52,7 @@ public class DimensionDifference {
 			return Optional.empty();
 		}
 
-		return Optional.of(second / first);
+		return Optional.of((second - first) / first);
 	}
 
 	public boolean isSignificant() {
@@ -61,7 +61,7 @@ public class DimensionDifference {
 			.orElse(true);
 
 		boolean stddevSignificant = getSecondStddev()
-			.map(stddev -> Math.abs(getAbsdiff()) >= significanceFactors.getStddevThreshold() * stddev)
+			.map(stddev -> Math.abs(getDiff()) >= significanceFactors.getStddevThreshold() * stddev)
 			.orElse(true);
 
 		return relSignificant && stddevSignificant;

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonDimensionDifference.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonDimensionDifference.java
@@ -12,17 +12,17 @@ import javax.annotation.Nullable;
 public class JsonDimensionDifference {
 
 	private final JsonDimension dimension;
-	private final double absdiff;
+	private final double diff;
 	@Nullable
 	private final Double reldiff;
 	@Nullable
 	private final Double stddev;
 
-	public JsonDimensionDifference(JsonDimension dimension, double absdiff, @Nullable Double reldiff,
+	public JsonDimensionDifference(JsonDimension dimension, double diff, @Nullable Double reldiff,
 		@Nullable Double stddev) {
 
 		this.dimension = dimension;
-		this.absdiff = absdiff;
+		this.diff = diff;
 		this.reldiff = reldiff;
 		this.stddev = stddev;
 	}
@@ -38,7 +38,7 @@ public class JsonDimensionDifference {
 
 		return new JsonDimensionDifference(
 			JsonDimension.fromDimensionInfo(dimensionInfos.get(difference.getDimension())),
-			difference.getAbsdiff(),
+			difference.getDiff(),
 			difference.getReldiff().orElse(null),
 			difference.getSecondStddev().orElse(null)
 		);
@@ -56,8 +56,8 @@ public class JsonDimensionDifference {
 		return dimension;
 	}
 
-	public double getAbsdiff() {
-		return absdiff;
+	public double getDiff() {
+		return diff;
 	}
 
 	@Nullable

--- a/backend/backend/src/main/resources/example_config.yml
+++ b/backend/backend/src/main/resources/example_config.yml
@@ -38,7 +38,7 @@ disconnectedRunnerGracePeriodSeconds: 600
 # A commit becomes significant if the following rules hold for at least one of its measurements and
 # the corresponding measurement in the run of any parent commit:
 #
-# Rule 1: |newValue / oldValue| >= significanceRelativeThreshold
+# Rule 1: |(newValue - oldValue) / oldValue| >= significanceRelativeThreshold
 # Rule 2: |newValue - oldValue| >= significanceStddevThreshold * stddev(newValues)
 #
 # If the amount of new values is below significanceMinStddevAmount, rule 2 doesn't apply.

--- a/docs/public-api/public-api.v2.yaml
+++ b/docs/public-api/public-api.v2.yaml
@@ -458,7 +458,7 @@ paths:
       summary: test auth token
       tags: []
       responses:
-        '200':
+        '204':
           description: OK
         '401':
           description: Unauthorized

--- a/docs/public-api/public-api.v2.yaml
+++ b/docs/public-api/public-api.v2.yaml
@@ -1074,18 +1074,21 @@ components:
       properties:
         dimension:
           $ref: '#/components/schemas/Dimension'
-        absdiff:
+        diff:
           type: number
           description: new value - old value
         reldiff:
           type: number
-          description: new value / old value (only present if the old_value is non-zero)
+          description: |-
+            (new value - old value) / old value
+
+            Only present if the old_value is non-zero.
         stddev:
           type: number
           description: The standard deviation of the run the new value is from. Only present if the amount of values in the sample is above the minimum stddev amount.
       required:
         - dimension
-        - absdiff
+        - diff
   securitySchemes:
     admin_credentials:
       type: http


### PR DESCRIPTION
- Change spec so `/test-token` returns a 204 No Content on success
- Rename the `absdiff`parameter to `diff` because `absdiff` sounds too much like `|a - b|`
- Change the `reldiff` formula from `newValue / oldValue` to `(newValue - oldValue) / oldValue` (see also [wikipedia](https://en.wikipedia.org/wiki/Relative_change_and_difference))