### PR TITLE
Fully support dark mode in graphs

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "axios": "^0.19.1",
     "core-js": "^3.4.4",
     "d3": "^5.15.0",
-    "dygraphs": "git://github.com/I-Al-Istannen/dygraphs.git#ec2e528ad97d7ad62da65f0bf4d01de61abffbf1",
+    "dygraphs": "git://github.com/I-Al-Istannen/dygraphs.git#56a58aeabe2ecd2a6b5cfa689ed8f21c206194f4",
     "echarts": "^4.8.0",
     "vue": "^2.6.10",
     "vue-class-component": "^7.2.2",

--- a/frontend/src/components/graphs/EchartsDetailGraph.vue
+++ b/frontend/src/components/graphs/EchartsDetailGraph.vue
@@ -15,6 +15,7 @@
             ref="chart"
             :autoresize="true"
             :options="chartOptions"
+            :theme="chartTheme"
             @datazoom="echartsZoomed"
             @contextmenu="echartsOpenContextMenu"
             @click="echartsClicked"
@@ -160,13 +161,13 @@ export default class EchartsDetailGraph extends Vue {
   // <!--<editor-fold desc="ECHARTS GRAPH OPTIONS">-->
   @Watch('detailDataPoints')
   @Watch('beginYAtZero')
+  @Watch('graphFailedOrUnbenchmarkedColor') // DataPoints need adjusting, they store the color
   private updateGraph() {
     console.log('UPDATED')
 
     this.selectAppropriateSeries()
 
     this.chartOptions = {
-      backgroundColor: this.graphBackgroundColor,
       grid: {
         left: 20,
         right: 20,
@@ -465,6 +466,7 @@ export default class EchartsDetailGraph extends Vue {
       symbol: 'none',
       lineStyle: {
         type: 'dotted',
+        color: this.themeColor('error'),
         width: 2
       },
       label: {
@@ -674,16 +676,70 @@ export default class EchartsDetailGraph extends Vue {
       { maximumFractionDigits: 3 }
     )
   }
+
   private get graphBackgroundColor() {
     return this.$vuetify.theme.currentTheme.graphBackground as string
   }
+
   private dimensionColor(dimension: DimensionId) {
     return vxm.colorModule.colorByIndex(
       vxm.detailGraphModule.colorIndex(dimension)!
     )
   }
+
   private get graphFailedOrUnbenchmarkedColor() {
     return this.$vuetify.theme.currentTheme.graphFailedOrUnbenchmarked as string
+  }
+
+  private get themeColor(): (key: string) => string {
+    return key => this.$vuetify.theme.currentTheme[key] as string
+  }
+
+  private get chartTheme() {
+    const axisSettings = () => ({
+      axisLine: {
+        lineStyle: {
+          color: 'currentColor'
+        }
+      },
+      axisTick: {
+        lineStyle: {
+          color: 'currentColor'
+        }
+      },
+      axisLabel: {
+        textStyle: {
+          color: 'currentColor'
+        }
+      },
+      splitLine: {
+        lineStyle: {
+          color: this.themeColor('rowHighlight')
+        }
+      },
+      splitArea: {
+        areaStyle: {
+          color: this.themeColor('rowHighlight')
+        }
+      }
+    })
+    return {
+      backgroundColor: this.graphBackgroundColor,
+      valueAxis: axisSettings(),
+      timeAxis: axisSettings(),
+      dataZoom: {
+        textStyle: {
+          color: 'currentColor'
+        }
+      },
+      toolbox: {
+        iconStyle: {
+          normal: {
+            borderColor: 'currentColor'
+          }
+        }
+      }
+    }
   }
   // <!--</editor-fold>-->
 

--- a/frontend/src/components/graphs/NewDytailGraph.vue
+++ b/frontend/src/components/graphs/NewDytailGraph.vue
@@ -20,6 +20,7 @@ import Crosshair from 'dygraphs/src/extras/crosshair.js'
 
 type RealOptions = dygraphs.Options & {
   rangeSelectorPlotLineWidth?: number
+  rangeSelectorAlpha?: number
 }
 
 @Component({})
@@ -79,6 +80,14 @@ export default class DytailGraph extends Vue {
 
   private dimensionsColors(): string[] {
     return this.dimensions.map(this.dimensionColor)
+  }
+
+  private get selectorAlpha(): number {
+    return vxm.userModule.darkThemeSelected ? 0.2 : 0.7
+  }
+
+  private get selectorLineWidth(): number {
+    return vxm.userModule.darkThemeSelected ? 2 : 1.5
   }
 
   private get minDateValue(): number {
@@ -194,8 +203,10 @@ export default class DytailGraph extends Vue {
         vxm.detailGraphModule.zoomYStartValue,
         vxm.detailGraphModule.zoomYEndValue
       ],
-      includeZero: this.beginYAtZero
-    })
+      includeZero: this.beginYAtZero,
+      rangeSelectorPlotLineWidth: this.selectorLineWidth,
+      rangeSelectorAlpha: this.selectorAlpha
+    } as RealOptions)
   }
 
   mounted(): void {
@@ -244,10 +255,10 @@ export default class DytailGraph extends Vue {
         plugins: [new Crosshair({ direction: 'vertical' })],
         showRangeSelector: true,
         rangeSelectorHeight: 30,
-        rangeSelectorPlotLineWidth: 1,
-        rangeSelectorAlpha: 0.5,
+        rangeSelectorPlotLineWidth: this.selectorLineWidth,
+        rangeSelectorAlpha: this.selectorAlpha,
         rangeSelectorForegroundLineWidth: 0.5,
-        rangeSelectorPlotFillColor: 'lightgray',
+        rangeSelectorPlotFillColor: '',
         rangeSelectorPlotStrokeColor: 'grey',
         rangeSelectorBackgroundStrokeColor: 'currentColor',
         // and, to keep the ability to brush and zoom:

--- a/frontend/src/components/graphs/NewDytailGraph.vue
+++ b/frontend/src/components/graphs/NewDytailGraph.vue
@@ -148,9 +148,16 @@ export default class DytailGraph extends Vue {
     return 'something went wrong :(\n couldn\'t find commit'
   }
 
+  // Used in the watcher for up()
+  // noinspection JSUnusedLocalSymbols
+  private get darkTheme() {
+    return vxm.userModule.darkThemeSelected
+  }
+
   @Watch('datapoints')
   @Watch('dimensions')
   @Watch('beginYAtZero')
+  @Watch('darkTheme')
   private up() {
     const data: number[][] = []
 
@@ -204,6 +211,7 @@ export default class DytailGraph extends Vue {
       {
         axes: {
           x: {
+            axisLineColor: 'currentColor',
             axisLabelFormatter: (
               x: number | Date,
               granularity: number,
@@ -218,6 +226,9 @@ export default class DytailGraph extends Vue {
                 ? this.xAxisFormatter(new Date(x), [start, end])
                 : ''
             }
+          },
+          y: {
+            axisLineColor: 'currentColor'
           }
         },
         ylabel: this.yLabel,
@@ -229,14 +240,16 @@ export default class DytailGraph extends Vue {
         panEdgeFraction: 0.00001,
         zoomCallback: this.dygraphsZoomed,
         legendFormatter: this.tooltipFormatter,
+        crosshairColor: 'currentColor',
         plugins: [new Crosshair({ direction: 'vertical' })],
         showRangeSelector: true,
         rangeSelectorHeight: 30,
         rangeSelectorPlotLineWidth: 1,
         rangeSelectorAlpha: 0.5,
         rangeSelectorForegroundLineWidth: 0.5,
-        rangeSelectorPlotFillColor: 'lightgrey',
+        rangeSelectorPlotFillColor: 'lightgray',
         rangeSelectorPlotStrokeColor: 'grey',
+        rangeSelectorBackgroundStrokeColor: 'currentColor',
         // and, to keep the ability to brush and zoom:
         interactionModel: Dygraph.defaultInteractionModel
       } as RealOptions
@@ -326,5 +339,9 @@ export default class DytailGraph extends Vue {
 
 .dygraph-rangesel-zoomhandle {
   margin-top: 15px;
+}
+
+.dygraph-axis-label {
+  color: currentColor;
 }
 </style>

--- a/frontend/src/plugins/vuetify.ts
+++ b/frontend/src/plugins/vuetify.ts
@@ -32,7 +32,7 @@ export default new Vuetify({
         snackbarSuccess: '#3db223',
         warning: '#ff9830',
         error: '#f2495c',
-        graphBackground: '#424242',
+        graphBackground: '#2f3136',
         graphFailedOrUnbenchmarked: '#d3d3d3', // lightgray
         graphReferenceElements: '#d3d3d3', // lightgray
         rowHighlight: '#616161'

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3717,9 +3717,9 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
-"dygraphs@git://github.com/I-Al-Istannen/dygraphs.git#ec2e528ad97d7ad62da65f0bf4d01de61abffbf1":
+"dygraphs@git://github.com/I-Al-Istannen/dygraphs.git#56a58aeabe2ecd2a6b5cfa689ed8f21c206194f4":
   version "2.1.0"
-  resolved "git://github.com/I-Al-Istannen/dygraphs.git#ec2e528ad97d7ad62da65f0bf4d01de61abffbf1"
+  resolved "git://github.com/I-Al-Istannen/dygraphs.git#56a58aeabe2ecd2a6b5cfa689ed8f21c206194f4"
 
 easy-stack@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR fixes theming issues with the new detail graphs in dark mode.

### Echarts
Before
![image](https://user-images.githubusercontent.com/20284688/94989359-7c9de580-0574-11eb-841a-9509b919a0d2.png)

After
![image](https://user-images.githubusercontent.com/20284688/94989366-92130f80-0574-11eb-944a-70eb2026202a.png)

### Dygraphs
Before
![image](https://user-images.githubusercontent.com/20284688/94989387-b969dc80-0574-11eb-8aca-644d13b09ad0.png)

After-ish
![image](https://user-images.githubusercontent.com/20284688/94990091-c4733b80-0579-11eb-97da-a11d5c14b987.png)