### PR TITLE
Fix 500 in some cases

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/CommitReadAccess.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/CommitReadAccess.java
@@ -10,6 +10,7 @@ import de.aaaaaaah.velcom.backend.access.exceptions.NoSuchCommitException;
 import de.aaaaaaah.velcom.backend.access.exceptions.RepoAccessException;
 import de.aaaaaaah.velcom.backend.access.filter.AuthorTimeRevFilter;
 import de.aaaaaaah.velcom.backend.storage.repo.RepoStorage;
+import de.aaaaaaah.velcom.backend.storage.repo.exception.NoSuchRepositoryException;
 import de.aaaaaaah.velcom.backend.storage.repo.exception.RepositoryAcquisitionException;
 import io.micrometer.core.annotation.Timed;
 import java.io.IOException;
@@ -133,7 +134,7 @@ public class CommitReadAccess {
 					// See javadoc
 				}
 			}
-		} catch (RepositoryAcquisitionException ignored) {
+		} catch (RepositoryAcquisitionException | NoSuchRepositoryException ignored) {
 			// See javadoc
 		}
 
@@ -291,7 +292,7 @@ public class CommitReadAccess {
 			}
 
 			return commitMap;
-		} catch (RepositoryAcquisitionException | GitAPIException | IOException e) {
+		} catch (RepositoryAcquisitionException | NoSuchRepositoryException | GitAPIException | IOException e) {
 			throw new RepoAccessException(repoId, e);
 		}
 	}
@@ -317,7 +318,7 @@ public class CommitReadAccess {
 		try {
 			String directoryName = repoId.getDirectoryName();
 			jgitRepo = repoStorage.acquireRepository(directoryName);
-		} catch (RepositoryAcquisitionException e) {
+		} catch (RepositoryAcquisitionException | NoSuchRepositoryException e) {
 			throw new CommitLogException(repoId, branches, e);
 		}
 

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/RepoWriteAccess.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/RepoWriteAccess.java
@@ -19,6 +19,7 @@ import de.aaaaaaah.velcom.backend.storage.repo.GuickCloning;
 import de.aaaaaaah.velcom.backend.storage.repo.GuickCloning.CloneException;
 import de.aaaaaaah.velcom.backend.storage.repo.RepoStorage;
 import de.aaaaaaah.velcom.backend.storage.repo.exception.AddRepositoryException;
+import de.aaaaaaah.velcom.backend.storage.repo.exception.NoSuchRepositoryException;
 import de.aaaaaaah.velcom.backend.storage.repo.exception.RepositoryAcquisitionException;
 import java.io.IOException;
 import java.util.Collection;
@@ -199,7 +200,7 @@ public class RepoWriteAccess extends RepoReadAccess {
 			String defaultBranchStr = repo.getBranch();
 			trackedBranchName = BranchName.fromName(defaultBranchStr);
 			setTrackedBranches(repoId, List.of(trackedBranchName));
-		} catch (RepositoryAcquisitionException | IOException e) {
+		} catch (RepositoryAcquisitionException | NoSuchRepositoryException | IOException e) {
 			throw new AddRepoException(name, remoteUrl, e);
 		}
 


### PR DESCRIPTION
This PR catches a few cases where a NoSuchRepositoryException was not dealt with properly, such as when requesting a `/commit` with an invalid repoid (that is still a valid UUID).