### PR TITLE
Correctly parse the new storage format when restoring

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -18,12 +18,13 @@ window.addEventListener('storage', event => {
   }
 
   if (event.key === 'persisted_session_state' && sessionStorage.length === 0) {
-    restoreFromPassedSession(event.newValue)
+    Vue.nextTick(() => restoreFromPassedSession())
   }
 })
 
 if (sessionStorage.length === 0) {
-  restoreFromPassedSession(null)
+  // noinspection JSIgnoredPromiseFromCall
+  restoreFromPassedSession()
 }
 
 const vue = new Vue({


### PR DESCRIPTION
When a new tab is opened the session storage of the parent is cloned and transferred to the child. This ensures graphs and other things behave as you would expect, even when opening things in a new tab: They have the same state as the parent tab, but can then diverge freely.

The persistence upgrades broke it, this patch fixes it.