### PR TITLE
Allow runs without differences

### DIFF
--- a/frontend/src/components/rundetail/MeasurementsDisplay.vue
+++ b/frontend/src/components/rundetail/MeasurementsDisplay.vue
@@ -183,7 +183,7 @@ export default class MeasurementsDisplay extends Vue {
   @Prop()
   private measurements!: Measurement[]
   @Prop()
-  private differences!: DimensionDifference[]
+  private differences?: DimensionDifference[]
 
   private showDetailErrorDialog: boolean = false
   private detailErrorDialogMessage: string = ''
@@ -257,6 +257,9 @@ export default class MeasurementsDisplay extends Vue {
   private differenceForDimension(
     dimension: Dimension
   ): DimensionDifference | undefined {
+    if (!this.differences) {
+      return undefined
+    }
     return this.differences.find(it => it.dimension.equals(dimension))
   }
 

--- a/frontend/src/store/modules/commitDetailComparisonStore.ts
+++ b/frontend/src/store/modules/commitDetailComparisonStore.ts
@@ -37,10 +37,11 @@ export class CommitDetailComparisonStore extends VxModule {
       }
     })
 
-    return new RunWithDifferences(
-      runFromJson(response.data.run),
-      response.data.differences.map(differenceFromJson)
-    )
+    const differences = response.data.differences
+      ? response.data.differences.map(differenceFromJson)
+      : undefined
+
+    return new RunWithDifferences(runFromJson(response.data.run), differences)
   }
 
   /**

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -307,9 +307,9 @@ export class RunDescription {
 
 export class RunWithDifferences {
   readonly run: Run
-  readonly differences: DimensionDifference[]
+  readonly differences?: DimensionDifference[]
 
-  constructor(run: Run, differences: DimensionDifference[]) {
+  constructor(run: Run, differences?: DimensionDifference[]) {
     this.run = run
     this.differences = differences
   }


### PR DESCRIPTION
Differences are not included if there was no unambiguous parent commit. In those cases the frontend shouldn't crash, it should just not display them.