### PR TITLE
Limit children to commits reachable from tracked branches

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/ServerMain.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/ServerMain.java
@@ -171,7 +171,7 @@ public class ServerMain extends Application<GlobalConfig> {
 
 		// Endpoints
 		environment.jersey().register(new AllReposEndpoint(repoAccess, benchmarkAccess, tokenAccess));
-		environment.jersey().register(new CommitEndpoint(commitAccess, benchmarkAccess));
+		environment.jersey().register(new CommitEndpoint(commitAccess, repoAccess, benchmarkAccess));
 		environment.jersey().register(new CompareEndpoint(benchmarkAccess, commitAccess, comparer));
 		environment.jersey().register(new RunEndpoint(benchmarkAccess, commitAccess, comparer));
 		environment.jersey().register(new TestTokenEndpoint());

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/CommitReadAccess.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/CommitReadAccess.java
@@ -148,7 +148,7 @@ public class CommitReadAccess {
 	 * @throws CommitAccessException when accessing the repo fails
 	 */
 	public Collection<CommitHash> getChildren(RepoId repoId, CommitHash commitHash,
-		Set<BranchName> targetBranches) {
+		Set<BranchName> startingBranches) {
 
 		try (
 			Repository repo = repoStorage.acquireRepository(repoId.getDirectoryName());
@@ -156,11 +156,10 @@ public class CommitReadAccess {
 		) {
 			ObjectId targetId = repo.resolve(commitHash.getHash());
 
-			// TODO: 21/09/2020 Maybe use all branches instead of only tracked branches?
 			List<RevCommit> startPoints = new ArrayList<>();
 			for (Ref branchRef : Git.wrap(repo).branchList().call()) {
 				BranchName branchName = BranchName.fromFullName(branchRef.getName());
-				if (targetBranches.contains(branchName)) {
+				if (startingBranches.contains(branchName)) {
 					RevCommit revCommit = plotWalk.parseCommit(branchRef.getObjectId());
 					startPoints.add(revCommit);
 				}

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/CommitEndpoint.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/CommitEndpoint.java
@@ -65,10 +65,15 @@ public class CommitEndpoint {
 			.map(Branch::getName)
 			.collect(Collectors.toSet());
 
+		// If the commit can't be reached from any tracked branch, none of its children can either. so
+		// an empty list of tracked child hashes is appropriate.
 		Set<CommitHash> trackedChildHashes = new HashSet<>(
-			commitAccess.getChildren(repoId, hash, trackedBranches));
+			commitAccess.getChildren(repoId, hash, trackedBranches).orElse(List.of()));
+		// If the commit can't be reached from any branch, none of its children can either, so an empty
+		// list of (untracked) child hashes is appropriate. Otherwise, commits like GitHub's auto
+		// generated merge commits would be visible as children.
 		Set<CommitHash> untrackedChildHashes = new HashSet<>(
-			commitAccess.getChildren(repoId, hash, allBranches));
+			commitAccess.getChildren(repoId, hash, allBranches).orElse(List.of()));
 		untrackedChildHashes.removeAll(trackedChildHashes);
 
 		List<JsonCommitDescription> trackedChildren = trackedChildHashes.stream()

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonCommit.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonCommit.java
@@ -9,7 +9,8 @@ public class JsonCommit {
 	private final UUID repoId;
 	private final String hash;
 	private final List<JsonCommitDescription> parents;
-	private final List<JsonCommitDescription> children;
+	private final List<JsonCommitDescription> trackedChildren;
+	private final List<JsonCommitDescription> untrackedChildren;
 	private final String author;
 	private final long authorDate;
 	private final String committer;
@@ -20,13 +21,15 @@ public class JsonCommit {
 	private final List<JsonRunDescription> runs;
 
 	public JsonCommit(UUID repoId, String hash, List<JsonCommitDescription> parents,
-		List<JsonCommitDescription> children, String author, long authorDate, String committer,
-		long committerDate, String summary, @Nullable String message, List<JsonRunDescription> runs) {
+		List<JsonCommitDescription> trackedChildren, List<JsonCommitDescription> untrackedChildren,
+		String author, long authorDate, String committer, long committerDate, String summary,
+		@Nullable String message, List<JsonRunDescription> runs) {
 
 		this.repoId = repoId;
 		this.hash = hash;
 		this.parents = parents;
-		this.children = children;
+		this.trackedChildren = trackedChildren;
+		this.untrackedChildren = untrackedChildren;
 		this.author = author;
 		this.authorDate = authorDate;
 		this.committer = committer;
@@ -48,8 +51,12 @@ public class JsonCommit {
 		return parents;
 	}
 
-	public List<JsonCommitDescription> getChildren() {
-		return children;
+	public List<JsonCommitDescription> getTrackedChildren() {
+		return trackedChildren;
+	}
+
+	public List<JsonCommitDescription> getUntrackedChildren() {
+		return untrackedChildren;
 	}
 
 	public String getAuthor() {

--- a/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonCommitTest.java
+++ b/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonCommitTest.java
@@ -14,6 +14,7 @@ class JsonCommitTest extends SerializingTest {
 			"e16272feb472dc4d357cc19dd97112c036a67990",
 			List.of(),
 			List.of(),
+			List.of(),
 			"authorName",
 			1596881630,
 			"committerName",
@@ -26,7 +27,8 @@ class JsonCommitTest extends SerializingTest {
 			+ "\"repo_id\": \"24dd4fd3-5c6d-4542-a7a4-b181f37295a6\","
 			+ "\"hash\": \"e16272feb472dc4d357cc19dd97112c036a67990\","
 			+ "\"parents\": [],"
-			+ "\"children\": [],"
+			+ "\"tracked_children\": [],"
+			+ "\"untracked_children\": [],"
 			+ "\"author\": \"authorName\","
 			+ "\"author_date\": 1596881630,"
 			+ "\"committer\": \"committerName\","

--- a/docs/public-api/public-api.v2.yaml
+++ b/docs/public-api/public-api.v2.yaml
@@ -797,8 +797,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CommitDescription'
-        children:
+        tracked_children:
           type: array
+          description: Child commits that can be reached from at least one tracked branch
+          items:
+            $ref: '#/components/schemas/CommitDescription'
+        untracked_children:
+          type: array
+          description: 'Child commits that can''t be reached from any tracked branch, but from at least one untracked branch'
           items:
             $ref: '#/components/schemas/CommitDescription'
         author:
@@ -824,7 +830,8 @@ components:
         - repo_id
         - hash
         - parents
-        - children
+        - tracked_children
+        - untracked_children
         - author
         - author_date
         - committer

--- a/frontend/src/components/rundetail/CommitDetail.vue
+++ b/frontend/src/components/rundetail/CommitDetail.vue
@@ -37,11 +37,13 @@
                 :key="index"
                 justify="space-between"
                 no-gutters
+                class="py-1"
               >
                 <v-col cols="6" class="pr-4">
                   <div v-if="parent" class="d-flex justify-start">
                     <commit-navigation-button
                       :commitDescription="parent"
+                      :tracked="true"
                       type="PARENT"
                     ></commit-navigation-button>
                   </div>
@@ -50,7 +52,8 @@
                 <v-col cols="6">
                   <div v-if="child" class="d-flex justify-end">
                     <commit-navigation-button
-                      :commitDescription="child"
+                      :commitDescription="child.description"
+                      :tracked="child.tracked"
                       type="CHILD"
                     ></commit-navigation-button>
                   </div>
@@ -92,21 +95,17 @@
 import Vue from 'vue'
 import Component from 'vue-class-component'
 import { Prop } from 'vue-property-decorator'
-import { Commit, CommitDescription } from '@/store/types'
+import { Commit, CommitChild, CommitDescription } from '@/store/types'
 import { formatDateUTC, formatDate } from '@/util/TimeUtil'
 import InlineMinimalRepoNameDisplay from '../InlineMinimalRepoDisplay.vue'
 import CommitBenchmarkActions from '../CommitBenchmarkActions.vue'
-import { mdiArrowLeft, mdiArrowRight } from '@mdi/js'
 import CommitNavigationButton from './CommitNavigationButton.vue'
 
 class NavigationTarget {
   readonly parent: CommitDescription | null
-  readonly child: CommitDescription | null
+  readonly child: CommitChild | null
 
-  constructor(
-    parent: CommitDescription | null,
-    child: CommitDescription | null
-  ) {
+  constructor(parent: CommitDescription | null, child: CommitChild | null) {
     this.parent = parent
     this.child = child
   }
@@ -133,7 +132,7 @@ export default class CommitDetail extends Vue {
 
   private get navigationTargets(): NavigationTarget[] {
     const targets: NavigationTarget[] = []
-    let mutualItems = Math.min(
+    const mutualItems = Math.min(
       this.commit.parents.length,
       this.commit.children.length
     )
@@ -156,10 +155,6 @@ export default class CommitDetail extends Vue {
 
     return targets
   }
-
-  // Icons
-  private parentCommitIcon = mdiArrowLeft
-  private childCommitIcon = mdiArrowRight
 }
 </script>
 

--- a/frontend/src/components/rundetail/CommitNavigationButton.vue
+++ b/frontend/src/components/rundetail/CommitNavigationButton.vue
@@ -3,10 +3,10 @@
     <template #activator="{ on }">
       <v-btn
         v-on="on"
-        left
         text
         outlined
         class="d-flex commit-navigation-button"
+        :class="tracked ? '' : 'text--disabled'"
         :to="{
           name: 'run-detail',
           params: {
@@ -24,6 +24,7 @@
         </v-icon>
       </v-btn>
     </template>
+    <span v-if="!tracked" class="font-weight-bold">(On untracked branch)</span>
     {{ commitDescription.hash }} by {{ commitDescription.author }}
   </v-tooltip>
 </template>
@@ -41,6 +42,8 @@ export default class CommitNavigationButton extends Vue {
   private commitDescription!: CommitDescription
   @Prop({ default: 'PARENT' })
   private type!: 'PARENT' | 'CHILD'
+  @Prop({ default: true })
+  private tracked!: boolean
 
   // ICONS
   private parentCommitIcon = mdiArrowLeft

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -98,6 +98,16 @@ export class Dimension {
 
 export type CommitHash = Flavor<string, 'commit_hash'>
 
+export class CommitChild {
+  readonly tracked: boolean
+  readonly description: CommitDescription
+
+  constructor(tracked: boolean, description: CommitDescription) {
+    this.tracked = tracked
+    this.description = description
+  }
+}
+
 export class Commit {
   readonly repoId: RepoId
   readonly hash: CommitHash
@@ -108,8 +118,15 @@ export class Commit {
   readonly summary: string
   readonly message: string | ''
   readonly runs: RunDescription[]
+  /**
+   * Sorted alphabetically.
+   */
   readonly parents: CommitDescription[]
-  readonly children: CommitDescription[]
+  /**
+   * Tracked children will come before tracked children,
+   * inside the buckets they are sorted alphabetically
+   */
+  readonly children: CommitChild[]
 
   // noinspection DuplicatedCode
   constructor(
@@ -123,7 +140,7 @@ export class Commit {
     summary: string,
     runs: RunDescription[],
     parents: CommitDescription[],
-    children: CommitDescription[]
+    children: CommitChild[]
   ) {
     this.repoId = repoId
     this.hash = hash
@@ -136,6 +153,17 @@ export class Commit {
     this.runs = runs
     this.parents = parents
     this.children = children
+
+    this.parents.sort((a, b) => a.summary.localeCompare(b.summary))
+    this.children.sort((a, b) => {
+      if (a.tracked && b.tracked) {
+        return a.description.summary.localeCompare(b.description.summary)
+      }
+      if (a.tracked) {
+        return -1
+      }
+      return 1
+    })
   }
 }
 

--- a/frontend/src/util/CommitComparisonJsonHelper.ts
+++ b/frontend/src/util/CommitComparisonJsonHelper.ts
@@ -11,7 +11,8 @@ import {
   Commit,
   RunDescription,
   RunComparison,
-  DimensionDifference
+  DimensionDifference,
+  CommitChild
 } from '@/store/types'
 import {
   sourceFromJson,
@@ -63,6 +64,12 @@ export function runDescriptionFromJson(json: any): RunDescription {
 }
 
 export function commitFromJson(json: any): Commit {
+  const trackedChildren = json.tracked_children.map(
+    (it: any) => new CommitChild(true, commitDescriptionFromJson(it))
+  )
+  const untrackedChildren = json.untracked_children.map(
+    (it: any) => new CommitChild(false, commitDescriptionFromJson(it))
+  )
   return new Commit(
     json.repo_id,
     json.hash,
@@ -74,7 +81,7 @@ export function commitFromJson(json: any): Commit {
     json.summary,
     json.runs.map(runDescriptionFromJson),
     json.parents.map(commitDescriptionFromJson),
-    json.children.map(commitDescriptionFromJson)
+    trackedChildren.concat(untrackedChildren)
   )
 }
 


### PR DESCRIPTION
This PR stops `Merge ... into ...` commits (which are presumably automatically generated by github) from appearing as children of a commit.

I'm not sure if we should limit children to commits reachable from tracked branches or instead commits reachable from any branch (but not any ref).