### PR TITLE
Fix repo archive not being removed after transfer

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/ArchiveAccess.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/ArchiveAccess.java
@@ -236,6 +236,8 @@ public class ArchiveAccess {
 				TransferUtils.tarRepo(archive, outputStream);
 			} catch (IOException e) {
 				throw new TransferException(task, e);
+			} finally {
+				repoArchives.deleteArchive(repoId, hash); // Cleanup
 			}
 		}
 	}


### PR DESCRIPTION
Not deleting the archive of a repo after its transfer to a runner
causes the archive to exist forever in the archive directory
even though it probably is no longer needed.