### PR TITLE
Improve performance of /recent/runs endpoint

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/ServerMain.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/ServerMain.java
@@ -150,7 +150,7 @@ public class ServerMain extends Application<GlobalConfig> {
 		RunComparator runComparator = new RunComparator(significanceFactors);
 		TimesliceComparison comparison = new TimesliceComparison(commitAccess, benchmarkAccess);
 		SignificantRunsCollector significantRunsCollector = new SignificantRunsCollector(
-			benchmarkAccess, commitAccess, runComparator
+			significanceFactors, benchmarkAccess, commitAccess, runComparator
 		);
 
 		// Listener

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/ServerMain.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/ServerMain.java
@@ -13,6 +13,7 @@ import de.aaaaaaah.velcom.backend.access.entities.AuthToken;
 import de.aaaaaaah.velcom.backend.access.entities.RemoteUrl;
 import de.aaaaaaah.velcom.backend.data.benchrepo.BenchRepo;
 import de.aaaaaaah.velcom.backend.data.queue.Queue;
+import de.aaaaaaah.velcom.backend.data.recentruns.SignificantRunsCollector;
 import de.aaaaaaah.velcom.backend.data.repocomparison.TimesliceComparison;
 import de.aaaaaaah.velcom.backend.data.runcomparison.RunComparator;
 import de.aaaaaaah.velcom.backend.data.runcomparison.SignificanceFactors;
@@ -148,6 +149,9 @@ public class ServerMain extends Application<GlobalConfig> {
 		);
 		RunComparator runComparator = new RunComparator(significanceFactors);
 		TimesliceComparison comparison = new TimesliceComparison(commitAccess, benchmarkAccess);
+		SignificantRunsCollector significantRunsCollector = new SignificantRunsCollector(
+			benchmarkAccess, commitAccess, runComparator
+		);
 
 		// Listener
 		Listener listener = new Listener(configuration, repoAccess, commitAccess, knownCommitAccess,
@@ -174,7 +178,7 @@ public class ServerMain extends Application<GlobalConfig> {
 		environment.jersey().register(new TestTokenEndpoint());
 		environment.jersey().register(new QueueEndpoint(commitAccess, repoAccess, queue, dispatcher));
 		environment.jersey()
-			.register(new RecentRunsEndpoint(benchmarkAccess, commitAccess, runComparator));
+			.register(new RecentRunsEndpoint(benchmarkAccess, commitAccess, significantRunsCollector));
 		environment.jersey()
 			.register(new RepoEndpoint(repoAccess, tokenAccess, benchmarkAccess, listener));
 		environment.jersey().register(new GraphComparisonEndpoint(comparison, benchmarkAccess));

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/entities/Run.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/entities/Run.java
@@ -115,15 +115,6 @@ public class Run {
 			.collect(Collectors.toSet());
 	}
 
-	/**
-	 * @return true if the run has failed measurements or is entirely failed
-	 */
-	public boolean hasFails() {
-		return getResult().getRight()
-			.map(ms -> ms.stream().anyMatch(m -> m.getContent().isLeft()))
-			.orElse(true);
-	}
-
 	@Override
 	public String toString() {
 		return "Run{" +

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/entities/sources/CommitSource.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/entities/sources/CommitSource.java
@@ -1,5 +1,6 @@
 package de.aaaaaaah.velcom.backend.access.entities.sources;
 
+import de.aaaaaaah.velcom.backend.access.entities.Commit;
 import de.aaaaaaah.velcom.backend.access.entities.CommitHash;
 import de.aaaaaaah.velcom.backend.access.entities.RepoId;
 import java.util.Objects;
@@ -15,6 +16,10 @@ public class CommitSource {
 	public CommitSource(RepoId repoId, CommitHash hash) {
 		this.repoId = Objects.requireNonNull(repoId);
 		this.hash = Objects.requireNonNull(hash);
+	}
+
+	public static CommitSource fromCommit(Commit commit) {
+		return new CommitSource(commit.getRepoId(), commit.getHash());
 	}
 
 	public RepoId getRepoId() {

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/recentruns/SignificantRun.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/recentruns/SignificantRun.java
@@ -1,0 +1,35 @@
+package de.aaaaaaah.velcom.backend.data.recentruns;
+
+import de.aaaaaaah.velcom.backend.access.entities.Run;
+import de.aaaaaaah.velcom.backend.data.runcomparison.DimensionDifference;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class SignificantRun {
+
+	private final Run run;
+	private final List<DimensionDifference> differences;
+
+	public SignificantRun(Run run, List<DimensionDifference> differences) {
+		this.run = Objects.requireNonNull(run);
+		this.differences = new ArrayList<>(Objects.requireNonNull(differences));
+	}
+
+	public Run getRun() {
+		return run;
+	}
+
+	public List<DimensionDifference> getDifferences() {
+		return differences;
+	}
+
+	@Override
+	public String toString() {
+		return "SignificantRun{" +
+			"run=" + run +
+			", differences=" + differences +
+			'}';
+	}
+
+}

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/recentruns/SignificantRunsCollector.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/recentruns/SignificantRunsCollector.java
@@ -1,28 +1,29 @@
 package de.aaaaaaah.velcom.backend.data.recentruns;
 
-import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
-import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 
 import de.aaaaaaah.velcom.backend.access.BenchmarkReadAccess;
 import de.aaaaaaah.velcom.backend.access.CommitReadAccess;
+import de.aaaaaaah.velcom.backend.access.entities.Commit;
 import de.aaaaaaah.velcom.backend.access.entities.CommitHash;
 import de.aaaaaaah.velcom.backend.access.entities.RepoId;
 import de.aaaaaaah.velcom.backend.access.entities.Run;
 import de.aaaaaaah.velcom.backend.access.entities.sources.CommitSource;
 import de.aaaaaaah.velcom.backend.data.runcomparison.DimensionDifference;
 import de.aaaaaaah.velcom.backend.data.runcomparison.RunComparator;
+import de.aaaaaaah.velcom.backend.data.runcomparison.SignificanceFactors;
 import io.micrometer.core.annotation.Timed;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 public class SignificantRunsCollector {
@@ -30,14 +31,16 @@ public class SignificantRunsCollector {
 	private static final int BATCH_SIZE = 50;
 	private static final int MAX_TRIES = 10;
 
+	private final SignificanceFactors significanceFactors;
 	private final BenchmarkReadAccess benchmarkAccess;
 	private final CommitReadAccess commitAccess;
 	private final RunComparator runComparator;
 
-	public SignificantRunsCollector(
-		BenchmarkReadAccess benchmarkAccess,
-		CommitReadAccess commitAccess,
+	public SignificantRunsCollector(SignificanceFactors significanceFactors,
+		BenchmarkReadAccess benchmarkAccess, CommitReadAccess commitAccess,
 		RunComparator runComparator) {
+
+		this.significanceFactors = significanceFactors;
 		this.benchmarkAccess = Objects.requireNonNull(benchmarkAccess);
 		this.commitAccess = Objects.requireNonNull(commitAccess);
 		this.runComparator = Objects.requireNonNull(runComparator);
@@ -48,79 +51,121 @@ public class SignificantRunsCollector {
 		List<SignificantRun> runs = new ArrayList<>();
 
 		for (int i = 0; i < MAX_TRIES && runs.size() < amount; i++) {
-			runs.addAll(collectBatch(i * BATCH_SIZE, BATCH_SIZE));
+			runs.addAll(collectBatch(i * BATCH_SIZE));
 		}
 
 		return runs.subList(0, Math.min(amount, runs.size()));
 	}
 
-	private List<SignificantRun> collectBatch(int skip, int amount) {
-		List<SignificantRun> batchResult = new ArrayList<>();
+	private List<SignificantRun> collectBatch(int skip) {
+		// 1. Load runs
+		// 2. Load parent runs per run
+		//   2.1. Load commits per RepoId
+		//   2.2. Load parent runs per CommitSource
+		// 3. Filter out significant runs
 
-		// 1.) Load the runs for this batch from database
-		List<Run> runs = benchmarkAccess.getRecentRuns(skip, amount).stream()
-			.filter(run -> run.getSource().isLeft())
-			.collect(toCollection(ArrayList::new));
+		List<Run> runs = benchmarkAccess.getRecentRuns(skip, SignificantRunsCollector.BATCH_SIZE);
+		Map<RepoId, Collection<Commit>> commitsPerRepo = getCommitsPerRepo(runs);
+		Map<CommitSource, Collection<Run>> parentRunsPerSource = getParentRunsPerSource(commitsPerRepo);
 
-		if (runs.isEmpty()) {
-			return emptyList();
-		}
-
-		// Runs that failed entirely are already significant and don't need comparisons
-		runs.stream()
-			.filter(run -> run.getResult().isLeft()) // run has RunError instead of measurements
-			.forEach(failedRun -> batchResult.add(new SignificantRun(failedRun, emptyList())));
-		runs.removeIf(run -> run.getResult().isLeft()); // no need to load parent runs for comparisons
-
-		Map<RepoId, Set<CommitHash>> groupedCommits = runs.stream()
-			.map(run -> run.getSource().getLeft().get())
-			.collect(groupingBy(CommitSource::getRepoId, mapping(CommitSource::getHash, toSet())));
-
-		// 2.) Get parent runs for the collected runs
-		Map<CommitSource, Collection<CommitHash>> parentMap = new HashMap<>();
-		Map<CommitSource, Run> parentRuns = new HashMap<>();
-
-		for (RepoId repoId : groupedCommits.keySet()) {
-			// 2.1) Load commits to find out what hashes the parent runs have
-			Set<CommitHash> hashesForThisRepo = groupedCommits.get(repoId);
-			Set<CommitHash> parentHashesForThisRepo = new HashSet<>();
-
-			commitAccess.getCommits(repoId, hashesForThisRepo).values().forEach(commit -> {
-				parentMap.put(new CommitSource(repoId, commit.getHash()), commit.getParentHashes());
-				parentHashesForThisRepo.addAll(commit.getParentHashes());
-			});
-
-			// 2.2) Load parent runs from database
-			benchmarkAccess.getLatestRuns(repoId, parentHashesForThisRepo).forEach((hash, run) -> {
-				parentRuns.put(new CommitSource(repoId, hash), run);
-			});
-		}
-
-		// 3.) Compare commits with their parents
-		for (Run run : runs) {
-			CommitSource source = run.getSource().getLeft().get();
-			Collection<CommitHash> parentHashes = parentMap.get(source);
-
-			if (parentHashes == null) {
-				// This run is referencing a commit that either does not exist anymore or has no parents
-				continue;
-			}
-
-			List<DimensionDifference> differences = parentHashes.stream()
-				.map(parentHash -> new CommitSource(source.getRepoId(), parentHash))
-				.filter(parentRuns::containsKey)
-				.map(parentRuns::get)
-				.map(parentRun -> runComparator.compare(parentRun, run))
-				.flatMap(comparison -> comparison.getDifferences().stream())
-				.filter(DimensionDifference::isSignificant)
-				.collect(toList());
-
-			if (!differences.isEmpty()) {
-				batchResult.add(new SignificantRun(run, differences));
-			}
-		}
-
-		return batchResult;
+		return runs.stream()
+			.flatMap(run -> getSignificantRun(run, parentRunsPerSource).stream())
+			.collect(toList());
 	}
 
+	private Map<RepoId, Collection<Commit>> getCommitsPerRepo(Collection<Run> runs) {
+		Map<RepoId, Set<CommitHash>> hashesByRepo = runs.stream()
+			.flatMap(run -> run.getSource().getLeft().stream())
+			.collect(groupingBy(CommitSource::getRepoId, mapping(CommitSource::getHash, toSet())));
+
+		Map<RepoId, Collection<Commit>> result = new HashMap<>();
+		hashesByRepo.forEach((repoId, hashes) -> {
+			Collection<Commit> commits = commitAccess.getCommits(repoId, hashes).values();
+			result.put(repoId, commits);
+		});
+
+		return result;
+	}
+
+	private Map<CommitSource, Collection<Run>> getParentRunsPerSource(
+		Map<RepoId, Collection<Commit>> commitsPerRepo) {
+
+		Map<RepoId, Map<CommitHash, Run>> parentRuns = new HashMap<>();
+		commitsPerRepo.forEach((repoId, commits) -> {
+			Set<CommitHash> parentHashes = commits.stream()
+				.flatMap(commit -> commit.getParentHashes().stream())
+				.collect(toSet());
+			parentRuns.put(repoId, benchmarkAccess.getLatestRuns(repoId, parentHashes));
+		});
+
+		return commitsPerRepo.values().stream()
+			.flatMap(Collection::stream)
+			.collect(toMap(
+				CommitSource::fromCommit,
+				commit -> {
+					// There will always be an entry for the repo id as long as commitsPerRepo doesn't contain
+					// any commits under the wrong repo id
+					Map<CommitHash, Run> runByHash = parentRuns.get(commit.getRepoId());
+
+					return commit.getParentHashes().stream()
+						// Ignoring parent commits without associated run, which do occur occasionally
+						.flatMap(hash -> Optional.ofNullable(runByHash.get(hash)).stream())
+						.collect(toList());
+				}
+			));
+	}
+
+	/**
+	 * @param run a run
+	 * @param parents a map of all known commits' parent runs. Is not required to contain an entry
+	 * 	for this particular run
+	 * @return a {@link SignificantRun} if the run is significant, {@link Optional#empty()} otherwise
+	 */
+	private Optional<SignificantRun> getSignificantRun(Run run,
+		Map<CommitSource, Collection<Run>> parents) {
+
+		List<DimensionDifference> significantDifferences = run.getSource().getLeft()
+			.flatMap(source -> Optional.ofNullable(parents.get(source)))
+			.stream()
+			.flatMap(Collection::stream)
+			.map(parent -> runComparator.compare(parent, run))
+			.flatMap(comparison -> comparison.getDifferences().stream())
+			.filter(this::isDifferenceSignificant)
+			.collect(toList());
+
+		if (hasFails(run) || !significantDifferences.isEmpty()) {
+			return Optional.of(new SignificantRun(run, significantDifferences));
+		} else {
+			return Optional.empty();
+		}
+	}
+
+	/**
+	 * @return true if the run has failed measurements or is entirely failed
+	 */
+	private boolean hasFails(Run run) {
+		return run.getResult().getRight()
+			.map(ms -> ms.stream().anyMatch(m -> m.getContent().isLeft()))
+			.orElse(true);
+	}
+
+	/**
+	 * @param diff the difference to check
+	 * @return true if the difference is significant according to the {@code significanceFactors}
+	 */
+	private boolean isDifferenceSignificant(DimensionDifference diff) {
+		boolean relSignificant = diff.getReldiff()
+			.map(reldiff -> Math.abs(reldiff) >= significanceFactors.getRelativeThreshold())
+			// There is no reldiff if the first value is 0. But if the second value is also zero, that
+			// hardly constitutes a significant difference. Otherwise, it is a move away from 0, which is
+			// always significant.
+			.orElse(diff.getFirst() != diff.getSecond());
+
+		boolean stddevSignificant = diff.getSecondStddev()
+			.map(stddev -> Math.abs(diff.getDiff()) >= significanceFactors.getStddevThreshold() * stddev)
+			// If there is no stddev, this check should not prevent differences from being significant
+			.orElse(true);
+
+		return relSignificant && stddevSignificant;
+	}
 }

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/recentruns/SignificantRunsCollector.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/recentruns/SignificantRunsCollector.java
@@ -1,0 +1,126 @@
+package de.aaaaaaah.velcom.backend.data.recentruns;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toCollection;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
+import de.aaaaaaah.velcom.backend.access.BenchmarkReadAccess;
+import de.aaaaaaah.velcom.backend.access.CommitReadAccess;
+import de.aaaaaaah.velcom.backend.access.entities.CommitHash;
+import de.aaaaaaah.velcom.backend.access.entities.RepoId;
+import de.aaaaaaah.velcom.backend.access.entities.Run;
+import de.aaaaaaah.velcom.backend.access.entities.sources.CommitSource;
+import de.aaaaaaah.velcom.backend.data.runcomparison.DimensionDifference;
+import de.aaaaaaah.velcom.backend.data.runcomparison.RunComparator;
+import io.micrometer.core.annotation.Timed;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public class SignificantRunsCollector {
+
+	private static final int BATCH_SIZE = 50;
+	private static final int MAX_TRIES = 10;
+
+	private final BenchmarkReadAccess benchmarkAccess;
+	private final CommitReadAccess commitAccess;
+	private final RunComparator runComparator;
+
+	public SignificantRunsCollector(
+		BenchmarkReadAccess benchmarkAccess,
+		CommitReadAccess commitAccess,
+		RunComparator runComparator) {
+		this.benchmarkAccess = Objects.requireNonNull(benchmarkAccess);
+		this.commitAccess = Objects.requireNonNull(commitAccess);
+		this.runComparator = Objects.requireNonNull(runComparator);
+	}
+
+	@Timed(histogram = true)
+	public List<SignificantRun> collectMostRecent(int amount) {
+		List<SignificantRun> runs = new ArrayList<>();
+
+		for (int i = 0; i < MAX_TRIES && runs.size() < amount; i++) {
+			runs.addAll(collectBatch(i * BATCH_SIZE, BATCH_SIZE));
+		}
+
+		return runs.subList(0, Math.min(amount, runs.size()));
+	}
+
+	private List<SignificantRun> collectBatch(int skip, int amount) {
+		List<SignificantRun> batchResult = new ArrayList<>();
+
+		// 1.) Load the runs for this batch from database
+		List<Run> runs = benchmarkAccess.getRecentRuns(skip, amount).stream()
+			.filter(run -> run.getSource().isLeft())
+			.collect(toCollection(ArrayList::new));
+
+		if (runs.isEmpty()) {
+			return emptyList();
+		}
+
+		// Runs that failed entirely are already significant and don't need comparisons
+		runs.stream()
+			.filter(run -> run.getResult().isLeft()) // run has RunError instead of measurements
+			.forEach(failedRun -> batchResult.add(new SignificantRun(failedRun, emptyList())));
+		runs.removeIf(run -> run.getResult().isLeft()); // no need to load parent runs for comparisons
+
+		Map<RepoId, Set<CommitHash>> groupedCommits = runs.stream()
+			.map(run -> run.getSource().getLeft().get())
+			.collect(groupingBy(CommitSource::getRepoId, mapping(CommitSource::getHash, toSet())));
+
+		// 2.) Get parent runs for the collected runs
+		Map<CommitSource, Collection<CommitHash>> parentMap = new HashMap<>();
+		Map<CommitSource, Run> parentRuns = new HashMap<>();
+
+		for (RepoId repoId : groupedCommits.keySet()) {
+			// 2.1) Load commits to find out what hashes the parent runs have
+			Set<CommitHash> hashesForThisRepo = groupedCommits.get(repoId);
+			Set<CommitHash> parentHashesForThisRepo = new HashSet<>();
+
+			commitAccess.getCommits(repoId, hashesForThisRepo).values().forEach(commit -> {
+				parentMap.put(new CommitSource(repoId, commit.getHash()), commit.getParentHashes());
+				parentHashesForThisRepo.addAll(commit.getParentHashes());
+			});
+
+			// 2.2) Load parent runs from database
+			benchmarkAccess.getLatestRuns(repoId, parentHashesForThisRepo).forEach((hash, run) -> {
+				parentRuns.put(new CommitSource(repoId, hash), run);
+			});
+		}
+
+		// 3.) Compare commits with their parents
+		for (Run run : runs) {
+			CommitSource source = run.getSource().getLeft().get();
+			Collection<CommitHash> parentHashes = parentMap.get(source);
+
+			if (parentHashes == null) {
+				// This run is referencing a commit that either does not exist anymore or has no parents
+				continue;
+			}
+
+			List<DimensionDifference> differences = parentHashes.stream()
+				.map(parentHash -> new CommitSource(source.getRepoId(), parentHash))
+				.filter(parentRuns::containsKey)
+				.map(parentRuns::get)
+				.map(parentRun -> runComparator.compare(parentRun, run))
+				.flatMap(comparison -> comparison.getDifferences().stream())
+				.filter(DimensionDifference::isSignificant)
+				.collect(toList());
+
+			if (!differences.isEmpty()) {
+				batchResult.add(new SignificantRun(run, differences));
+			}
+		}
+
+		return batchResult;
+	}
+
+}

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/runcomparison/DimensionDifference.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/runcomparison/DimensionDifference.java
@@ -6,25 +6,19 @@ import javax.annotation.Nullable;
 
 public class DimensionDifference {
 
-	private final SignificanceFactors significanceFactors;
 	private final Dimension dimension;
 	private final double first;
 	private final double second;
 	@Nullable
 	private final Double secondStddev;
 
-	public DimensionDifference(SignificanceFactors significanceFactors, Dimension dimension,
-		double first, double second, @Nullable Double secondStddev) {
+	public DimensionDifference(Dimension dimension, double first, double second,
+		@Nullable Double secondStddev) {
 
-		this.significanceFactors = significanceFactors;
 		this.dimension = dimension;
 		this.first = first;
 		this.second = second;
 		this.secondStddev = secondStddev;
-	}
-
-	public SignificanceFactors getSignificanceFactors() {
-		return significanceFactors;
 	}
 
 	public Dimension getDimension() {
@@ -53,21 +47,5 @@ public class DimensionDifference {
 		}
 
 		return Optional.of((second - first) / first);
-	}
-
-	public boolean isSignificant() {
-		boolean relSignificant = getReldiff()
-			.map(reldiff -> Math.abs(reldiff) >= significanceFactors.getRelativeThreshold())
-			// There is no reldiff if the first value is 0. But if the second value is also zero, that
-			// hardly constitutes a significant difference. Otherwise, it is a move away from 0, which is
-			// always significant.
-			.orElse(first != second);
-
-		boolean stddevSignificant = getSecondStddev()
-			.map(stddev -> Math.abs(getDiff()) >= significanceFactors.getStddevThreshold() * stddev)
-			// If there is no stddev, this check should not prevent differences from being significant
-			.orElse(true);
-
-		return relSignificant && stddevSignificant;
 	}
 }

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/runcomparison/RunComparator.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/runcomparison/RunComparator.java
@@ -39,7 +39,6 @@ public class RunComparator {
 			MeasurementValues secondValues = secondMap.get(dimension);
 
 			DimensionDifference difference = new DimensionDifference(
-				significanceFactors,
 				dimension,
 				firstValues.getAverageValue(),
 				secondValues.getAverageValue(),

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/RecentRunsEndpoint.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/RecentRunsEndpoint.java
@@ -33,9 +33,6 @@ public class RecentRunsEndpoint {
 	private static final int MIN_N = 1;
 	private static final int MAX_N = 100;
 
-	private static final int SIGNIFICANT_MAX_OFFSET = 500;
-	private static final int SIGNIFICANT_BATCH_SIZE = 50;
-
 	private final BenchmarkReadAccess benchmarkAccess;
 	private final CommitReadAccess commitAccess;
 	private final SignificantRunsCollector significantRunsCollector;

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/RecentRunsEndpoint.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/RecentRunsEndpoint.java
@@ -2,21 +2,16 @@ package de.aaaaaaah.velcom.backend.restapi.endpoints;
 
 import de.aaaaaaah.velcom.backend.access.BenchmarkReadAccess;
 import de.aaaaaaah.velcom.backend.access.CommitReadAccess;
-import de.aaaaaaah.velcom.backend.access.entities.Commit;
 import de.aaaaaaah.velcom.backend.access.entities.Dimension;
 import de.aaaaaaah.velcom.backend.access.entities.DimensionInfo;
 import de.aaaaaaah.velcom.backend.access.entities.Run;
-import de.aaaaaaah.velcom.backend.access.entities.sources.CommitSource;
+import de.aaaaaaah.velcom.backend.data.recentruns.SignificantRunsCollector;
 import de.aaaaaaah.velcom.backend.data.runcomparison.DimensionDifference;
-import de.aaaaaaah.velcom.backend.data.runcomparison.RunComparator;
 import de.aaaaaaah.velcom.backend.restapi.jsonobjects.JsonDimensionDifference;
 import de.aaaaaaah.velcom.backend.restapi.jsonobjects.JsonRunDescription;
 import de.aaaaaaah.velcom.backend.restapi.jsonobjects.JsonRunDescription.JsonSuccess;
 import de.aaaaaaah.velcom.backend.restapi.jsonobjects.JsonSource;
-import de.aaaaaaah.velcom.shared.util.Pair;
 import io.micrometer.core.annotation.Timed;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -43,14 +38,14 @@ public class RecentRunsEndpoint {
 
 	private final BenchmarkReadAccess benchmarkAccess;
 	private final CommitReadAccess commitAccess;
-	private final RunComparator runComparator;
+	private final SignificantRunsCollector significantRunsCollector;
 
-	public RecentRunsEndpoint(BenchmarkReadAccess benchmarkAccess, CommitReadAccess commitAccess,
-		RunComparator runComparator) {
-
+	public RecentRunsEndpoint(BenchmarkReadAccess benchmarkAccess,
+		CommitReadAccess commitAccess,
+		SignificantRunsCollector significantRunsCollector) {
 		this.benchmarkAccess = benchmarkAccess;
 		this.commitAccess = commitAccess;
-		this.runComparator = runComparator;
+		this.significantRunsCollector = significantRunsCollector;
 	}
 
 	@GET
@@ -66,8 +61,8 @@ public class RecentRunsEndpoint {
 
 		final List<JsonRunEntry> runEntries;
 		if (significant) {
-			runEntries = getSignificantRuns(n).stream()
-				.map(pair -> toJsonRunEntry(pair.getFirst(), pair.getSecond()))
+			runEntries = significantRunsCollector.collectMostRecent(n).stream()
+				.map(run -> toJsonRunEntry(run.getRun(), run.getDifferences()))
 				.collect(Collectors.toList());
 		} else {
 			runEntries = benchmarkAccess.getRecentRuns(0, n).stream()
@@ -102,52 +97,6 @@ public class RecentRunsEndpoint {
 			),
 			jsonDiffs
 		);
-	}
-
-	@Timed(histogram = true)
-	private List<Pair<Run, List<DimensionDifference>>> getSignificantRuns(int n) {
-		List<Pair<Run, List<DimensionDifference>>> runs = new ArrayList<>();
-
-		outer:
-		for (int offset = 0; offset < SIGNIFICANT_MAX_OFFSET; offset += SIGNIFICANT_BATCH_SIZE) {
-			List<Run> recentRuns = benchmarkAccess.getRecentRuns(offset, SIGNIFICANT_BATCH_SIZE);
-			Collections.reverse(recentRuns); // Ordered from newest to oldest now
-			if (recentRuns.isEmpty()) {
-				break;
-			}
-
-			for (Run run : recentRuns) {
-				List<DimensionDifference> dimensions = getSignificantDimensions(run);
-				if (run.hasFails() || !dimensions.isEmpty()) {
-					runs.add(new Pair<>(run, dimensions));
-
-					if (runs.size() >= n) {
-						break outer;
-					}
-				}
-			}
-		}
-
-		Collections.reverse(runs);
-		return runs;
-	}
-
-	private List<DimensionDifference> getSignificantDimensions(Run run) {
-		if (run.getSource().getLeft().isEmpty()) {
-			return List.of();
-		}
-
-		CommitSource source = run.getSource().getLeft().get();
-		Commit sourceCommit = commitAccess.getCommit(source.getRepoId(), source.getHash());
-
-		return benchmarkAccess
-			.getLatestRuns(sourceCommit.getRepoId(), sourceCommit.getParentHashes())
-			.values()
-			.stream()
-			.map(parentRun -> runComparator.compare(parentRun, run))
-			.flatMap(comparison -> comparison.getDifferences().stream())
-			.filter(DimensionDifference::isSignificant)
-			.collect(Collectors.toList());
 	}
 
 	private static class GetReply {


### PR DESCRIPTION
This pull requests changes the following two things:

1. The collection of recent significant runs is extracted into its own class on the data layer: `SignificantRunsCollector`
2. Performance is (hopefully) improved by batch loading commit data and parent runs per repo (instead of per run)