### PR TITLE
Use dygraphs graph for large datasets

### DIFF
--- a/frontend/src/views/NewRepoDetail.vue
+++ b/frontend/src/views/NewRepoDetail.vue
@@ -291,7 +291,11 @@ export default class RepoDetail extends Vue {
   private availableGraphComponents = [
     {
       predicate: () => {
-        return vxm.detailGraphModule.visiblePoints < 30_000
+        // Do not care about zooming, only use echarts when he have only a handful of data points
+        const points =
+          vxm.detailGraphModule.detailGraph.length *
+          vxm.detailGraphModule.selectedDimensions.length
+        return points < 30_000
       },
       component: EchartsDetailGraph,
       name: 'Fancy'


### PR DESCRIPTION
This should hopefully finish addressing #133 for now.

Previous PRs selected the dygraphs graph ealier and alleviated some inefficiencies.
This PR now bases the decision on the *total* number of points instead of the *visible* number of datapoints, as Echarts still struggles with the sheer amount of points on small zoom levels.