### PR TITLE
Better runner info

### DIFF
--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/benchmarking/Benchmarker.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/benchmarking/Benchmarker.java
@@ -6,6 +6,7 @@ import de.aaaaaaah.velcom.runner.benchmarking.output.BenchmarkScriptOutputParser
 import de.aaaaaaah.velcom.runner.benchmarking.output.OutputParseException;
 import de.aaaaaaah.velcom.runner.formatting.NamedRows;
 import de.aaaaaaah.velcom.runner.formatting.NamedSections;
+import de.aaaaaaah.velcom.shared.GitProperties;
 import de.aaaaaaah.velcom.shared.protocol.serialization.Result;
 import de.aaaaaaah.velcom.shared.util.ExceptionHelper;
 import de.aaaaaaah.velcom.shared.util.execution.ProgramExecutor;
@@ -101,6 +102,7 @@ public class Benchmarker {
 	private NamedRows getBasicInfo() {
 		NamedRows rows = new NamedRows();
 		rows.add("Runner name", runnerName);
+		rows.add("Hash", GitProperties.getHash());
 
 		rows.add(
 			"System",

--- a/backend/shared/src/main/java/de/aaaaaaah/velcom/shared/util/systeminfo/CpuInfo.java
+++ b/backend/shared/src/main/java/de/aaaaaaah/velcom/shared/util/systeminfo/CpuInfo.java
@@ -59,7 +59,9 @@ public class CpuInfo {
 	}
 
 	public String format() {
-		return String.join(",", coreModels());
+		String models = String.join(",", coreModels());
+		int n = virtualCoreCount();
+		return String.format("%s (%d %s)", models, n, (n == 1) ? "thread" : "threads");
 	}
 
 	@Override

--- a/backend/shared/src/main/java/de/aaaaaaah/velcom/shared/util/systeminfo/MemoryInfo.java
+++ b/backend/shared/src/main/java/de/aaaaaaah/velcom/shared/util/systeminfo/MemoryInfo.java
@@ -8,12 +8,14 @@ import java.util.Optional;
  */
 public class MemoryInfo {
 
-	private final long freeMemoryKib;
 	private final long totalMemoryKib;
+	private final long freeMemoryKib;
+	private final long availableMemoryKib;
 
-	public MemoryInfo(long freeMemoryKib, long totalMemoryKib) {
-		this.freeMemoryKib = freeMemoryKib;
+	public MemoryInfo(long totalMemoryKib, long freeMemoryKib, long availableMemoryKib) {
 		this.totalMemoryKib = totalMemoryKib;
+		this.freeMemoryKib = freeMemoryKib;
+		this.availableMemoryKib = availableMemoryKib;
 	}
 
 	public long totalMemoryKib() {
@@ -22,6 +24,10 @@ public class MemoryInfo {
 
 	public long freeMemoryKiB() {
 		return freeMemoryKib;
+	}
+
+	public long getAvailableMemoryKib() {
+		return availableMemoryKib;
 	}
 
 	/**
@@ -35,8 +41,9 @@ public class MemoryInfo {
 	public static MemoryInfo fromMeminfo(List<String> meminfo) {
 		long memTotal = lineFromMeminfo(meminfo, "MemTotal").orElse(-1L);
 		long memFree = lineFromMeminfo(meminfo, "MemFree").orElse(-1L);
+		long memAvailable = lineFromMeminfo(meminfo, "MemAvailable").orElse(-1L);
 
-		return new MemoryInfo(memFree, memTotal);
+		return new MemoryInfo(memTotal, memFree, memAvailable);
 	}
 
 	private static Optional<Long> lineFromMeminfo(List<String> meminfo, String lineName) {
@@ -58,9 +65,9 @@ public class MemoryInfo {
 	public String format() {
 		if (totalMemoryKib > 256 * 1024) {
 			return String
-				.format("%d MiB used, %d MiB total", freeMemoryKib / 1024, totalMemoryKib / 1024);
+				.format("%d MiB total, %d MiB available", totalMemoryKib / 1024, availableMemoryKib / 1024);
 		} else {
-			return String.format("%d KiB used, %d KiB total", freeMemoryKib, totalMemoryKib);
+			return String.format("%d KiB total, %d KiB available", totalMemoryKib, availableMemoryKib);
 		}
 	}
 

--- a/backend/shared/src/main/java/de/aaaaaaah/velcom/shared/util/systeminfo/MemoryInfo.java
+++ b/backend/shared/src/main/java/de/aaaaaaah/velcom/shared/util/systeminfo/MemoryInfo.java
@@ -18,14 +18,25 @@ public class MemoryInfo {
 		this.availableMemoryKib = availableMemoryKib;
 	}
 
+	/**
+	 * @return the total memory available on the system, in KiB
+	 */
 	public long totalMemoryKib() {
 		return totalMemoryKib;
 	}
 
+	/**
+	 * @return the amount of memory that is currently unused, in KiB
+	 */
 	public long freeMemoryKiB() {
 		return freeMemoryKib;
 	}
 
+	/**
+	 * @return an estimate of the amount of memory available for starting new applications without
+	 * 	swapping, in KiB. See also <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773">this
+	 * 	commit in the linux kernel</a>.
+	 */
 	public long getAvailableMemoryKib() {
 		return availableMemoryKib;
 	}


### PR DESCRIPTION
This PR changes the runner info and status a bit.
- CPU info includes thread count
- Memory info uses `MemAvailable` instead of `MemFree` and also doesn't call `MemFree` `used`.
- Version hash is included if a run fails