### PR TITLE
Do not send work to runners if backend is not ready

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/Dispatcher.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/Dispatcher.java
@@ -143,6 +143,13 @@ public class Dispatcher implements IDispatcher {
 	 * @return the next available task.
 	 */
 	public Optional<Task> getWork(TeleRunner runner) {
+		synchronized (teleRunners) {
+			// We do not know the runner yet or we know an old version of it apparently.
+			Optional<TeleRunner> knownRunner = getTeleRunner(runner.getRunnerName());
+			if (knownRunner.isEmpty() || knownRunner.get() != runner) {
+				return Optional.empty();
+			}
+		}
 		Optional<Task> nextTask = queue.fetchNextTask();
 		if (nextTask.isEmpty()) {
 			return Optional.empty();

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/ServerMasterWebsocketServlet.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/ServerMasterWebsocketServlet.java
@@ -86,7 +86,6 @@ public class ServerMasterWebsocketServlet extends WebSocketServlet {
 			synchronized (myTeleRunner) {
 				if (myTeleRunner.isDisposed()) {
 					myTeleRunner = new TeleRunner(name, serializer, dispatcher, benchRepo);
-					dispatcher.addRunner(myTeleRunner);
 					LOGGER.info(
 						"Revived runner {} connecting from {} with new instance!", name, req.getRemoteAddress()
 					);


### PR DESCRIPTION
If a runner connects, the backend will ask the runner about its status.

Currently this is done using the normal periodic status requesting. This might cause the runner to ask for work before it has sent its information over. As a result the backend has an incomplete view of the runner and the backend-part of the runner dies.

There are two possible ways to fix this, that could also be combined:
1. Do not send any work over when the backend isn't sure it has all information. This is the approach implemented in this PR.
2. Directly request the status once a runner connected and hope the runner is nice and doesn't ask for work before answering