### PR TITLE
Fix listener not adding some commits to queue

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/RepoEndpoint.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/RepoEndpoint.java
@@ -214,6 +214,12 @@ public class RepoEndpoint {
 				.map(BranchName::fromName)
 				.collect(Collectors.toSet());
 			repoAccess.setTrackedBranches(repoId, trackedBranchNames);
+
+			try {
+				listener.updateRepo(repoId);
+			} catch (CommitSearchException e) {
+				LOGGER.warn("Failed to update repo {} successfully", repoId, e);
+			}
 		});
 	}
 


### PR DESCRIPTION
This PR reverts a change that was made to fix an older issue, but created this new issue. It also fixes the other issue in a different way. A disadvantage of this new approach is that commits from untracked branches can no longer be added to the queue. This should be fixed in a future PR.

The "older issue" was that trying to add commits from a previously untracked branch to the queue immediately after tracking the branch failed because the listener had not yet added them to the known_commits table.