### PR TITLE
Use yarnpkg instead of yarn

### DIFF
--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -5,11 +5,11 @@ mode?=production
 all: build
 
 node_modules: package.json yarn.lock
-	yarn install
+	yarnpkg install
 	touch node_modules
 
 dist: $(shell find src -name "*.vue" -o -name "*.ts") node_modules .env.production
-	yarn build --mode="$(mode)"
+	yarnpkg build --mode="$(mode)"
 	touch dist
 
 build: dist
@@ -19,4 +19,4 @@ clean:
 	rm -rf dist
 
 start-frontend:
-	yarn serve
+	yarnpkg serve


### PR DESCRIPTION
This change should make the makefile work on more systems than before. For
example on ubuntu, the package for yarn only contains an executable called
yarnpkg.