### PR TITLE
Parallelize CI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,23 +11,14 @@ env:
 
 jobs:
   # Runs the build.
-  build:
+  build-frontend:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
-        with:
-          java-version: '11'
       - uses: actions/setup-node@v2-beta
         with:
           node-version: '12'
-      - uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
 
       - name: "Build frontend (kit.edu)"
         run: "make frontend mode=production-kit-single-port"
@@ -48,8 +39,25 @@ jobs:
           name: frontend-artifacts
           path: frontend/dist
 
+  # Runs the build.
+  build-backend:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       - name: "Build backend"
         run: "make backend"
+
       - name: "Upload backend/backend artifact"
         uses: actions/upload-artifact@v2
         with:
@@ -69,7 +77,7 @@ jobs:
   # Push aaaaaaah image to GitHub Packages.
   push-aaaaaaah:
     # Ensure build job passes before pushing image.
-    needs: [build]
+    needs: [build-frontend, build-backend]
 
     runs-on: ubuntu-latest
     if: "github.event_name == 'push' && github.ref == 'refs/heads/main'"
@@ -158,7 +166,7 @@ jobs:
   # Push image to GitHub Packages.
   push-kit:
     # Ensure build job passes before pushing image.
-    needs: [build]
+    needs: [build-frontend, build-backend]
 
     runs-on: ubuntu-latest
     if: "github.event_name == 'push' && github.ref == 'refs/heads/stable'"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,8 +10,26 @@ env:
   UID: 1004
 
 jobs:
-  # Runs the build.
-  build-frontend:
+  # Build the aaaaaaah frontend
+  build-frontend-aaaaaaah:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '12'
+
+      - name: "Build frontend (aaaaaaah.de)"
+        run: "make frontend mode=production-single-port"
+      - name: "Upload frontend artifacts (aaaaaaah.de)"
+        uses: actions/upload-artifact@v2
+        with:
+          name: frontend-artifacts
+          path: frontend/dist
+
+  # Build the kit frontend
+  build-frontend-kit:
     runs-on: ubuntu-latest
 
     steps:
@@ -28,18 +46,7 @@ jobs:
           name: frontend-artifacts-kit
           path: frontend/dist
 
-      - name: "Clean frontend"
-        run: "make -C frontend/ clean"
-
-      - name: "Build frontend (aaaaaaah.de)"
-        run: "make frontend mode=production-single-port"
-      - name: "Upload frontend artifacts (aaaaaaah.de)"
-        uses: actions/upload-artifact@v2
-        with:
-          name: frontend-artifacts
-          path: frontend/dist
-
-  # Runs the build.
+  # Build the shared backend
   build-backend:
     runs-on: ubuntu-latest
 
@@ -77,7 +84,7 @@ jobs:
   # Push aaaaaaah image to GitHub Packages.
   push-aaaaaaah:
     # Ensure build job passes before pushing image.
-    needs: [build-frontend, build-backend]
+    needs: [build-frontend-aaaaaaah, build-backend]
 
     runs-on: ubuntu-latest
     if: "github.event_name == 'push' && github.ref == 'refs/heads/main'"
@@ -166,7 +173,7 @@ jobs:
   # Push image to GitHub Packages.
   push-kit:
     # Ensure build job passes before pushing image.
-    needs: [build-frontend, build-backend]
+    needs: [build-frontend-kit, build-backend]
 
     runs-on: ubuntu-latest
     if: "github.event_name == 'push' && github.ref == 'refs/heads/stable'"


### PR DESCRIPTION
The previous CI pipeline takes around 10 minutes to fully deploy and 6 minutes to just build and test it. Crucially, building the backend and the two frontends does not depend on each other. So now Github Actions can launch those three tasks in parallel, and then build the docker images sequentially after all three have finished.

This cuts the pure build time in half and probably shaves off around 3 minutes of the full pipeline as well.