### PR TITLE
Allow benchmarks without metrics

### DIFF
--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/benchmarking/output/BenchmarkScriptOutputParser.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/benchmarking/output/BenchmarkScriptOutputParser.java
@@ -86,10 +86,6 @@ public class BenchmarkScriptOutputParser {
 			metrics.add(parseMetric(field.getKey(), field.getValue()));
 		}
 
-		if (metrics.isEmpty()) {
-			throw new OutputParseException("Benchmark '" + name + "' has no metric: " + node);
-		}
-
 		return new Benchmark(name, metrics);
 	}
 

--- a/backend/runner/src/test/java/de/aaaaaaah/velcom/runner/benchmarking/output/BenchmarkScriptOutputParserTest.java
+++ b/backend/runner/src/test/java/de/aaaaaaah/velcom/runner/benchmarking/output/BenchmarkScriptOutputParserTest.java
@@ -42,7 +42,6 @@ class BenchmarkScriptOutputParserTest {
 
 	@ParameterizedTest
 	@CsvSource(value = {
-		"{\"benchmark\": {} }",
 		"{\"benchmark\": [] }",
 		"{\"benchmark\": 20 }",
 		"{\"benchmark\": false }",
@@ -86,7 +85,6 @@ class BenchmarkScriptOutputParserTest {
 		"{ \"test\": { \"metric\": { \"error\": [] } } }",
 		"{ \"error\": 20 }",
 		"{ \"error\": false }",
-		"{ \"error\": {} }",
 		"{ \"error\": [] }",
 	}, delimiter = '|')
 	void parseInvalidErrorMessage(String data) {

--- a/backend/runner/src/test/resources/benchmark-script/valid-input.csv
+++ b/backend/runner/src/test/resources/benchmark-script/valid-input.csv
@@ -10,3 +10,4 @@ true | { "error": "äöüß0ßß21gfaλΑ‡†č" }
 false | { "benchmark": { "metric": { "unit": "cats", "results": [1234, 123], "resultInterpretation": "NEUTRAL" } } }
 false | { "benchmark": { "metric": { "unit": "cats", "values": [1234, 123], "resultInterpretation": "NEUTRAL" } } }
 false | { "benchmark": { "metric": { "unit": "cats", "results": [1234, 123], "interpretation": "NEUTRAL" } } }
+false | { "benchmark": {} }


### PR DESCRIPTION
Neither the previous nor this new behaviour is explicitly specified in the wiki. This change makes sense in the case of auto-discovered metrics. See [this run](http://speedcenter.informatik.kit.edu/velcom/run-detail/bab50d33-13a1-40c4-85a0-fda5f93f8b22/943687ad0977f11809ae80353d67e11cc0c2a02f) for an example.