### PR TITLE
[Experimental] Day equidistant echarts

### DIFF
--- a/frontend/src/components/graphs/EchartsDetailGraph.vue
+++ b/frontend/src/components/graphs/EchartsDetailGraph.vue
@@ -164,9 +164,10 @@ export default class EchartsDetailGraph extends Vue {
   // <!--<editor-fold desc="ECHARTS GRAPH OPTIONS">-->
   @Watch('detailDataPoints')
   @Watch('beginYAtZero')
+  @Watch('dayEquidistant')
   @Watch('graphFailedOrUnbenchmarkedColor') // DataPoints need adjusting, they store the color
   private updateGraph() {
-    console.log('UPDATED')
+    console.log('Echarts updated')
 
     this.selectAppropriateSeries()
 
@@ -406,8 +407,6 @@ export default class EchartsDetailGraph extends Vue {
   private get echartsDataPoints(): Map<DimensionId, EchartsDataPoint[]> {
     const map: Map<DimensionId, EchartsDataPoint[]> = new Map()
 
-    console.time('complete setup')
-    console.log(this.dimensions)
     this.dimensions.forEach(dimension => {
       if (this.dayEquidistant) {
         map.set(dimension, this.buildDayEquidistantPointsForSingle(dimension))
@@ -415,8 +414,6 @@ export default class EchartsDetailGraph extends Vue {
         map.set(dimension, this.buildNormalPointsForSingle(dimension))
       }
     })
-    console.log('\n\n===\n\n')
-    console.timeEnd('complete setup')
 
     return map
   }

--- a/frontend/src/views/NewRepoDetail.vue
+++ b/frontend/src/views/NewRepoDetail.vue
@@ -35,6 +35,7 @@
               :is="selectedGraphComponent"
               :dimensions="selectedDimensions"
               :beginYAtZero="yStartsAtZero"
+              :dayEquidistant="dayEquidistantGraphSelected"
             ></component>
           </v-card-text>
         </v-card>
@@ -69,13 +70,27 @@
                 </v-col>
                 <v-col class="d-flex justify-end">
                   <v-btn
+                    v-if="graphSupportsDayEquidistantDisplay"
+                    color="primary"
+                    outlined
+                    class="mr-4"
+                    @click="
+                      dayEquidistantGraphSelected = !dayEquidistantGraphSelected
+                    "
+                  >
+                    <span v-if="dayEquidistantGraphSelected">
+                      Disable Day-Equistant Graph
+                    </span>
+                    <span v-else>Enable Day-Equistant Graph</span>
+                  </v-btn>
+                  <v-btn
                     @click="yStartsAtZero = !yStartsAtZero"
                     color="primary"
                     outlined
                   >
-                    <span v-if="yStartsAtZero"
-                      >Begin Y-Axis at minimum value</span
-                    >
+                    <span v-if="yStartsAtZero">
+                      Begin Y-Axis at minimum value
+                    </span>
                     <span v-else>Begin Y-Axis at zero</span>
                   </v-btn>
                 </v-col>
@@ -292,6 +307,7 @@ export default class RepoDetail extends Vue {
   ]
 
   private selectedGraphComponent: typeof Vue | null = GraphPlaceholder
+  private dayEquidistantGraphSelected: boolean = false
 
   private get repo(): Repo {
     return vxm.repoModule.repoById(this.id)!
@@ -376,6 +392,10 @@ export default class RepoDetail extends Vue {
 
   private set yStartsAtZero(startsAtZero: boolean) {
     vxm.detailGraphModule.beginYScaleAtZero = startsAtZero
+  }
+
+  private get graphSupportsDayEquidistantDisplay() {
+    return this.selectedGraphComponent === EchartsDetailGraph
   }
 
   private lockDates(date: 'start' | 'end'): void {


### PR DESCRIPTION
## Warning
This PR is based on #113. It must be rebased and adjusted once that is merged. Only after that it can be merged.
This PR is also not required or *maybe* even wanted for the upcoming merge with stable.

## Idea
Using the author-time based layout, commits tend to cluster in small groups (if you have a working sleep rhythm and are working from one timezone). This can make it hard to see what changes a commit introduced, as you need to zoom in extremely far, losing track of the greater trends.

To combat this, this PR introduces day-equidistant layouting. Every commit is placed in a bucket based on *the day of* its author date and then each bucket has an equidistant layout. Gaps still appear as they did before, but if multiple commits are made in a day they are layed out equidistantly with the gap between them indicating the commit frequency for that day.

Due to this the x axis is now lying - the values might be as much as a day off. The hover tooltip still shows the correct date though and the commits are sorted by their author date.

#### Strictly Time based
![Before](https://user-images.githubusercontent.com/20284688/94339549-f8d77c80-fffa-11ea-8e35-9de5342b5162.png)

#### Day-Equidistant
![After](https://user-images.githubusercontent.com/20284688/94339550-fc6b0380-fffa-11ea-88de-6b826b64a790.png)

## Further work
Play a bit with this and expose it in the UI.