### PR TITLE
Fix click on error button taking you to detail graph

### DIFF
--- a/frontend/src/components/rundetail/MeasurementsDisplay.vue
+++ b/frontend/src/components/rundetail/MeasurementsDisplay.vue
@@ -40,12 +40,13 @@
           class="error-message error-message-tooltip"
           text
           outlined
-          @click="
+          @click.stop="
             showDetailErrorDialog = true
             detailErrorDialogMessage = item.error
           "
-          >{{ formatErrorShorthand(item.error) }}</v-btn
         >
+          {{ formatErrorShorthand(item.error) }}
+        </v-btn>
       </template>
       <template
         v-for="{ slotName, tooltip } in headerFormats"


### PR DESCRIPTION
Before this patch, clicking on an error button takes you to detail page (i.e. it executes the normal row click listener). This PR stops that.