### PR TITLE
Fix startTime and endTime in RepoComparisonGraph

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/repocomparison/RepoComparisonGraph.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/repocomparison/RepoComparisonGraph.java
@@ -5,6 +5,8 @@ import static java.util.Objects.requireNonNull;
 import de.aaaaaaah.velcom.backend.access.entities.DimensionInfo;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nullable;
 
 public class RepoComparisonGraph {
 
@@ -14,11 +16,11 @@ public class RepoComparisonGraph {
 	private final Instant endTime;
 
 	public RepoComparisonGraph(DimensionInfo dimensionInfo,
-		List<RepoGraphData> data, Instant startTime, Instant endTime) {
+		List<RepoGraphData> data, @Nullable Instant startTime, @Nullable Instant endTime) {
 		this.dimensionInfo = requireNonNull(dimensionInfo);
 		this.data = requireNonNull(data);
-		this.startTime = requireNonNull(startTime);
-		this.endTime = requireNonNull(endTime);
+		this.startTime = startTime;
+		this.endTime = endTime;
 	}
 
 	public DimensionInfo getDimensionInfo() {
@@ -29,12 +31,12 @@ public class RepoComparisonGraph {
 		return data;
 	}
 
-	public Instant getStartTime() {
-		return startTime;
+	public Optional<Instant> getStartTime() {
+		return Optional.ofNullable(startTime);
 	}
 
-	public Instant getEndTime() {
-		return endTime;
+	public Optional<Instant> getEndTime() {
+		return Optional.ofNullable(endTime);
 	}
 
 	@Override

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/repocomparison/RepoDataResult.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/repocomparison/RepoDataResult.java
@@ -1,0 +1,45 @@
+package de.aaaaaaah.velcom.backend.data.repocomparison;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Contains the comparison graph data for a single repository, the startTime (which was either set
+ * manually or is the author date of the oldest commit of this repository in this graph), and the
+ * endTime which also was either set or is the author date of the youngest commit of this repository
+ * in this graph.
+ */
+public class RepoDataResult {
+
+	private final RepoGraphData graphData;
+	private final Instant startTime;
+	private final Instant endTime;
+
+	public RepoDataResult(RepoGraphData graphData, Instant startTime, Instant endTime) {
+		this.graphData = Objects.requireNonNull(graphData);
+		this.startTime = Objects.requireNonNull(startTime);
+		this.endTime = Objects.requireNonNull(endTime);
+	}
+
+	public RepoGraphData getGraphData() {
+		return graphData;
+	}
+
+	public Instant getStartTime() {
+		return startTime;
+	}
+
+	public Instant getEndTime() {
+		return endTime;
+	}
+
+	@Override
+	public String toString() {
+		return "RepoDataResult{" +
+			"graphData=" + graphData +
+			", startTime=" + startTime +
+			", endTime=" + endTime +
+			'}';
+	}
+
+}


### PR DESCRIPTION
This fixes two problems:

1.) Before this change, RepoComparisonGraph instances require a not-null startTime and endTime being passed to them via constructor.
Since there are circumstances (eg. when no data is available and no startTime, endTime were specified) where either startTime or endTime or both are null, this requirement cannot always be satisfied.

2.) When startTime or endTime are not specified and at least one commit is found, startTime and endTime were updated, but not passed to the resulting RepoComparisonGraph instance.

# Todo:

- [x] Test changes