### PR TITLE
Fix run-comparison metrics and show Information

### DIFF
--- a/frontend/src/components/comparison/RunComparisonTable.vue
+++ b/frontend/src/components/comparison/RunComparisonTable.vue
@@ -120,20 +120,29 @@ export default class RunComparisonTable extends Vue {
   }
 
   private get items(): TableItem[] {
-    return this.getDimensionsForRun(this.first)
-      .concat(this.getDimensionsForRun(this.second))
-      .map(
-        dimension =>
-          new TableItem(
-            dimension.benchmark,
-            dimension.metric,
-            dimension.unit,
-            dimension.interpretation,
-            this.getValue(this.first, dimension),
-            this.getDifference(dimension),
-            this.getValue(this.second, dimension)
-          )
-      )
+    const allDimensions = this.getDimensionsForRun(this.first).concat(
+      this.getDimensionsForRun(this.second)
+    )
+
+    const uniqueDimensions: Dimension[] = []
+    allDimensions.forEach(dim => {
+      if (!uniqueDimensions.find(existing => existing.equals(dim))) {
+        uniqueDimensions.push(dim)
+      }
+    })
+
+    return uniqueDimensions.map(
+      dimension =>
+        new TableItem(
+          dimension.benchmark,
+          dimension.metric,
+          dimension.unit,
+          dimension.interpretation,
+          this.getValue(this.first, dimension),
+          this.getDifference(dimension),
+          this.getValue(this.second, dimension)
+        )
+    )
   }
 
   private getDimensionsForRun(run: Run): Dimension[] {

--- a/frontend/src/components/overviews/CommitOverviewBase.vue
+++ b/frontend/src/components/overviews/CommitOverviewBase.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card>
+  <v-card :outlined="outlined">
     <slot name="body_top"></slot>
     <v-list-item>
       <slot name="avatar"></slot>
@@ -64,6 +64,9 @@ import { RawLocation } from 'vue-router'
 export default class CommitOverviewBase extends Vue {
   @Prop()
   private commit!: CommitDescription
+
+  @Prop({ default: false })
+  private outlined!: boolean
 
   @Prop({ default: null })
   private linkLocation!: RawLocation

--- a/frontend/src/components/rundetail/CommitDetail.vue
+++ b/frontend/src/components/rundetail/CommitDetail.vue
@@ -13,9 +13,17 @@
                   justify-lg="space-between"
                 >
                   <v-col cols="auto">
-                    <span class="mx-2 message font-weight-regular">
-                      {{ commit.summary }}
-                    </span>
+                    <router-link
+                      class="concealed-link"
+                      :to="{
+                        name: 'run-detail',
+                        params: { first: commit.repoId, second: commit.hash }
+                      }"
+                    >
+                      <span class="mx-2 message font-weight-regular">
+                        {{ commit.summary }}
+                      </span>
+                    </router-link>
                   </v-col>
                   <v-col cols="auto" class="ml-3 body-1 pt-2 pt-lg-0">
                     <inline-repo-display

--- a/frontend/src/components/rundetail/RunDetail.vue
+++ b/frontend/src/components/rundetail/RunDetail.vue
@@ -27,37 +27,7 @@
     </v-row>
     <v-row no-gutters class="mt-3">
       <v-col>
-        <v-card>
-          <v-card-title>
-            <v-toolbar dark color="primary">
-              Run information
-            </v-toolbar>
-          </v-card-title>
-          <v-card-text class="py-0">
-            <v-container fluid class="ma-0 pa-0">
-              <v-row align="center" justify="space-around">
-                <v-col
-                  :lg="item.alwaysAuto ? 'auto' : '2'"
-                  md="auto"
-                  sm="auto"
-                  class="pt-0"
-                  v-for="item in runInfoItems"
-                  :key="item.header"
-                >
-                  <v-card outlined>
-                    <v-card-title class="pb-1">
-                      <v-icon left dense>{{ item.icon }}</v-icon>
-                      {{ item.header }}
-                    </v-card-title>
-                    <v-card-text>
-                      <span :class="item.bodyClass">{{ item.body }}</span>
-                    </v-card-text>
-                  </v-card>
-                </v-col>
-              </v-row>
-            </v-container>
-          </v-card-text>
-        </v-card>
+        <run-info :run="run"></run-info>
       </v-col>
     </v-row>
   </v-container>
@@ -76,18 +46,12 @@ import {
   RunWithDifferences
 } from '@/store/types'
 import { Prop } from 'vue-property-decorator'
-import { formatDate, formatDurationHuman } from '@/util/TimeUtil'
 import MeasurementsDisplay from '@/components/rundetail/MeasurementsDisplay.vue'
-import {
-  mdiFlash,
-  mdiCameraTimer,
-  mdiAlarmCheck,
-  mdiClockFast,
-  mdiRobot
-} from '@mdi/js'
+import RunInfo from '@/components/rundetail/RunInfo.vue'
 
 @Component({
   components: {
+    'run-info': RunInfo,
     'measurements-display': MeasurementsDisplay
   }
 })
@@ -95,50 +59,8 @@ export default class RunDetail extends Vue {
   @Prop()
   private runWithDifferences!: RunWithDifferences
 
-  private formatDate(date: Date) {
-    return formatDate(date)
-  }
-
-  private formatDuration(start: Date, end: Date) {
-    return formatDurationHuman(start, end)
-  }
-
   private get run(): Run {
     return this.runWithDifferences.run
-  }
-
-  private get runInfoItems() {
-    return [
-      {
-        header: 'Trigger',
-        icon: this.iconTrigger,
-        body: `${this.run.source.type.toLocaleLowerCase()} by ${
-          this.run.author
-        }`
-      },
-      {
-        header: 'Started',
-        icon: this.iconStarted,
-        body: this.formatDate(this.run.startTime)
-      },
-      {
-        header: 'Finished',
-        icon: this.iconFinished,
-        body: this.formatDate(this.run.stopTime)
-      },
-      {
-        header: 'Duration',
-        icon: this.iconDuration,
-        body: this.formatDuration(this.run.startTime, this.run.stopTime)
-      },
-      {
-        header: this.run.runnerName,
-        icon: this.iconRunner,
-        body: this.run.runnerInfo,
-        bodyClass: 'worker-description',
-        alwaysAuto: true
-      }
-    ]
   }
 
   private get runColor() {
@@ -180,18 +102,10 @@ export default class RunDetail extends Vue {
     }
     return undefined
   }
-
-  // ICONS
-  private iconTrigger = mdiFlash
-  private iconStarted = mdiClockFast
-  private iconFinished = mdiAlarmCheck
-  private iconDuration = mdiCameraTimer
-  private iconRunner = mdiRobot
 }
 </script>
 
 <style scoped>
-.worker-description,
 .error-text {
   white-space: pre-wrap;
   font-family: monospace;

--- a/frontend/src/components/rundetail/RunInfo.vue
+++ b/frontend/src/components/rundetail/RunInfo.vue
@@ -9,7 +9,8 @@
     </v-card-title>
     <v-card-text class="py-0">
       <v-container fluid class="ma-0 pa-0">
-        <v-row align="center" justify="space-around">
+        <slot name="before-body"></slot>
+        <v-row align="center" justify="space-around" class="mx-1">
           <v-col
             :lg="item.alwaysAuto ? 'auto' : '2'"
             md="auto"

--- a/frontend/src/components/rundetail/RunInfo.vue
+++ b/frontend/src/components/rundetail/RunInfo.vue
@@ -1,0 +1,113 @@
+<template>
+  <v-card>
+    <v-card-title>
+      <v-toolbar dark color="primary">
+        <slot name="title">
+          Run Information
+        </slot>
+      </v-toolbar>
+    </v-card-title>
+    <v-card-text class="py-0">
+      <v-container fluid class="ma-0 pa-0">
+        <v-row align="center" justify="space-around">
+          <v-col
+            :lg="item.alwaysAuto ? 'auto' : '2'"
+            md="auto"
+            sm="auto"
+            class="pt-0"
+            v-for="item in runInfoItems"
+            :key="item.header"
+          >
+            <v-card outlined>
+              <v-card-title class="pb-1">
+                <v-icon left dense>{{ item.icon }}</v-icon>
+                {{ item.header }}
+              </v-card-title>
+              <v-card-text>
+                <span :class="item.bodyClass">{{ item.body }}</span>
+              </v-card-text>
+            </v-card>
+          </v-col>
+        </v-row>
+      </v-container>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import Component from 'vue-class-component'
+import {
+  mdiAlarmCheck,
+  mdiCameraTimer,
+  mdiClockFast,
+  mdiFlash,
+  mdiRobot
+} from '@mdi/js'
+import { formatDate, formatDurationHuman } from '@/util/TimeUtil'
+import { Prop } from 'vue-property-decorator'
+import { Run } from '@/store/types'
+
+@Component
+export default class RunInfo extends Vue {
+  @Prop()
+  private run!: Run
+
+  private formatDate(date: Date) {
+    return formatDate(date)
+  }
+
+  private formatDuration(start: Date, end: Date) {
+    return formatDurationHuman(start, end)
+  }
+
+  private get runInfoItems() {
+    return [
+      {
+        header: 'Trigger',
+        icon: this.iconTrigger,
+        body: `${this.run.source.type.toLocaleLowerCase()} by ${
+          this.run.author
+        }`
+      },
+      {
+        header: 'Started',
+        icon: this.iconStarted,
+        body: this.formatDate(this.run.startTime)
+      },
+      {
+        header: 'Finished',
+        icon: this.iconFinished,
+        body: this.formatDate(this.run.stopTime)
+      },
+      {
+        header: 'Duration',
+        icon: this.iconDuration,
+        body: this.formatDuration(this.run.startTime, this.run.stopTime)
+      },
+      {
+        header: this.run.runnerName,
+        icon: this.iconRunner,
+        body: this.run.runnerInfo,
+        bodyClass: 'worker-description',
+        alwaysAuto: true
+      }
+    ]
+  }
+
+  // ICONS
+  private iconTrigger = mdiFlash
+  private iconStarted = mdiClockFast
+  private iconFinished = mdiAlarmCheck
+  private iconDuration = mdiCameraTimer
+  private iconRunner = mdiRobot
+}
+</script>
+
+<style scoped>
+/*noinspection CssUnusedSymbol*/
+.worker-description {
+  white-space: pre-wrap;
+  font-family: monospace;
+}
+</style>

--- a/frontend/src/views/RunCommitDetailView.vue
+++ b/frontend/src/views/RunCommitDetailView.vue
@@ -119,7 +119,7 @@ export default class RunCommitDetailView extends Vue {
         })
       }
     } else if (this.firstComponent && this.secondComponent) {
-      // we have a repo id and run id
+      // we have a repo id and commit hash
       this.commit = await vxm.commitDetailComparisonModule.fetchCommit({
         repoId: this.firstComponent,
         commitHash: this.secondComponent

--- a/frontend/src/views/RunComparison.vue
+++ b/frontend/src/views/RunComparison.vue
@@ -33,6 +33,16 @@
               Run id: {{ comparison.run1.id }}
             </v-chip>
           </template>
+          <template #before-body v-if="firstCommit">
+            <v-row class="mx-1">
+              <v-col>
+                <commit-overview-base
+                  :commit="firstCommit"
+                  :outlined="true"
+                ></commit-overview-base>
+              </v-col>
+            </v-row>
+          </template>
         </run-info>
       </v-col>
     </v-row>
@@ -53,6 +63,16 @@
               Run id: {{ comparison.run2.id }}
             </v-chip>
           </template>
+          <template #before-body v-if="secondCommit">
+            <v-row class="mx-1">
+              <v-col>
+                <commit-overview-base
+                  :commit="secondCommit"
+                  :outlined="true"
+                ></commit-overview-base>
+              </v-col>
+            </v-row>
+          </template>
         </run-info>
       </v-col>
     </v-row>
@@ -64,12 +84,20 @@ import Vue from 'vue'
 import Component from 'vue-class-component'
 import { vxm } from '@/store'
 import { Watch } from 'vue-property-decorator'
-import { RunComparison } from '@/store/types'
+import {
+  CommitDescription,
+  CommitTaskSource,
+  Run,
+  RunComparison
+} from '@/store/types'
 import RunComparisonTable from '@/components/comparison/RunComparisonTable.vue'
+import CommitDetail from '@/components/rundetail/CommitDetail.vue'
+import CommitOverviewBase from '@/components/overviews/CommitOverviewBase.vue'
 import RunInfo from '@/components/rundetail/RunInfo.vue'
 
 @Component({
   components: {
+    'commit-overview-base': CommitOverviewBase,
     'run-info': RunInfo,
     'comparison-table': RunComparisonTable
   }
@@ -106,6 +134,27 @@ export default class RunComparisonView extends Vue {
       hash1: this.hash1,
       hash2: this.hash2
     })
+  }
+
+  private get firstCommit() {
+    if (!this.comparison) {
+      return null
+    }
+    return this.commitForRun(this.comparison.run1)
+  }
+
+  private get secondCommit() {
+    if (!this.comparison) {
+      return null
+    }
+    return this.commitForRun(this.comparison.run1)
+  }
+
+  private commitForRun(run: Run): CommitDescription | null {
+    if (!(run.source instanceof CommitTaskSource)) {
+      return null
+    }
+    return run.source.commitDescription
   }
 
   mounted(): void {

--- a/frontend/src/views/RunComparison.vue
+++ b/frontend/src/views/RunComparison.vue
@@ -16,6 +16,46 @@
         </v-card>
       </v-col>
     </v-row>
+    <v-row v-if="comparison && comparison.run1">
+      <v-col>
+        <run-info :run="comparison.run1">
+          <template #title>
+            <span>First Run Information</span>
+            <v-spacer></v-spacer>
+            <v-chip
+              :to="{
+                name: 'run-detail',
+                params: { first: comparison.run1.id }
+              }"
+              outlined
+              label
+            >
+              Run id: {{ comparison.run1.id }}
+            </v-chip>
+          </template>
+        </run-info>
+      </v-col>
+    </v-row>
+    <v-row v-if="comparison && comparison.run2">
+      <v-col>
+        <run-info :run="comparison.run2">
+          <template #title>
+            <span>Second Run Information</span>
+            <v-spacer></v-spacer>
+            <v-chip
+              :to="{
+                name: 'run-detail',
+                params: { first: comparison.run2.id }
+              }"
+              outlined
+              label
+            >
+              Run id: {{ comparison.run2.id }}
+            </v-chip>
+          </template>
+        </run-info>
+      </v-col>
+    </v-row>
   </v-container>
 </template>
 
@@ -26,9 +66,11 @@ import { vxm } from '@/store'
 import { Watch } from 'vue-property-decorator'
 import { RunComparison } from '@/store/types'
 import RunComparisonTable from '@/components/comparison/RunComparisonTable.vue'
+import RunInfo from '@/components/rundetail/RunInfo.vue'
 
 @Component({
   components: {
+    'run-info': RunInfo,
     'comparison-table': RunComparisonTable
   }
 })


### PR DESCRIPTION
Previously the run comparison duplicated dimensions resulting in an *interesting* table. This PR fixes that.

It also adds the run information to the comparison page - but the commit information would probably be more useful? Some input is needed here.

The alignment of the infos is also a bit unpleasant. Sizing them dynamically helps on the detail page, but hurts us here. Maybe it should be scrapped and only commit info shown?

![Screenshot 2020-09-24 21-26-39](https://user-images.githubusercontent.com/20284688/94191796-5d38f580-feae-11ea-97f7-f22bad573edb.png)
