### PR TITLE
Manage branches in Listener

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/Listener.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/Listener.java
@@ -68,8 +68,8 @@ public class Listener {
 	 * @param benchRepo used to keep the bench repo up-to-date
 	 */
 	public Listener(GlobalConfig config, RepoWriteAccess repoAccess, CommitReadAccess commitAccess,
-		KnownCommitWriteAccess knownCommitAccess,
-		BenchRepo benchRepo) {
+		KnownCommitWriteAccess knownCommitAccess, BenchRepo benchRepo) {
+
 		this.repoAccess = repoAccess;
 		this.commitAccess = commitAccess;
 		this.knownCommitAccess = knownCommitAccess;
@@ -113,7 +113,7 @@ public class Listener {
 
 			repoAccess.updateRepo(repoId);
 
-			manageTrackedBranches(repoId);
+			pruneTrackedBranches(repoId);
 			checkForUnknownCommits(repoId);
 		} finally {
 			this.lock.unlock();
@@ -126,9 +126,9 @@ public class Listener {
 	/**
 	 * Remove all tracked branches that don't actually exist in our repo.
 	 *
-	 * @param repo the repo whose tracked branches to update
+	 * @param repoId the id of the repo whose tracked branches to update
 	 */
-	private void manageTrackedBranches(RepoId repoId) {
+	private void pruneTrackedBranches(RepoId repoId) {
 		Repo repo = repoAccess.getRepo(repoId);
 
 		Set<BranchName> existingBranches = repoAccess.getBranches(repo.getRepoId())
@@ -147,7 +147,7 @@ public class Listener {
 	/**
 	 * Checks for new commits on the specified repository and passes the new commits to the queue.
 	 *
-	 * @param repo the repository to check for
+	 * @param repoId the id of the repository to check for
 	 */
 	private void checkForUnknownCommits(RepoId repoId)
 		throws CommitSearchException, RepoAccessException, NoSuchRepoException {

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/Listener.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/Listener.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -93,7 +94,7 @@ public class Listener {
 
 		for (Repo repo : repoAccess.getAllRepos()) {
 			try {
-				checkForUnknownCommits(repo.getRepoId());
+				updateRepo(repo.getRepoId());
 			} catch (CommitSearchException | RepoAccessException | NoSuchRepoException e) {
 				LOGGER.warn("Could not fetch updates for repo: " + repo, e);
 			}
@@ -103,47 +104,76 @@ public class Listener {
 		updateDurations.update(end - start);
 	}
 
-	/**
-	 * Checks for new commits on the specified repository and passes the new commits to the queue.
-	 *
-	 * @param repoId the id of the repository to check for
-	 */
-	public void checkForUnknownCommits(RepoId repoId)
-		throws CommitSearchException, RepoAccessException, NoSuchRepoException {
-
+	public void updateRepo(RepoId repoId) throws CommitSearchException {
+		LOGGER.info("Updating repo {}", repoId.getId());
 		long start = System.currentTimeMillis();
 
 		try {
 			this.lock.lock();
 
-			LOGGER.info("Checking for unknown commits on repo: {}", repoId);
-
-			Repo repo = repoAccess.getRepo(repoId);
-
 			repoAccess.updateRepo(repoId);
 
-			if (!knownCommitAccess.hasKnownCommits(repoId)) {
+			manageTrackedBranches(repoId);
+			checkForUnknownCommits(repoId);
+		} finally {
+			this.lock.unlock();
+		}
+
+		long end = System.currentTimeMillis();
+		LOGGER.debug("Updating repo {} took {} ms", repoId.getId(), (end - start));
+	}
+
+	/**
+	 * Remove all tracked branches that don't actually exist in our repo.
+	 *
+	 * @param repo the repo whose tracked branches to update
+	 */
+	private void manageTrackedBranches(RepoId repoId) {
+		Repo repo = repoAccess.getRepo(repoId);
+
+		Set<BranchName> existingBranches = repoAccess.getBranches(repo.getRepoId())
+			.stream()
+			.map(Branch::getName)
+			.collect(Collectors.toSet());
+
+		Set<BranchName> trackedBranches = repo.getTrackedBranches().stream()
+			.map(Branch::getName)
+			.filter(existingBranches::contains)
+			.collect(Collectors.toSet());
+
+		repoAccess.setTrackedBranches(repo.getRepoId(), trackedBranches);
+	}
+
+	/**
+	 * Checks for new commits on the specified repository and passes the new commits to the queue.
+	 *
+	 * @param repo the repository to check for
+	 */
+	private void checkForUnknownCommits(RepoId repoId)
+		throws CommitSearchException, RepoAccessException, NoSuchRepoException {
+
+		Repo repo = repoAccess.getRepo(repoId);
+
+		try {
+			if (!knownCommitAccess.hasKnownCommits(repo.getRepoId())) {
 				// this repository does not have any known commits which means that it must be new
 				// therefore only the first commit of each tracked branch is inserted into the queue
 				// and all other commits that exist so far will be marked as known
 
 				// (1): Mark all commits as known (NO_BENCHMARK_REQUIRED)
-				List<BranchName> branches = repoAccess.getBranches(repoId)
+				List<BranchName> branches = repoAccess.getBranches(repo.getRepoId())
 					.stream()
 					.map(Branch::getName)
 					.collect(toList());
 
 				Collection<CommitHash> commits;
-
-				try (Stream<Commit> commitStream = commitAccess.getCommitLog(
-					repo.getRepoId(), branches)) {
-
+				try (Stream<Commit> commitStream = commitAccess.getCommitLog(repo.getRepoId(), branches)) {
 					commits = commitStream
 						.map(Commit::getHash)
 						.collect(Collectors.toUnmodifiableList());
 				}
 
-				knownCommitAccess.markCommitsAsKnown(repoId, commits);
+				knownCommitAccess.markCommitsAsKnown(repo.getRepoId(), commits);
 
 				// (2): Make last commit of each tracked branch known
 				List<CommitHash> latestHashes = repo.getTrackedBranches()
@@ -152,10 +182,11 @@ public class Listener {
 					.collect(toList());
 
 				List<Task> tasks = latestHashes.stream()
-					.map(hash -> commitToTask(repoId, hash))
+					.map(hash -> commitToTask(repo.getRepoId(), hash))
 					.collect(toList());
 
-				knownCommitAccess.markCommitsAsKnownAndInsertIntoQueue(repoId, latestHashes, tasks);
+				knownCommitAccess
+					.markCommitsAsKnownAndInsertIntoQueue(repo.getRepoId(), latestHashes, tasks);
 			} else {
 				// The repo already has some known commits so we need to be smart about it
 				// Group all new commits across all tracked branches into this
@@ -166,7 +197,7 @@ public class Listener {
 				try {
 					for (Branch trackedBranch : repo.getTrackedBranches()) {
 						CommitHash startCommitHash = repoAccess.getLatestCommitHash(trackedBranch);
-						Commit startCommit = commitAccess.getCommit(repoId, startCommitHash);
+						Commit startCommit = commitAccess.getCommit(repo.getRepoId(), startCommitHash);
 
 						Collection<Commit> newCommits = unknownCommitFinder.find(
 							commitAccess, knownCommitAccess, startCommit
@@ -176,7 +207,7 @@ public class Listener {
 					}
 				} catch (IOException e) {
 					throw new CommitSearchException(
-						"failed to check for unknown commits in repo: " + repoId, e
+						"failed to check for unknown commits in repo: " + repo.getTrackedBranches(), e
 					);
 				}
 
@@ -191,15 +222,10 @@ public class Listener {
 					.map(this::commitToTask)
 					.collect(toList());
 
-				knownCommitAccess.markCommitsAsKnownAndInsertIntoQueue(repoId, hashes, tasks);
+				knownCommitAccess.markCommitsAsKnownAndInsertIntoQueue(repo.getRepoId(), hashes, tasks);
 			}
 		} catch (Exception e) {
-			throw new CommitSearchException(repoId, e);
-		} finally {
-			this.lock.unlock();
-
-			long end = System.currentTimeMillis();
-			LOGGER.debug("checkForUnknownCommits({}) took {} ms", repoId.getId(), (end - start));
+			throw new CommitSearchException(repo.getRepoId(), e);
 		}
 	}
 

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/RepoEndpoint.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/RepoEndpoint.java
@@ -107,7 +107,7 @@ public class RepoEndpoint {
 		// Run listener on this repo on a separate thread
 		new Thread(() -> {
 			try {
-				listener.checkForUnknownCommits(repo.getRepoId());
+				listener.updateRepo(repo.getRepoId());
 			} catch (CommitSearchException e) {
 				LOGGER.warn("Failed to run listener for new repo: {}", repo, e);
 			}

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/storage/repo/GuickCloning.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/storage/repo/GuickCloning.java
@@ -144,7 +144,7 @@ public abstract class GuickCloning {
 		@Override
 		public void updateBareRepo(Path repoDir) throws CloneException {
 			try {
-				Git.open(repoDir.toFile()).fetch().call();
+				Git.open(repoDir.toFile()).fetch().setRemoveDeletedRefs(true).call();
 			} catch (GitAPIException | IOException e) {
 				throw new CloneException(
 					"Error when pulling the latest changes from a bare git repo",
@@ -240,7 +240,7 @@ public abstract class GuickCloning {
 				ProgramResult programResult = new ProgramExecutor()
 					.execute(
 						GIT_EXECUTABLE, "-C", repoDir.toAbsolutePath().toString(),
-						"fetch", "--all"
+						"fetch", "--all", "--prune"
 					).get();
 				guardResult("Fetch failed :/", programResult);
 			} catch (InterruptedException | ExecutionException e) {


### PR DESCRIPTION
This PR fixes the issue that old branches were still displayed even though they were deleted in the source repo. It also fixes the occasional Listener exception when trying to update commits for a repo.