### PR TITLE
Sort metrics and benchmarks in the dimension selectors

### DIFF
--- a/frontend/src/components/graphs/DimensionSelection.vue
+++ b/frontend/src/components/graphs/DimensionSelection.vue
@@ -56,7 +56,7 @@ class BenchmarkItem {
   constructor(name: string, children: DimensionItem[]) {
     this.id = name
     this.name = name
-    this.children = children
+    this.children = children.sort((a, b) => a.name.localeCompare(b.name))
   }
 }
 
@@ -118,6 +118,7 @@ export default class DimensionSelection extends Vue {
           repo.dimensions
             .filter(dimension => dimension.benchmark === benchmark)
             .map(dimension => new DimensionItem(dimension))
+            .sort((a, b) => a.name.localeCompare(b.name))
         )
     )
   }

--- a/frontend/src/components/graphs/MatrixDimensionSelection.vue
+++ b/frontend/src/components/graphs/MatrixDimensionSelection.vue
@@ -64,7 +64,9 @@ export default class MatrixMeasurementIdSelection extends Vue {
   }
 
   private get allBenchmarks(): string[] {
-    return vxm.repoModule.occuringBenchmarks([this.repoId])
+    return vxm.repoModule
+      .occuringBenchmarks([this.repoId])
+      .sort((a, b) => a.localeCompare(b))
   }
 
   private metricsFor(benchmark: string): string[] {
@@ -141,7 +143,7 @@ export default class MatrixMeasurementIdSelection extends Vue {
   private get allMetrics(): string[] {
     return Array.from(
       new Set(this.allBenchmarks.flatMap(it => this.metricsFor(it))).values()
-    ).sort()
+    ).sort((a, b) => a.localeCompare(b))
   }
 
   private metricColor(benchmark: string, metric: string): string {


### PR DESCRIPTION
Previously not all selectors on the detail sorted their metrics and dimensions by name - now they do.