### PR TITLE
Stream and display stdout/stderr in Runner

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/KnownRunner.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/KnownRunner.java
@@ -21,6 +21,8 @@ public class KnownRunner {
 	@Nullable
 	private final Task currentTask;
 	@Nullable
+	final String lastOutputLines;
+	@Nullable
 	private final Instant workingSince;
 
 	/**
@@ -33,10 +35,11 @@ public class KnownRunner {
 	 * @param task the task the runner is currently working on
 	 * @param lostConnection true if the connection to the runner is lost
 	 * @param workingSince the time the runner is working on a run now
+	 * @param lastOutputLines the last output lines
 	 */
 	public KnownRunner(String name, String information, @Nullable String versionHash,
 		Status lastStatus, @Nullable Task task, boolean lostConnection,
-		@Nullable Instant workingSince) {
+		@Nullable Instant workingSince, @Nullable String lastOutputLines) {
 		this.name = Objects.requireNonNull(name, "name can not be null!");
 		this.information = Objects.requireNonNull(information, "information can not be null!");
 		this.versionHash = versionHash;
@@ -44,6 +47,7 @@ public class KnownRunner {
 		this.currentTask = task;
 		this.lostConnection = lostConnection;
 		this.workingSince = workingSince;
+		this.lastOutputLines = lastOutputLines;
 	}
 
 	public String getName() {
@@ -71,6 +75,13 @@ public class KnownRunner {
 
 	public boolean hasLostConnection() {
 		return lostConnection;
+	}
+
+	/**
+	 * @return the last output lines
+	 */
+	public Optional<String> getLastOutputLines() {
+		return Optional.ofNullable(lastOutputLines);
 	}
 
 	/**

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/KnownRunner.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/KnownRunner.java
@@ -2,6 +2,7 @@ package de.aaaaaaah.velcom.backend.runner;
 
 import de.aaaaaaah.velcom.backend.access.entities.Task;
 import de.aaaaaaah.velcom.shared.protocol.serialization.Status;
+import de.aaaaaaah.velcom.shared.util.LinesWithOffset;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
@@ -21,7 +22,7 @@ public class KnownRunner {
 	@Nullable
 	private final Task currentTask;
 	@Nullable
-	final String lastOutputLines;
+	final LinesWithOffset lastOutputLines;
 	@Nullable
 	private final Instant workingSince;
 
@@ -39,7 +40,7 @@ public class KnownRunner {
 	 */
 	public KnownRunner(String name, String information, @Nullable String versionHash,
 		Status lastStatus, @Nullable Task task, boolean lostConnection,
-		@Nullable Instant workingSince, @Nullable String lastOutputLines) {
+		@Nullable Instant workingSince, @Nullable LinesWithOffset lastOutputLines) {
 		this.name = Objects.requireNonNull(name, "name can not be null!");
 		this.information = Objects.requireNonNull(information, "information can not be null!");
 		this.versionHash = versionHash;
@@ -80,7 +81,7 @@ public class KnownRunner {
 	/**
 	 * @return the last output lines
 	 */
-	public Optional<String> getLastOutputLines() {
+	public Optional<LinesWithOffset> getLastOutputLines() {
 		return Optional.ofNullable(lastOutputLines);
 	}
 

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/single/TeleRunner.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/single/TeleRunner.java
@@ -165,7 +165,8 @@ public class TeleRunner {
 			reply.getStatus(),
 			myCurrentTask.get(),
 			!hasConnection(),
-			workingSince.get()
+			workingSince.get(),
+			reply.getLastOutputLines().orElse(null)
 		);
 	}
 

--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/TeleBackend.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/TeleBackend.java
@@ -288,6 +288,10 @@ public class TeleBackend {
 		return getBenchmarker().map(Benchmarker::getTaskId);
 	}
 
+	public Optional<String> getLastOutputLines() {
+		return getBenchmarker().map(Benchmarker::getLastOutputLines);
+	}
+
 	private Optional<Benchmarker> getBenchmarker() {
 		synchronized (benchmarkerLock) {
 			return Optional.ofNullable(benchmarker);

--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/TeleBackend.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/TeleBackend.java
@@ -11,6 +11,7 @@ import de.aaaaaaah.velcom.shared.protocol.serialization.Status;
 import de.aaaaaaah.velcom.shared.protocol.serialization.clientbound.RequestRunReply;
 import de.aaaaaaah.velcom.shared.protocol.serialization.serverbound.RequestRun;
 import de.aaaaaaah.velcom.shared.util.FileHelper;
+import de.aaaaaaah.velcom.shared.util.LinesWithOffset;
 import de.aaaaaaah.velcom.shared.util.compression.TarHelper;
 import de.aaaaaaah.velcom.shared.util.systeminfo.LinuxSystemInfo;
 import java.io.IOException;
@@ -288,7 +289,7 @@ public class TeleBackend {
 		return getBenchmarker().map(Benchmarker::getTaskId);
 	}
 
-	public Optional<String> getLastOutputLines() {
+	public Optional<LinesWithOffset> getLastOutputLines() {
 		return getBenchmarker().map(Benchmarker::getLastOutputLines);
 	}
 

--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/benchmarking/Benchmarker.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/benchmarking/Benchmarker.java
@@ -177,7 +177,11 @@ public class Benchmarker {
 			List<String> lines = stdErr.lines().collect(Collectors.toList());
 			Collections.reverse(lines);
 
-			return lines.stream().limit(100).collect(Collectors.joining("\n"));
+			List<String> sublist = lines.subList(Math.max(lines.size() - 100, 0), lines.size());
+
+			Collections.reverse(sublist);
+
+			return String.join("\n", sublist);
 		});
 
 		try {

--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/benchmarking/Benchmarker.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/benchmarking/Benchmarker.java
@@ -18,7 +18,6 @@ import de.aaaaaaah.velcom.shared.util.systeminfo.LinuxSystemInfo;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -177,7 +176,8 @@ public class Benchmarker {
 			String stdErr = work.getCurrentStdErr();
 			List<String> lines = stdErr.lines().collect(Collectors.toList());
 
-			List<String> sublist = lines.subList(Math.max(lines.size() - 100, 0), lines.size());
+			int maxLinesToReturn = 100;
+			List<String> sublist = lines.subList(Math.max(lines.size() - maxLinesToReturn, 0), lines.size());
 
 			int indexFirstLine = lines.size() - sublist.size();
 

--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/benchmarking/Benchmarker.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/benchmarking/Benchmarker.java
@@ -10,6 +10,7 @@ import de.aaaaaaah.velcom.shared.protocol.serialization.Result;
 import de.aaaaaaah.velcom.shared.protocol.serialization.Result.Benchmark;
 import de.aaaaaaah.velcom.shared.util.Either;
 import de.aaaaaaah.velcom.shared.util.ExceptionHelper;
+import de.aaaaaaah.velcom.shared.util.LinesWithOffset;
 import de.aaaaaaah.velcom.shared.util.execution.ProgramExecutor;
 import de.aaaaaaah.velcom.shared.util.execution.ProgramResult;
 import de.aaaaaaah.velcom.shared.util.execution.StreamsProcessOutput;
@@ -37,7 +38,7 @@ import javax.annotation.Nullable;
 public class Benchmarker {
 
 	private final AtomicReference<BenchResult> result; // nullable inside the reference
-	private final AtomicReference<Supplier<String>> outputFetcher;
+	private final AtomicReference<Supplier<LinesWithOffset>> outputFetcher;
 
 	private final CompletableFuture<Void> finishFuture;
 
@@ -102,10 +103,10 @@ public class Benchmarker {
 	/**
 	 * @return the last few lines of the output (stderr) or an empty String if none yet
 	 */
-	public String getLastOutputLines() {
-		Supplier<String> supplier = outputFetcher.get();
+	public LinesWithOffset getLastOutputLines() {
+		Supplier<LinesWithOffset> supplier = outputFetcher.get();
 		if (supplier == null) {
-			return "";
+			return new LinesWithOffset(0, List.of());
 		}
 		return supplier.get();
 	}
@@ -180,8 +181,9 @@ public class Benchmarker {
 			List<String> sublist = lines.subList(Math.max(lines.size() - 100, 0), lines.size());
 
 			Collections.reverse(sublist);
+			int indexFirstLine = lines.size() - sublist.size();
 
-			return String.join("\n", sublist);
+			return new LinesWithOffset(indexFirstLine, sublist);
 		});
 
 		try {

--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/benchmarking/Benchmarker.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/benchmarking/Benchmarker.java
@@ -37,7 +37,7 @@ import javax.annotation.Nullable;
 public class Benchmarker {
 
 	private final AtomicReference<BenchResult> result; // nullable inside the reference
-	private final AtomicReference<Supplier<LinesWithOffset>> outputFetcher;
+	private final AtomicReference<Supplier<LinesWithOffset>> outputFetcher; // nullable inside the reference
 
 	private final CompletableFuture<Void> finishFuture;
 

--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/benchmarking/Benchmarker.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/benchmarking/Benchmarker.java
@@ -176,11 +176,9 @@ public class Benchmarker {
 		outputFetcher.set(() -> {
 			String stdErr = work.getCurrentStdErr();
 			List<String> lines = stdErr.lines().collect(Collectors.toList());
-			Collections.reverse(lines);
 
 			List<String> sublist = lines.subList(Math.max(lines.size() - 100, 0), lines.size());
 
-			Collections.reverse(sublist);
 			int indexFirstLine = lines.size() - sublist.size();
 
 			return new LinesWithOffset(indexFirstLine, sublist);

--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/states/RunnerState.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/states/RunnerState.java
@@ -97,7 +97,8 @@ public abstract class RunnerState implements State {
 			teleBackend.getBenchHash().orElse(null),
 			teleBackend.getBenchResult().isPresent(),
 			teleBackend.getStatus(),
-			teleBackend.getCurrentRunId().orElse(null)
+			teleBackend.getCurrentRunId().orElse(null),
+			teleBackend.getLastOutputLines().orElse(null)
 		);
 		LOGGER.debug("Replying with {}", getStatusReply);
 		connection.sendPacket(getStatusReply.asPacket(connection.getSerializer()));

--- a/backend/shared/src/main/java/de/aaaaaaah/velcom/shared/protocol/serialization/serverbound/GetStatusReply.java
+++ b/backend/shared/src/main/java/de/aaaaaaah/velcom/shared/protocol/serialization/serverbound/GetStatusReply.java
@@ -25,6 +25,8 @@ public class GetStatusReply implements ServerBound {
 	private final Status status;
 	@Nullable
 	private final UUID runId;
+	@Nullable
+	private final String lastOutputLines;
 
 	@JsonCreator
 	public GetStatusReply(
@@ -33,7 +35,8 @@ public class GetStatusReply implements ServerBound {
 		@Nullable String benchHash,
 		@JsonProperty(required = true) boolean resultAvailable,
 		@JsonProperty(required = true) Status status,
-		@Nullable UUID runId
+		@Nullable UUID runId,
+		@Nullable String lastOutputLines
 	) {
 		this.info = info;
 		this.versionHash = versionHash;
@@ -41,6 +44,7 @@ public class GetStatusReply implements ServerBound {
 		this.resultAvailable = resultAvailable;
 		this.status = status;
 		this.runId = runId;
+		this.lastOutputLines = lastOutputLines;
 	}
 
 	public String getInfo() {
@@ -65,6 +69,10 @@ public class GetStatusReply implements ServerBound {
 
 	public Optional<UUID> getRunId() {
 		return Optional.ofNullable(runId);
+	}
+
+	public Optional<String> getLastOutputLines() {
+		return Optional.ofNullable(lastOutputLines);
 	}
 
 	@Override

--- a/backend/shared/src/main/java/de/aaaaaaah/velcom/shared/protocol/serialization/serverbound/GetStatusReply.java
+++ b/backend/shared/src/main/java/de/aaaaaaah/velcom/shared/protocol/serialization/serverbound/GetStatusReply.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import de.aaaaaaah.velcom.shared.protocol.serialization.Serializer;
 import de.aaaaaaah.velcom.shared.protocol.serialization.Status;
+import de.aaaaaaah.velcom.shared.util.LinesWithOffset;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -26,7 +27,7 @@ public class GetStatusReply implements ServerBound {
 	@Nullable
 	private final UUID runId;
 	@Nullable
-	private final String lastOutputLines;
+	private final LinesWithOffset lastOutputLines;
 
 	@JsonCreator
 	public GetStatusReply(
@@ -36,7 +37,7 @@ public class GetStatusReply implements ServerBound {
 		@JsonProperty(required = true) boolean resultAvailable,
 		@JsonProperty(required = true) Status status,
 		@Nullable UUID runId,
-		@Nullable String lastOutputLines
+		@Nullable LinesWithOffset lastOutputLines
 	) {
 		this.info = info;
 		this.versionHash = versionHash;
@@ -71,7 +72,7 @@ public class GetStatusReply implements ServerBound {
 		return Optional.ofNullable(runId);
 	}
 
-	public Optional<String> getLastOutputLines() {
+	public Optional<LinesWithOffset> getLastOutputLines() {
 		return Optional.ofNullable(lastOutputLines);
 	}
 

--- a/backend/shared/src/main/java/de/aaaaaaah/velcom/shared/util/LinesWithOffset.java
+++ b/backend/shared/src/main/java/de/aaaaaaah/velcom/shared/util/LinesWithOffset.java
@@ -13,7 +13,7 @@ public class LinesWithOffset {
 
 	/**
 	 * If there are three lines and the last two are included in this object, the firstLineOffset will
-	 * be 1 (totalLength - includedLength).
+	 * be one (totalLength - includedLength).
 	 *
 	 * @param firstLineOffset the offset of the first line. 0 based.
 	 * @param lines the lines

--- a/backend/shared/src/main/java/de/aaaaaaah/velcom/shared/util/LinesWithOffset.java
+++ b/backend/shared/src/main/java/de/aaaaaaah/velcom/shared/util/LinesWithOffset.java
@@ -1,0 +1,33 @@
+package de.aaaaaaah.velcom.shared.util;
+
+import java.util.List;
+
+/**
+ * A collection of lines including the offset of the first one. This is useful when you are only
+ * working with an excerpt but want to preserve absolute line numbers.
+ */
+public class LinesWithOffset {
+
+	private final int firstLineOffset;
+	private final List<String> lines;
+
+	/**
+	 * If there are three lines and the last two are included in this object, the firstLineOffset will
+	 * be 1 (totalLength - includedLength).
+	 *
+	 * @param firstLineOffset the offset of the first line. 0 based.
+	 * @param lines the lines
+	 */
+	public LinesWithOffset(int firstLineOffset, List<String> lines) {
+		this.firstLineOffset = firstLineOffset;
+		this.lines = lines;
+	}
+
+	public int getFirstLineOffset() {
+		return firstLineOffset;
+	}
+
+	public List<String> getLines() {
+		return lines;
+	}
+}

--- a/backend/shared/src/main/java/de/aaaaaaah/velcom/shared/util/StringOutputStream.java
+++ b/backend/shared/src/main/java/de/aaaaaaah/velcom/shared/util/StringOutputStream.java
@@ -6,28 +6,28 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
 /**
- * An {@link OutputStream} that writes to a String.
+ * A synchronized {@link OutputStream} that writes to a String.
  */
 public class StringOutputStream extends OutputStream {
 
-	private ByteArrayOutputStream byteArrayOutputStream;
+	private final ByteArrayOutputStream byteArrayOutputStream;
 
 	public StringOutputStream() {
 		this.byteArrayOutputStream = new ByteArrayOutputStream();
 	}
 
 	@Override
-	public void write(int b) {
+	public synchronized void write(int b) {
 		byteArrayOutputStream.write(b);
 	}
 
 	@Override
-	public void write(byte[] b) throws IOException {
+	public synchronized void write(byte[] b) throws IOException {
 		byteArrayOutputStream.write(b);
 	}
 
 	@Override
-	public void write(byte[] b, int off, int len) {
+	public synchronized void write(byte[] b, int off, int len) {
 		byteArrayOutputStream.write(b, off, len);
 	}
 
@@ -36,7 +36,7 @@ public class StringOutputStream extends OutputStream {
 	 *
 	 * @return the underlying string
 	 */
-	public String getString() {
+	public synchronized String getString() {
 		return new String(byteArrayOutputStream.toByteArray(), StandardCharsets.UTF_8);
 	}
 }

--- a/backend/shared/src/main/java/de/aaaaaaah/velcom/shared/util/execution/StreamsProcessOutput.java
+++ b/backend/shared/src/main/java/de/aaaaaaah/velcom/shared/util/execution/StreamsProcessOutput.java
@@ -1,0 +1,20 @@
+package de.aaaaaaah.velcom.shared.util.execution;
+
+import java.util.concurrent.Future;
+
+/**
+ * A future that also provides snapshots of the current standard out and standard error of the
+ * process it waits on.
+ */
+public interface StreamsProcessOutput<T> extends Future<T> {
+
+	/**
+	 * @return a snapshot of the current standard output of the process
+	 */
+	String getCurrentStdOut();
+
+	/**
+	 * @return a snapshot of the current standard error
+	 */
+	String getCurrentStdErr();
+}

--- a/backend/shared/src/main/java/de/aaaaaaah/velcom/shared/util/execution/WaitingFutureTask.java
+++ b/backend/shared/src/main/java/de/aaaaaaah/velcom/shared/util/execution/WaitingFutureTask.java
@@ -1,5 +1,6 @@
 package de.aaaaaaah.velcom.shared.util.execution;
 
+import de.aaaaaaah.velcom.shared.util.StringOutputStream;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -12,13 +13,18 @@ import java.util.concurrent.TimeoutException;
  *
  * @param <T> the type of the task
  */
-class WaitingFutureTask<T> implements Future<T> {
+class WaitingFutureTask<T> implements Future<T>, StreamsProcessOutput<T> {
 
 	private final Thread worker;
 	private final FutureTask<T> underlying;
+	private final StringOutputStream stdErr;
+	private final StringOutputStream stdOut;
 
-	public WaitingFutureTask(FutureTask<T> task) {
+	public WaitingFutureTask(FutureTask<T> task, StringOutputStream stdOut,
+		StringOutputStream stdErr) {
 		this.underlying = task;
+		this.stdOut = stdOut;
+		this.stdErr = stdErr;
 		this.worker = new Thread(underlying, "MyFutureTask worker");
 		this.worker.start();
 	}
@@ -54,5 +60,15 @@ class WaitingFutureTask<T> implements Future<T> {
 			throw new CancellationException("Execution cancelled, thread died");
 		}
 		return underlying.get(timeout, unit);
+	}
+
+	@Override
+	public String getCurrentStdOut() {
+		return stdOut.getString();
+	}
+
+	@Override
+	public String getCurrentStdErr() {
+		return stdErr.getString();
 	}
 }

--- a/backend/shared/src/test/java/de/aaaaaaah/velcom/shared/protocol/serialization/serverbound/GetStatusReplyTest.java
+++ b/backend/shared/src/test/java/de/aaaaaaah/velcom/shared/protocol/serialization/serverbound/GetStatusReplyTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.aaaaaaah.velcom.shared.protocol.serialization.SerializerBasedTest;
 import de.aaaaaaah.velcom.shared.protocol.serialization.Status;
+import de.aaaaaaah.velcom.shared.util.LinesWithOffset;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -32,7 +34,18 @@ class GetStatusReplyTest extends SerializerBasedTest {
 
 	@Test
 	void deserializeWithAllOptionals() {
-		String json = "{\"info\": \"system info goes here\", \"version_hash\": \"bloop\", \"bench_hash\": \"blabla\", \"result_available\": false, \"status\": \"ABORT\", \"run_id\": \"576afdcb-eaf9-46b2-9287-fc3bf8df83df\", \"last_output_lines\": \"this is a line\\nWith a newline\"}";
+		String json = "{"
+			+ "\"info\": \"system info goes here\","
+			+ " \"version_hash\": \"bloop\","
+			+ " \"bench_hash\": \"blabla\","
+			+ " \"result_available\": false,"
+			+ " \"status\": \"ABORT\","
+			+ " \"run_id\": \"576afdcb-eaf9-46b2-9287-fc3bf8df83df\","
+			+ " \"last_output_lines\": {"
+			+ "   \"first_line_offset\": 20,"
+			+ "   \"lines\": [\"this is a line\",\"With a newline\"]"
+			+ " }"
+			+ "}";
 		Optional<GetStatusReply> result = serializer.deserialize(json, GetStatusReply.class);
 
 		UUID uuid = UUID.fromString("576afdcb-eaf9-46b2-9287-fc3bf8df83df");
@@ -45,7 +58,7 @@ class GetStatusReplyTest extends SerializerBasedTest {
 				false,
 				Status.ABORT,
 				uuid,
-				"this is a line\nWith a newline"
+				new LinesWithOffset(20, List.of("this is a line", "With a newline"))
 			),
 			result.get()
 		);

--- a/backend/shared/src/test/java/de/aaaaaaah/velcom/shared/protocol/serialization/serverbound/GetStatusReplyTest.java
+++ b/backend/shared/src/test/java/de/aaaaaaah/velcom/shared/protocol/serialization/serverbound/GetStatusReplyTest.java
@@ -23,6 +23,7 @@ class GetStatusReplyTest extends SerializerBasedTest {
 				null,
 				false,
 				Status.IDLE,
+				null,
 				null
 			),
 			result.get()
@@ -31,13 +32,21 @@ class GetStatusReplyTest extends SerializerBasedTest {
 
 	@Test
 	void deserializeWithAllOptionals() {
-		String json = "{\"info\": \"system info goes here\", \"version_hash\": \"bloop\", \"bench_hash\": \"blabla\", \"result_available\": false, \"status\": \"ABORT\", \"run_id\": \"576afdcb-eaf9-46b2-9287-fc3bf8df83df\"}";
+		String json = "{\"info\": \"system info goes here\", \"version_hash\": \"bloop\", \"bench_hash\": \"blabla\", \"result_available\": false, \"status\": \"ABORT\", \"run_id\": \"576afdcb-eaf9-46b2-9287-fc3bf8df83df\", \"last_output_lines\": \"this is a line\\nWith a newline\"}";
 		Optional<GetStatusReply> result = serializer.deserialize(json, GetStatusReply.class);
 
 		UUID uuid = UUID.fromString("576afdcb-eaf9-46b2-9287-fc3bf8df83df");
 		assertTrue(result.isPresent());
 		assertEquals(
-			new GetStatusReply("system info goes here", "bloop", "blabla", false, Status.ABORT, uuid),
+			new GetStatusReply(
+				"system info goes here",
+				"bloop",
+				"blabla",
+				false,
+				Status.ABORT,
+				uuid,
+				"this is a line\nWith a newline"
+			),
 			result.get()
 		);
 	}

--- a/bench
+++ b/bench
@@ -72,16 +72,16 @@ def build_makefile():
 
     guarded_try_metric(
         "backend",
-        "coverage",
-        lambda: get_coverage(),
-        "percent",
-        "MORE_IS_BETTER"
+        "build_time",
+        lambda: execute_program(["make", "-C", str(target_path()), "backend"])
     )
 
     guarded_try_metric(
         "backend",
-        "build_time",
-        lambda: execute_program(["make", "-C", str(target_path()), "backend"])
+        "coverage",
+        lambda: get_coverage(),
+        "percent",
+        "MORE_IS_BETTER"
     )
 
     guarded_try_metric(

--- a/bench
+++ b/bench
@@ -14,8 +14,8 @@ program_result = {}
 def execute_program(args: List[str]) -> float:
     """ Executes a given program and returns build time. """
     start = time.time()
-    subprocess.run(args, stdout=subprocess.PIPE,
-                   stderr=subprocess.PIPE, check=True)
+    subprocess.run(args, stdout=sys.stderr,
+                   stderr=sys.stderr, check=True)
     end = time.time()
     return end - start
 
@@ -72,16 +72,16 @@ def build_makefile():
 
     guarded_try_metric(
         "backend",
-        "build_time",
-        lambda: execute_program(["make", "-C", str(target_path()), "backend"])
-    )
-
-    guarded_try_metric(
-        "backend",
         "coverage",
         lambda: get_coverage(),
         "percent",
         "MORE_IS_BETTER"
+    )
+
+    guarded_try_metric(
+        "backend",
+        "build_time",
+        lambda: execute_program(["make", "-C", str(target_path()), "backend"])
     )
 
     guarded_try_metric(

--- a/docs/public-api/public-api.v2.yaml
+++ b/docs/public-api/public-api.v2.yaml
@@ -744,6 +744,39 @@ paths:
 
         The `start_time`, `end_time` and `duration` parameters work the same as for the `/graph/detail/{repoid}` endpoint.
         If some of the repos don't exist, they may be omitted from the response.
+  '/queue/task/{taskId}/progress':
+    parameters:
+      - schema:
+          type: string
+        name: taskId
+        in: path
+        required: true
+    get:
+      summary: task runner output
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  index_of_first_line:
+                    type: number
+                    description: 'The absolute index of the first line. If the benchmark script already printed 3 lines, but only the last two are returned, the index of the first line would be 1. The absolute index of any returned line is therefore <relative index> + <index_of_first_line>'
+                  output:
+                    type: array
+                    description: 'The stderr output of the benchmark script, split at the line separator.'
+                    items:
+                      type: string
+                required:
+                  - index_of_first_line
+                  - output
+        '404':
+          description: If the given task is not in the queue or not currently worked on by a runner.
+      operationId: get-queue-task-taskId-progress
+      description: Returns the last 100 lines the benchmark script working on the given task reported on its standard error stream.
 components:
   schemas:
     CommitHash:

--- a/frontend/src/components/TaskRunnerOutput.vue
+++ b/frontend/src/components/TaskRunnerOutput.vue
@@ -1,7 +1,9 @@
 <template>
   <v-card>
     <v-card-title>
-      <v-toolbar dark color="primary">Runner output (StdErr)</v-toolbar>
+      <v-toolbar dark color="primary">
+        Runner output (standard error stream)
+      </v-toolbar>
     </v-card-title>
     <v-card-text>
       <v-alert
@@ -19,7 +21,7 @@
         </span>
       </v-alert>
       <div class="runner-output mx-2">
-        <span
+        <div
           v-for="{ lineNumber, text, classes } in lines"
           :key="lineNumber"
           class="line"
@@ -31,7 +33,7 @@
             >{{ lineNumber }}</span
           >
           {{ text }}
-        </span>
+        </div>
       </div>
       <v-row align="center" justify="center">
         <v-col cols="3">

--- a/frontend/src/components/TaskRunnerOutput.vue
+++ b/frontend/src/components/TaskRunnerOutput.vue
@@ -10,7 +10,7 @@
       </v-alert>
       <div class="runner-output mx-2">
         <span
-          v-for="({ lineNumber, text, classes }) in lines"
+          v-for="{ lineNumber, text, classes } in lines"
           :key="lineNumber"
           class="line"
           :class="classes"

--- a/frontend/src/components/TaskRunnerOutput.vue
+++ b/frontend/src/components/TaskRunnerOutput.vue
@@ -17,7 +17,7 @@
         >
           <span
             class="mr-2 font-weight-bold align-end text-right d-inline-block"
-            style="width: 3ch; user-select: none"
+            style="min-width: 4ch; user-select: none"
             >{{ lineNumber }}</span
           >
           {{ text }}
@@ -40,7 +40,7 @@
 import Vue from 'vue'
 import Component from 'vue-class-component'
 import { Prop, Watch } from 'vue-property-decorator'
-import { TaskId } from '@/store/types'
+import { StreamedRunnerOutput, TaskId } from '@/store/types'
 import { vxm } from '@/store'
 
 @Component
@@ -49,7 +49,7 @@ export default class TaskRunnerOutput extends Vue {
   private taskId!: TaskId
 
   private timer: number | null = null
-  private output: string | null = null
+  private output: StreamedRunnerOutput | null = null
   private loadingError: boolean = false
 
   @Watch('taskId')
@@ -69,11 +69,12 @@ export default class TaskRunnerOutput extends Vue {
     text: string
     classes: string[]
   }[] {
-    if (!this.output) {
+    const output = this.output
+    if (!output) {
       return []
     }
-    return this.output.split('\n').map((line, index) => ({
-      lineNumber: index,
+    return output.outputLines.map((line, index) => ({
+      lineNumber: index + output.indexOfFirstLine + 1,
       text: line,
       classes: [
         line.toLowerCase().includes('warning') ? 'text--warning' : '',

--- a/frontend/src/components/TaskRunnerOutput.vue
+++ b/frontend/src/components/TaskRunnerOutput.vue
@@ -146,9 +146,6 @@ export default class TaskRunnerOutput extends Vue {
   max-height: 90vh;
   overflow-y: scroll;
 }
-.runner-output .line {
-  display: block;
-}
 .theme--light .runner-output .line:hover {
   background-color: var(--v-rowHighlight-lighten1) !important;
 }

--- a/frontend/src/components/TaskRunnerOutput.vue
+++ b/frontend/src/components/TaskRunnerOutput.vue
@@ -87,6 +87,14 @@ export default class TaskRunnerOutput extends Vue {
         it => it.id === this.taskId
       )
       this.$emit('loading-failed')
+      return
+    }
+
+    const element = this.$el.getElementsByClassName('runner-output')[0]
+    if (element.scrollHeight - element.scrollTop === element.clientHeight) {
+      Vue.nextTick(() => {
+        element.scrollTop = element.scrollHeight
+      })
     }
   }
 

--- a/frontend/src/components/TaskRunnerOutput.vue
+++ b/frontend/src/components/TaskRunnerOutput.vue
@@ -1,0 +1,60 @@
+<template>
+  <v-card>
+    <v-card-title>
+      <v-toolbar dark color="primary">Runner output (StdErr)</v-toolbar>
+    </v-card-title>
+    <v-card-text>
+      <div class="runner-output" v-if="output">
+        {{ output }}
+      </div>
+      <div v-else>Nothing there (yet)?</div>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import Component from 'vue-class-component'
+import { Prop, Watch } from 'vue-property-decorator'
+import { TaskId } from '@/store/types'
+import { vxm } from '@/store'
+
+@Component
+export default class TaskRunnerOutput extends Vue {
+  @Prop()
+  private taskId!: TaskId
+
+  private timer: number | null = null
+  private output: string | null = null
+
+  @Watch('taskId')
+  private async update() {
+    this.output = await vxm.queueModule.fetchRunnerOutput(this.taskId)
+  }
+
+  private mounted() {
+    this.update()
+    this.timer = setInterval(
+      () => {
+        this.taskId = vxm.queueModule.workers[0].workingOn!
+        this.update()
+      },
+      1000,
+      1000
+    )
+  }
+
+  private destroyed() {
+    if (this.timer !== null) {
+      clearInterval(this.timer)
+    }
+  }
+}
+</script>
+
+<style scoped>
+.runner-output {
+  font-family: monospace;
+  white-space: pre-line;
+}
+</style>

--- a/frontend/src/components/TaskRunnerOutput.vue
+++ b/frontend/src/components/TaskRunnerOutput.vue
@@ -9,7 +9,7 @@
         class="mx-4"
         v-if="loadingError"
       >
-        No output received in my last request.
+        No output received in the last request.
         <span v-if="!taskInProgress && taskInQueue">
           It looks like the task is not scheduled on a runner right now?
         </span>

--- a/frontend/src/components/overviews/QueueOverview.vue
+++ b/frontend/src/components/overviews/QueueOverview.vue
@@ -41,6 +41,7 @@
               :commit="task.source.commitDescription"
               :source="task.source"
               :id="task.id"
+              :linkLocation="taskLinkLocation(task)"
             >
               <template #body_top>
                 <v-progress-linear
@@ -109,6 +110,7 @@ import CommitOverviewBase from './CommitOverviewBase.vue'
 import { extractErrorMessage } from '@/util/ErrorUtils'
 import TarTaskOverview from './TarTaskOverview.vue'
 import { formatDurationHuman } from '@/util/TimeUtil'
+import { RawLocation } from 'vue-router'
 
 @Component({
   components: {
@@ -135,6 +137,13 @@ export default class QueueOverview extends Vue {
 
   private get isAdmin() {
     return vxm.userModule.isAdmin
+  }
+
+  private taskLinkLocation(task: Task): RawLocation {
+    return {
+      name: 'task-detail',
+      params: { taskId: task.id }
+    }
   }
 
   private liftToFront(task: Task, event: Event) {

--- a/frontend/src/components/rundetail/RunDetail.vue
+++ b/frontend/src/components/rundetail/RunDetail.vue
@@ -10,8 +10,8 @@
         </v-card>
       </v-col>
     </v-row>
-    <v-row no-gutters>
-      <v-col v-if="measurements !== undefined">
+    <v-row no-gutters v-if="measurements !== undefined">
+      <v-col>
         <v-card>
           <v-card-title>
             <v-toolbar dark color="primary">Run Result</v-toolbar>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -16,6 +16,7 @@ import {
   mdiCircleSlice6
 } from '@mdi/js'
 import { vxm } from '@/store'
+import TaskDetailView from '@/views/TaskDetailView.vue'
 
 Vue.use(VueRouter)
 
@@ -27,6 +28,7 @@ export type RouteName =
   | 'queue'
   | 'run-comparison'
   | 'run-detail'
+  | 'task-detail'
   | 'about'
   | '404'
 
@@ -113,6 +115,15 @@ const routes: RouteInfo[] = [
     meta: {
       navigable: false,
       label: 'Detail'
+    }
+  },
+  {
+    path: '/task-detail/:taskId',
+    name: 'task-detail',
+    component: TaskDetailView,
+    meta: {
+      navigable: false,
+      label: 'Task-Detail'
     }
   },
   {

--- a/frontend/src/store/modules/queueStore.ts
+++ b/frontend/src/store/modules/queueStore.ts
@@ -109,6 +109,23 @@ export class QueueStore extends VxModule {
   }
 
   /**
+   * Fetches the runner output for a given task. Returns null if the task is not
+   * currently being executed.
+   *
+   * @param taskId the id of the task
+   */
+  @action
+  async fetchRunnerOutput(taskId: string): Promise<string | null> {
+    const response = await axios.get(`/queue/task/${taskId}/progress`)
+
+    if (response.status === 404) {
+      return null
+    }
+
+    return response.data.output
+  }
+
+  /**
    * Sets all open tasks.
    *
    * @param {Task[]} payload the tasks

--- a/frontend/src/store/modules/queueStore.ts
+++ b/frontend/src/store/modules/queueStore.ts
@@ -123,7 +123,14 @@ export class QueueStore extends VxModule {
   async fetchRunnerOutput(
     taskId: string
   ): Promise<StreamedRunnerOutput | null> {
-    const response = await axios.get(`/queue/task/${taskId}/progress`)
+    let response
+    try {
+      response = await axios.get(`/queue/task/${taskId}/progress`, {
+        hideFromSnackbar: true
+      })
+    } catch (e) {
+      return null
+    }
 
     if (response.status === 404) {
       return null

--- a/frontend/src/store/modules/queueStore.ts
+++ b/frontend/src/store/modules/queueStore.ts
@@ -5,10 +5,15 @@ import {
   RepoId,
   CommitHash,
   TaskId,
-  CommitDescription
+  CommitDescription,
+  StreamedRunnerOutput
 } from '@/store/types'
 import axios from 'axios'
-import { taskFromJson, workerFromJson } from '@/util/QueueJsonHelper'
+import {
+  streamedRunnerOutputFromJson,
+  taskFromJson,
+  workerFromJson
+} from '@/util/QueueJsonHelper'
 
 const VxModule = createModule({
   namespaced: 'queueModule',
@@ -115,14 +120,16 @@ export class QueueStore extends VxModule {
    * @param taskId the id of the task
    */
   @action
-  async fetchRunnerOutput(taskId: string): Promise<string | null> {
+  async fetchRunnerOutput(
+    taskId: string
+  ): Promise<StreamedRunnerOutput | null> {
     const response = await axios.get(`/queue/task/${taskId}/progress`)
 
     if (response.status === 404) {
       return null
     }
 
-    return response.data.output
+    return streamedRunnerOutputFromJson(response.data)
   }
 
   /**

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -486,3 +486,16 @@ export class ComparisonDataPoint {
     this.repoId = repoId
   }
 }
+
+export class StreamedRunnerOutput {
+  readonly outputLines: string[]
+  /**
+   * The line number of the first line. Starts with 0.
+   */
+  readonly indexOfFirstLine: number
+
+  constructor(outputLines: string[], lineOffset: number) {
+    this.outputLines = outputLines
+    this.indexOfFirstLine = lineOffset
+  }
+}

--- a/frontend/src/util/QueueJsonHelper.ts
+++ b/frontend/src/util/QueueJsonHelper.ts
@@ -48,7 +48,7 @@ export function commitDescriptionFromJson(json: any): CommitDescription {
 
 export function streamedRunnerOutputFromJson(json: any): StreamedRunnerOutput {
   return new StreamedRunnerOutput(
-    json.output.split('\n'),
+    json.output,
     json.index_of_first_line
   )
 }

--- a/frontend/src/util/QueueJsonHelper.ts
+++ b/frontend/src/util/QueueJsonHelper.ts
@@ -47,8 +47,5 @@ export function commitDescriptionFromJson(json: any): CommitDescription {
 }
 
 export function streamedRunnerOutputFromJson(json: any): StreamedRunnerOutput {
-  return new StreamedRunnerOutput(
-    json.output,
-    json.index_of_first_line
-  )
+  return new StreamedRunnerOutput(json.output, json.index_of_first_line)
 }

--- a/frontend/src/util/QueueJsonHelper.ts
+++ b/frontend/src/util/QueueJsonHelper.ts
@@ -5,7 +5,8 @@ import {
   TarTaskSource,
   CommitTaskSource,
   CommitDescription,
-  Worker
+  Worker,
+  StreamedRunnerOutput
 } from '@/store/types'
 
 export function workerFromJson(json: any): Worker {
@@ -42,5 +43,12 @@ export function commitDescriptionFromJson(json: any): CommitDescription {
     json.author,
     new Date(json.author_date * 1000),
     json.summary
+  )
+}
+
+export function streamedRunnerOutputFromJson(json: any): StreamedRunnerOutput {
+  return new StreamedRunnerOutput(
+    json.output.split('\n'),
+    json.index_of_first_line
   )
 }

--- a/frontend/src/views/Queue.vue
+++ b/frontend/src/views/Queue.vue
@@ -20,7 +20,9 @@
         </v-col>
       </v-row>
       <v-row>
-        <task-runner-output :task-id="someTask"></task-runner-output>
+        <v-col>
+          <task-runner-output :task-id="someTask"></task-runner-output>
+        </v-col>
       </v-row>
       <v-row align="baseline" justify="center">
         <v-col>

--- a/frontend/src/views/Queue.vue
+++ b/frontend/src/views/Queue.vue
@@ -19,11 +19,6 @@
           </v-card>
         </v-col>
       </v-row>
-      <v-row>
-        <v-col>
-          <task-runner-output :task-id="someTask"></task-runner-output>
-        </v-col>
-      </v-row>
       <v-row align="baseline" justify="center">
         <v-col>
           <v-card>
@@ -53,11 +48,9 @@ import WorkerOverview from '../components/overviews/WorkerOverview.vue'
 import QueueOverview from '../components/overviews/QueueOverview.vue'
 import { vxm } from '@/store'
 import { Route, RawLocation } from 'vue-router'
-import TaskRunnerOutput from '@/components/TaskRunnerOutput.vue'
 
 @Component({
   components: {
-    'task-runner-output': TaskRunnerOutput,
     'worker-overview': WorkerOverview,
     'queue-overview': QueueOverview
   }

--- a/frontend/src/views/Queue.vue
+++ b/frontend/src/views/Queue.vue
@@ -66,7 +66,7 @@ export default class Queue extends Vue {
   }
 
   private get someTask() {
-    return 'e16e1c20-2d25-4a5a-937d-ebfa5e3f33a9'
+    return 'fde53cb7-6e8d-4e23-9f8f-c92c87a88baf'
   }
 
   beforeRouteLeave(

--- a/frontend/src/views/Queue.vue
+++ b/frontend/src/views/Queue.vue
@@ -19,6 +19,9 @@
           </v-card>
         </v-col>
       </v-row>
+      <v-row>
+        <task-runner-output :task-id="someTask"></task-runner-output>
+      </v-row>
       <v-row align="baseline" justify="center">
         <v-col>
           <v-card>
@@ -48,9 +51,11 @@ import WorkerOverview from '../components/overviews/WorkerOverview.vue'
 import QueueOverview from '../components/overviews/QueueOverview.vue'
 import { vxm } from '@/store'
 import { Route, RawLocation } from 'vue-router'
+import TaskRunnerOutput from '@/components/TaskRunnerOutput.vue'
 
 @Component({
   components: {
+    'task-runner-output': TaskRunnerOutput,
     'worker-overview': WorkerOverview,
     'queue-overview': QueueOverview
   }
@@ -58,6 +63,10 @@ import { Route, RawLocation } from 'vue-router'
 export default class Queue extends Vue {
   private get workers() {
     return vxm.queueModule.workers
+  }
+
+  private get someTask() {
+    return '1789aecefd6303e6d33a330b57fdb2fca2bb9823'
   }
 
   beforeRouteLeave(

--- a/frontend/src/views/Queue.vue
+++ b/frontend/src/views/Queue.vue
@@ -66,7 +66,7 @@ export default class Queue extends Vue {
   }
 
   private get someTask() {
-    return '1789aecefd6303e6d33a330b57fdb2fca2bb9823'
+    return 'e16e1c20-2d25-4a5a-937d-ebfa5e3f33a9'
   }
 
   beforeRouteLeave(

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -1,0 +1,131 @@
+<template>
+  <v-container>
+    <v-row v-if="!show404 && task === null && commit === null">
+      <v-col>
+        <v-skeleton-loader type="card"></v-skeleton-loader>
+      </v-col>
+    </v-row>
+    <v-row no-gutters v-if="nudgeToRunDetail">
+      <v-col>
+        <v-snackbar timeout="-1" multi-line :value="true" shaped color="info">
+          This task no longer exists, but it looks like a run exists for it! Do
+          you want to navigate there?
+          <template v-slot:action="{ attrs }">
+            <v-btn
+              color="ping"
+              text
+              dark
+              v-bind="attrs"
+              @click="navigateToRespectiveRun"
+            >
+              To the run!
+            </v-btn>
+          </template>
+        </v-snackbar>
+      </v-col>
+    </v-row>
+    <v-row v-if="commit" no-gutters>
+      <v-col>
+        <commit-detail :commit="commit"></commit-detail>
+      </v-col>
+    </v-row>
+    <v-row v-if="task" no-gutters>
+      <v-col>
+        <task-runner-output
+          :task-id="taskId"
+          @loading-failed="loadingOutputFailed"
+        ></task-runner-output>
+      </v-col>
+    </v-row>
+    <v-row v-if="show404">
+      <page-404
+        title="Task not found"
+        subtitle="Maybe try refreshing or add it to the queue!"
+      ></page-404>
+    </v-row>
+  </v-container>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import Component from 'vue-class-component'
+import NotFound404 from '@/views/NotFound404.vue'
+import { Commit, CommitTaskSource, Task, TaskSource } from '@/store/types'
+import { Watch } from 'vue-property-decorator'
+import { vxm } from '@/store'
+import CommitDetail from '@/components/rundetail/CommitDetail.vue'
+import TaskRunnerOutput from '@/components/TaskRunnerOutput.vue'
+
+@Component({
+  components: {
+    'task-runner-output': TaskRunnerOutput,
+    'page-404': NotFound404,
+    'commit-detail': CommitDetail
+  }
+})
+export default class TaskDetailView extends Vue {
+  private show404: boolean = false
+
+  private task: Task | null = null
+  private commit: Commit | null = null
+  private nudgeToRunDetail: boolean = false
+
+  private get taskId() {
+    return this.$route.params.taskId
+  }
+
+  @Watch('taskId')
+  private async update() {
+    this.show404 = false
+
+    await vxm.queueModule.fetchQueue()
+
+    const myTask = vxm.queueModule.openTasks.find(it => it.id === this.taskId)
+    this.task = myTask || null
+
+    if (!this.task) {
+      await this.handleTaskNotFound()
+      return
+    }
+    await this.handleSource(this.task.source)
+  }
+
+  private async handleSource(source: TaskSource) {
+    if (source instanceof CommitTaskSource) {
+      this.commit = await vxm.commitDetailComparisonModule.fetchCommit({
+        repoId: source.commitDescription.repoId,
+        commitHash: source.commitDescription.hash
+      })
+    }
+  }
+
+  private async handleTaskNotFound() {
+    try {
+      const run = await vxm.commitDetailComparisonModule.fetchRun(this.taskId)
+      this.nudgeToRunDetail = true
+      await this.handleSource(run.run.source)
+    } catch (e) {
+      this.show404 = true
+    }
+  }
+
+  private loadingOutputFailed() {
+    if (!vxm.queueModule.openTasks.find(it => it.id === this.taskId)) {
+      this.handleTaskNotFound()
+    }
+  }
+
+  private navigateToRespectiveRun() {
+    this.$router.push({
+      name: 'run-detail',
+      params: {
+        first: this.taskId
+      }
+    })
+  }
+
+  private mounted() {
+    this.update()
+  }
+}
+</script>

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -8,8 +8,8 @@
     <v-row no-gutters v-if="nudgeToRunDetail">
       <v-col>
         <v-snackbar timeout="-1" multi-line :value="true" shaped color="info">
-          This task no longer exists, but it looks like a run exists for it! Do
-          you want to navigate there?
+          This task no longer exists, but it looks like a run exists for it!
+          Click "to the run" on the right to navigate there.
           <template v-slot:action="{ attrs }">
             <v-btn
               color="ping"

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -18,7 +18,7 @@
               v-bind="attrs"
               @click="navigateToRespectiveRun"
             >
-              To the run!
+              To the run
             </v-btn>
           </template>
         </v-snackbar>
@@ -40,7 +40,7 @@
     <v-row v-if="show404">
       <page-404
         title="Task not found"
-        subtitle="Maybe try refreshing or add it to the queue!"
+        subtitle="Maybe try refreshing or add it to the queue"
       ></page-404>
     </v-row>
   </v-container>


### PR DESCRIPTION
## Words of caution
I would like to merge this after the other small to frontend changes are merged in master, as this change is slightly more likely to introduce problems and hasn't been tested on the live instance yet.

## Onwards
This patch allows the runner to capture the standard error stream of the executed program, send the last 100 lines to the backend and finally display it on the frontend in a new and shiney `task-detail` page you get to by clicking on queue items.

Closes #18 (hopefully)