### PR TITLE
Improve duration computation and validation

### DIFF
--- a/frontend/src/store/modules/detailGraphStore.ts
+++ b/frontend/src/store/modules/detailGraphStore.ts
@@ -54,7 +54,6 @@ export class DetailGraphStore extends VxModule {
   // One week in the past, as elegant as ever
   startTime: Date = new Date(new Date().setDate(new Date().getDate() - 7))
   endTime: Date = new Date()
-  duration: number = 7
 
   beginYScaleAtZero: boolean = false
 
@@ -158,6 +157,7 @@ export class DetailGraphStore extends VxModule {
     // Anchors to the current date
     extractDate('zoomXEnd', new Date(), value => {
       this.zoomXEndValue = value
+      this.endTime = new Date(value)
     })
     // Anchors to the end date (or the current one if not specified)
     extractDate(
@@ -165,6 +165,7 @@ export class DetailGraphStore extends VxModule {
       new Date(this.zoomXEndValue || new Date().getTime()),
       value => {
         this.zoomXStartValue = value
+        this.startTime = new Date(value)
       }
     )
     extractFloat('zoomYStart', value => {
@@ -185,6 +186,14 @@ export class DetailGraphStore extends VxModule {
         )
       })
     }
+  }
+
+  get duration(): number {
+    const timeDiff =
+      vxm.detailGraphModule.endTime.getTime() -
+      vxm.detailGraphModule.startTime.getTime()
+
+    return Math.ceil(timeDiff / (1000 * 3600 * 24))
   }
 
   /**

--- a/frontend/src/views/NewRepoDetail.vue
+++ b/frontend/src/views/NewRepoDetail.vue
@@ -224,13 +224,16 @@
                   </v-menu>
                 </v-col>
                 <v-col>
-                  <v-text-field
-                    @blur="saveDuration"
-                    v-model="duration"
-                    :disabled="dateLocked === 'neither'"
-                    label="number of days to fetch:"
-                    class="mr-5"
-                  ></v-text-field>
+                  <v-form>
+                    <v-text-field
+                      @blur="saveDuration"
+                      :value="duration"
+                      :disabled="dateLocked === 'neither'"
+                      label="number of days to fetch:"
+                      class="mr-5"
+                      :rules="[ruleIsNumber]"
+                    ></v-text-field>
+                  </v-form>
                 </v-col>
               </v-row>
             </v-container>
@@ -328,31 +331,30 @@ export default class RepoDetail extends Vue {
   private saveStartDateMenu(date: string) {
     ;(this.$refs.startDateMenu as any).save(date)
     vxm.detailGraphModule.startTime = new Date(date)
-    vxm.detailGraphModule.duration = this.computeDuration()
     this.retrieveGraphData()
   }
 
   private saveStopDateMenu(date: string) {
     ;(this.$refs.stopDateMenu as any).save(date)
     vxm.detailGraphModule.endTime = new Date(date)
-    vxm.detailGraphModule.duration = this.computeDuration()
     this.retrieveGraphData()
   }
 
-  private saveDuration() {
+  private saveDuration(event: Event) {
+    const target = event.target as HTMLInputElement
+    const duration: number = parseInt(target.value)
+
+    if (isNaN(duration)) {
+      return
+    }
+
     if (this.dateLocked === 'start') {
-      console.log(vxm.detailGraphModule.startTime.getDate())
       vxm.detailGraphModule.endTime = new Date(
-        new Date().setDate(
-          vxm.detailGraphModule.startTime.getDate() + this.duration
-        )
+        new Date().setDate(vxm.detailGraphModule.startTime.getDate() + duration)
       )
-      console.log(vxm.detailGraphModule.startTime.getDate() + this.duration)
     } else {
       vxm.detailGraphModule.startTime = new Date(
-        new Date().setDate(
-          vxm.detailGraphModule.endTime.getDate() - this.duration
-        )
+        new Date().setDate(vxm.detailGraphModule.endTime.getDate() - duration)
       )
     }
     this.retrieveGraphData()
@@ -382,10 +384,6 @@ export default class RepoDetail extends Vue {
     return vxm.detailGraphModule.duration
   }
 
-  private set duration(duration: number) {
-    vxm.detailGraphModule.duration = Number(duration) // the number is a lie :(
-  }
-
   private get yStartsAtZero(): boolean {
     return vxm.detailGraphModule.beginYScaleAtZero
   }
@@ -406,16 +404,6 @@ export default class RepoDetail extends Vue {
     } else {
       this.dateLocked = this.dateLocked === 'start' ? 'end' : 'start'
     }
-  }
-
-  private computeDuration(): number {
-    const timeDiff =
-      vxm.detailGraphModule.endTime.getTime() -
-      vxm.detailGraphModule.startTime.getTime()
-
-    return (vxm.detailGraphModule.duration = Math.ceil(
-      timeDiff / (1000 * 3600 * 24)
-    ))
   }
 
   private stopAfterStart(): boolean | string {
@@ -445,6 +433,10 @@ export default class RepoDetail extends Vue {
         this.selectedGraphComponent = correctSeries.component
       }
     }
+  }
+
+  private ruleIsNumber(input: string): string | boolean {
+    return isNaN(parseInt(input)) ? 'Please enter a number' : true
   }
 
   mounted(): void {


### PR DESCRIPTION
This PR improves the duration computation so it always reflects the actual state and adds some validation for it.

Additionally it actually applies the zoomXEnd and zoomXStart stored in permanent links to enlarge the fetch window, if needed.

## Further work:

#### Start / End in permanent links
Figure out an intuitive way to handle start/end days in permanent links and its relationship with zooming. Some options:
1. Do not store start and end dates and deduce them roughly based on the zoom window. This would alter how the page looks, but wouldn't require any further adjustments and leave kinda readable links
2. Also store start and end dates in permanent links

#### Duration in permanent links
Should we expose the "duration" parameter in permanent links? This would allow for links like "last week" or "two weeks ago", etc. while slightly complicating the parsing logic.