### PR TITLE
Permanent links to detail graph

### DIFF
--- a/frontend/src/components/CommitChip.vue
+++ b/frontend/src/components/CommitChip.vue
@@ -16,6 +16,7 @@
 import Vue from 'vue'
 import Component from 'vue-class-component'
 import { Prop } from 'vue-property-decorator'
+import { copyToClipboard } from '@/util/ClipboardUtils'
 
 @Component
 export default class CommitChip extends Vue {
@@ -32,20 +33,12 @@ export default class CommitChip extends Vue {
   private on?: any
 
   private copyToClipboard(hash: string) {
-    let selection = window.getSelection()
+    const selection = window.getSelection()
     if (selection && selection.toString() !== '') {
       // Do not overwrite user text selection
       return
     }
-    navigator.clipboard
-      .writeText(hash)
-      .then(() => this.$globalSnackbar.setSuccess('', 'Copied!'))
-      .catch(error =>
-        this.$globalSnackbar.setError(
-          '',
-          'Could not copy to clipboard :( ' + error
-        )
-      )
+    copyToClipboard(hash, this.$globalSnackbar)
   }
 }
 </script>

--- a/frontend/src/util/ClipboardUtils.ts
+++ b/frontend/src/util/ClipboardUtils.ts
@@ -1,0 +1,15 @@
+import { ISnackbar } from '@/util/Snackbar'
+
+/**
+ * Copies the given text to the clipboard.
+ * @param text the text to copy
+ * @param snackbar the snackbar to use for status reporting
+ */
+export function copyToClipboard(text: string, snackbar: ISnackbar): void {
+  navigator.clipboard
+    .writeText(text)
+    .then(() => snackbar.setSuccess('', 'Copied!'))
+    .catch(error =>
+      snackbar.setError('', 'Could not copy to clipboard :( ' + error)
+    )
+}

--- a/frontend/src/util/TimeUtil.ts
+++ b/frontend/src/util/TimeUtil.ts
@@ -85,17 +85,39 @@ export function formatDateUTC(date: number | Date): string {
 }
 
 /**
- * Formats a time as a "hh:mm:ss" string.
- * @param date the date to format
+ * Converts a relative date "<number>d" or "<number>w" or "<number>m" or
+ * "<number>y" to a Date.
+ *
+ * @param relative the input string
+ * @param anchor the anchor it is relative to
  */
-export function formatTime(date: Date): string {
-  return (
-    leftZeroPad(2, date.getHours()) +
-    ':' +
-    leftZeroPad(2, date.getMinutes()) +
-    ':' +
-    leftZeroPad(2, date.getSeconds())
-  )
+export function dateFromRelative(
+  relative: string,
+  anchor: Date = new Date()
+): Date | undefined {
+  const number: number = parseFloat(relative.substring(0, relative.length - 1))
+
+  let multiplier: number
+  if (relative.endsWith('d')) {
+    // millis * seconds in minute * minutes in hour * day
+    multiplier = 1000 * 60 * 60 * 24
+  } else if (relative.endsWith('w')) {
+    // millis * seconds in minute * minutes in hour * day * 7
+    multiplier = 1000 * 60 * 60 * 24 * 7
+  } else if (relative.endsWith('m')) {
+    // millis * seconds in minute * minutes in hour * day * 30
+    multiplier = 1000 * 60 * 60 * 24 * 30
+  } else if (relative.endsWith('y')) {
+    // millis * seconds in minute * minutes in hour * day * 365
+    multiplier = 1000 * 60 * 60 * 24 * 465
+  } else {
+    return undefined
+  }
+
+  if (isNaN(number)) {
+    return undefined
+  }
+  return new Date(anchor.getTime() + number * multiplier)
 }
 
 /**

--- a/frontend/src/views/NewRepoDetail.vue
+++ b/frontend/src/views/NewRepoDetail.vue
@@ -20,6 +20,11 @@
             </v-btn-toggle>
           </v-card-title>
           <v-card-text>
+            <v-row justify="end" class="mx-4">
+              <v-col cols="auto">
+                <share-graph-link-dialog />
+              </v-col>
+            </v-row>
             <component
               :is="selectedGraphComponent"
               :dimensions="selectedDimensions"
@@ -229,12 +234,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import Component from 'vue-class-component'
-import {
-  mdiCalendar,
-  mdiLinkVariantPlus,
-  mdiLock,
-  mdiLockOpenVariant
-} from '@mdi/js'
+import { mdiCalendar, mdiLock, mdiLockOpenVariant } from '@mdi/js'
 import { vxm } from '@/store'
 import RepoBaseInformation from '@/components/repodetail/RepoBaseInformation.vue'
 import DimensionSelection from '../components/graphs/DimensionSelection.vue'
@@ -244,9 +244,11 @@ import { Dimension, Repo } from '@/store/types'
 import EchartsDetailGraph from '@/components/graphs/EchartsDetailGraph.vue'
 import DytailGraph from '@/components/graphs/NewDytailGraph.vue'
 import { Watch } from 'vue-property-decorator'
+import ShareGraphLinkDialog from '@/views/ShareGraphLinkDialog.vue'
 
 @Component({
   components: {
+    'share-graph-link-dialog': ShareGraphLinkDialog,
     'repo-base-information': RepoBaseInformation,
     'matrix-dimension-selection': MatrixDimensionSelection,
     'normal-dimension-selection': DimensionSelection,
@@ -399,10 +401,6 @@ export default class RepoDetail extends Vue {
       : 'You have to select a date after the first one!'
   }
 
-  private get permanentLinkUrl() {
-    return vxm.detailGraphModule.permanentLink
-  }
-
   @Watch('id')
   private retrieveGraphData(): void {
     if (this.stopAfterStart()) {
@@ -419,9 +417,6 @@ export default class RepoDetail extends Vue {
   mounted(): void {
     this.retrieveGraphData()
   }
-
-  // ICONS
-  private permanentLinkIcon = mdiLinkVariantPlus
 }
 </script>
 

--- a/frontend/src/views/NewRepoDetail.vue
+++ b/frontend/src/views/NewRepoDetail.vue
@@ -68,6 +68,12 @@
                     <span v-else>Begin Y-Axis at zero</span>
                   </v-btn>
                 </v-col>
+                <v-col cols="auto">
+                  <v-btn text color="primary" :href="permanentLinkUrl">
+                    Permanent Link
+                    <v-icon right>{{ permanentLinkIcon }}</v-icon>
+                  </v-btn>
+                </v-col>
               </v-row>
             </v-container>
           </v-card-text>
@@ -223,7 +229,12 @@
 <script lang="ts">
 import Vue from 'vue'
 import Component from 'vue-class-component'
-import { mdiCalendar, mdiLock, mdiLockOpenVariant } from '@mdi/js'
+import {
+  mdiCalendar,
+  mdiLinkVariantPlus,
+  mdiLock,
+  mdiLockOpenVariant
+} from '@mdi/js'
 import { vxm } from '@/store'
 import RepoBaseInformation from '@/components/repodetail/RepoBaseInformation.vue'
 import DimensionSelection from '../components/graphs/DimensionSelection.vue'
@@ -388,6 +399,10 @@ export default class RepoDetail extends Vue {
       : 'You have to select a date after the first one!'
   }
 
+  private get permanentLinkUrl() {
+    return vxm.detailGraphModule.permanentLink
+  }
+
   @Watch('id')
   private retrieveGraphData(): void {
     if (this.stopAfterStart()) {
@@ -404,6 +419,9 @@ export default class RepoDetail extends Vue {
   mounted(): void {
     this.retrieveGraphData()
   }
+
+  // ICONS
+  private permanentLinkIcon = mdiLinkVariantPlus
 }
 </script>
 

--- a/frontend/src/views/RepoDetailFrame.vue
+++ b/frontend/src/views/RepoDetailFrame.vue
@@ -85,6 +85,7 @@ export default class RepoDetailFrame extends Vue {
     if (vxm.repoModule.allRepos.length === 1) {
       this.selectedRepoId = vxm.repoModule.allRepos[0].id
     }
+    vxm.detailGraphModule.adjustToPermanentLink(this.$route)
   }
 
   // ============== ICONS ==============

--- a/frontend/src/views/ShareGraphLinkDialog.vue
+++ b/frontend/src/views/ShareGraphLinkDialog.vue
@@ -1,0 +1,140 @@
+<template>
+  <v-dialog width="800px" v-model="dialogOpen">
+    <template #activator=" { on } ">
+      <v-btn v-on="on" text color="primary">
+        Share graph
+        <v-icon right>{{ permanentLinkIcon }}</v-icon>
+      </v-btn>
+    </template>
+    <v-card>
+      <v-card-title>
+        <v-toolbar color="primary" dark>
+          Share a permanent link to this graph
+        </v-toolbar>
+      </v-card-title>
+      <v-card-text>
+        <v-container fluid>
+          <v-row no-gutters>
+            <v-col
+              v-for="{
+                label,
+                selectable,
+                unselectableMessage,
+                key
+              } in selectableOptions"
+              :key="key"
+            >
+              <v-tooltip top :disabled="selectable">
+                <template #activator="{ on }">
+                  <span v-on="on">
+                    <v-checkbox
+                      v-on="on"
+                      hide-details
+                      v-model="options[key]"
+                      :disabled="!selectable"
+                      :indeterminate="!selectable"
+                      :label="label"
+                    ></v-checkbox>
+                  </span>
+                </template>
+                {{ unselectableMessage }}
+              </v-tooltip>
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col>
+              <v-text-field
+                id="url-field"
+                readonly
+                autofocus
+                :value="permanentLinkUrl"
+              >
+                <template #append>
+                  <div class="pb-2 pl-2">
+                    <v-btn
+                      outlined
+                      text
+                      color="primary"
+                      @click="copyPermanentLink"
+                    >
+                      Copy
+                    </v-btn>
+                  </div>
+                </template>
+              </v-text-field>
+            </v-col>
+          </v-row>
+        </v-container>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+<script lang="ts">
+import Vue from 'vue'
+import Component from 'vue-class-component'
+import { vxm } from '@/store'
+import { mdiLinkVariantPlus } from '@mdi/js'
+import { copyToClipboard } from '@/util/ClipboardUtils'
+import { PermanentLinkOptions } from '@/store/modules/detailGraphStore'
+import { Watch } from 'vue-property-decorator'
+
+@Component
+export default class ShareGraphLinkDialog extends Vue {
+  private dialogOpen: boolean = false
+
+  private options: PermanentLinkOptions = {
+    includeYZoom: true,
+    includeXZoom: true,
+    includeDimensions: true
+  }
+
+  private get selectableOptions() {
+    return [
+      {
+        label: 'Include X-axis zoom',
+        selectable:
+          vxm.detailGraphModule.zoomXStartValue !== null ||
+          vxm.detailGraphModule.zoomXEndValue !== null,
+        unselectableMessage: "You haven't zoomed the X axis",
+        key: 'includeXZoom'
+      },
+      {
+        label: 'Include Y-axis zoom',
+        selectable:
+          vxm.detailGraphModule.zoomYStartValue !== null ||
+          vxm.detailGraphModule.zoomYEndValue !== null,
+        unselectableMessage: "You haven't zoomed the Y axis",
+        key: 'includeYZoom'
+      },
+      {
+        label: 'Include dimensions',
+        selectable: vxm.detailGraphModule.selectedDimensions.length > 0,
+        unselectableMessage: "You haven't selected any dimensions",
+        key: 'includeDimensions'
+      }
+    ]
+  }
+
+  private get permanentLinkUrl() {
+    return vxm.detailGraphModule.permanentLink(this.options)
+  }
+
+  private copyPermanentLink() {
+    copyToClipboard(this.permanentLinkUrl, this.$globalSnackbar)
+  }
+
+  @Watch('dialogOpen')
+  private onDialogVisibilityChange() {
+    if (this.dialogOpen) {
+      this.options = {
+        includeDimensions: true,
+        includeXZoom: true,
+        includeYZoom: true
+      }
+    }
+  }
+
+  // ICONS
+  private permanentLinkIcon = mdiLinkVariantPlus
+}
+</script>


### PR DESCRIPTION
## Warning
This PR depends on #87. That PR needs to be merged before this one!

## About
This PR adds permanent links to the detail graph as well as a mechanism to generate them. If there is no X/Y zoom because the graph was not zoomed in, those checkboxes will be unselectable and turn into an "indeterminate" state.
![image](https://user-images.githubusercontent.com/20284688/94351500-6c0fdb80-0059-11eb-911b-1256498c65a6.png)

Leading to this dialog:
![image](https://user-images.githubusercontent.com/20284688/94351504-7c27bb00-0059-11eb-94d7-8c7d6a0bf20f.png)
