### PR TITLE
Don't fail on aspectj weaver jar in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ docker-github-ci:
 	mkdir -p .docker
 	cp backend.jar .docker
 	# Copy aspextj agent if it exists
-	[ -f aspectjweaver.jar ] && cp aspectjweaver.jar .docker
+	([ -f aspectjweaver.jar ] && cp aspectjweaver.jar .docker) || echo "AspectJ Weaver not found. Carrying on"
 	cp -r dist .docker
 	cp -r docs/* .docker
 	cp Dockerfile-Single-Port .docker/Dockerfile


### PR DESCRIPTION
The docker image properly carries on without the agent present (that I made sure), but the Makefile target used for the *Github* CI doesn't. The aspect j weaver agent is optional: If it is present, detailed performance metrics for many parts of the system will be recorded and exposed in /prometheusMetrics.

That change should also be fast-forwarded to stable. It hopefully doesn't impact the quite large last PR, as that requires manual intervention in either case, but could be a nice test for the CI pipeline afterwards.

@Kha 