### PR TITLE
Don't crash when bench repo changes its default branch

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/exceptions/MalformedRepoException.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/exceptions/MalformedRepoException.java
@@ -1,0 +1,11 @@
+package de.aaaaaaah.velcom.backend.access.exceptions;
+
+/**
+ * An exception thrown when a git repo doesn't fulfill the required properties.
+ */
+public class MalformedRepoException extends Exception {
+
+	public MalformedRepoException(String message) {
+		super(message);
+	}
+}

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/Listener.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/Listener.java
@@ -111,6 +111,8 @@ public class Listener {
 		try {
 			this.lock.lock();
 
+			// TODO: 23.09.20 Check if remote url has changed and re-clone if necessary
+
 			repoAccess.updateRepo(repoId);
 
 			pruneTrackedBranches(repoId);

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/storage/repo/GuickCloning.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/storage/repo/GuickCloning.java
@@ -164,8 +164,7 @@ public abstract class GuickCloning {
 			try {
 				ProgramResult programResult = new ProgramExecutor()
 					.execute(
-						GIT_EXECUTABLE, "clone",
-						"--mirror", "--recursive", "--recurse-submodules",
+						GIT_EXECUTABLE, "clone", "--mirror",
 						source,
 						targetDir.toAbsolutePath().toString()
 					).get();


### PR DESCRIPTION
When the bench repo changes its default branch, the backend now doesn't throw NPEs but instead tries to re-clone the bench repo. If the re-clone doesn't work, the backend doesn't start at all.