### PR TITLE
Delete outdated local storage

### DIFF
--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -10,6 +10,7 @@ import { QueueStore } from './modules/queueStore'
 import { ComparisonGraphStore } from './modules/comparisonGraphStore'
 import { DetailGraphStore } from './modules/detailGraphStore'
 import {
+  deletedOutdatedLocalData,
   persistenceLocalStorage,
   persistenceSessionStorage
 } from './persistence'
@@ -25,6 +26,8 @@ export interface RootState {
   detailGraphModule: DetailGraphStore
   userModule: UserStore
 }
+
+deletedOutdatedLocalData()
 
 Vue.use(Vuex)
 

--- a/frontend/src/store/persistence.ts
+++ b/frontend/src/store/persistence.ts
@@ -11,6 +11,23 @@ import {
   repoStoreToJson
 } from '@/util/StorePersistenceUtilities'
 
+const STORAGE_VERSION_KEY = 'VELCOM_STORAGE_VERSION'
+const STORAGE_VERSION_CURRENT = '1'
+
+/**
+ * Deletes old stored data which does not conform to what the store expects to
+ * deserialize now.
+ */
+export function deletedOutdatedLocalData(): void {
+  const storedVersion = window.localStorage.getItem(STORAGE_VERSION_KEY)
+  if (!storedVersion || storedVersion !== STORAGE_VERSION_CURRENT) {
+    window.localStorage.removeItem('vuex')
+    window.localStorage.removeItem('vuex-persist')
+    window.sessionStorage.removeItem('vuex')
+    window.sessionStorage.removeItem('vuex-persist')
+  }
+}
+
 interface LocalStoragePersisted {
   userModule?: UserStore
   colorModule?: ColorStore
@@ -28,6 +45,8 @@ export const persistenceLocalStorage = new VuexPersistence<Partial<RootState>>({
       repoModule: repoStoreToJson(state.repoModule)
     }
     storage!.setItem(key, JSON.stringify(persistable))
+
+    storage!.setItem(STORAGE_VERSION_KEY, STORAGE_VERSION_CURRENT)
   },
   restoreState: (key, storage) => {
     const data = storage!.getItem(key)
@@ -66,6 +85,7 @@ export const persistenceSessionStorage = new VuexPersistence<
     }
 
     storage!.setItem(key, JSON.stringify(persistable))
+    storage!.setItem(STORAGE_VERSION_KEY, STORAGE_VERSION_CURRENT)
   },
   restoreState: (key, storage) => {
     const data = storage!.getItem(key)


### PR DESCRIPTION
Data in local/session storage might persist across multiple VelCom versions - even if they alter the storage format!

Previously VelCom might crash if that happens. This patch introduces a mechanism to automatically delete old stored data if we make any incompatible changes.