### PR TITLE
Process and display ANSI colors

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -6,7 +6,8 @@ build: backend/target/backend.jar
 
 backend/target/backend.jar: $(shell find -name '*.java' -o -name '*.sql' -o -name pom.xml)
 	@echo 'Building backend'
-	mvn package site jacoco:report-aggregate
+	# We want colors!
+	MAVEN_OPTS="-Djansi.passthrough=true -Djansi.force=true" mvn -Dstyle.color=always package site jacoco:report-aggregate
 
 clean: clean-backend-data
 	mvn clean

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -5,11 +5,11 @@ mode?=production
 all: build
 
 node_modules: package.json yarn.lock
-	yarnpkg install
+	yarnpkg --color=always install
 	touch node_modules
 
 dist: $(shell find src -name "*.vue" -o -name "*.ts") node_modules .env.production
-	yarnpkg build --mode="$(mode)"
+	yarnpkg --color=always build --mode="$(mode)"
 	touch dist
 
 build: dist

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@types/d3": "^5.16.3",
     "@types/dygraphs": "^1.1.11",
+    "ansi-to-html": "^0.6.14",
     "axios": "^0.20.0",
     "core-js": "^3.4.4",
     "d3": "^5.15.0",

--- a/frontend/src/ansi-to-html.d.ts
+++ b/frontend/src/ansi-to-html.d.ts
@@ -1,0 +1,1 @@
+declare module 'ansi-to-html'

--- a/frontend/src/components/TaskRunnerOutput.vue
+++ b/frontend/src/components/TaskRunnerOutput.vue
@@ -53,8 +53,7 @@ import Component from 'vue-class-component'
 import { Prop, Watch } from 'vue-property-decorator'
 import { StreamedRunnerOutput, TaskId } from '@/store/types'
 import { vxm } from '@/store'
-import Convert from 'ansi-to-html'
-import { escapeHtml } from '@/util/TextUtils'
+import { safeConvertAnsi } from '@/util/TextUtils'
 
 @Component
 export default class TaskRunnerOutput extends Vue {
@@ -107,10 +106,9 @@ export default class TaskRunnerOutput extends Vue {
     if (!output) {
       return []
     }
-    const convert = new Convert()
     return output.outputLines.map((line, index) => ({
       lineNumber: index + output.indexOfFirstLine + 1,
-      text: convert.toHtml(escapeHtml(line))
+      text: safeConvertAnsi(line)
     }))
   }
 

--- a/frontend/src/components/TaskRunnerOutput.vue
+++ b/frontend/src/components/TaskRunnerOutput.vue
@@ -112,6 +112,17 @@ export default class TaskRunnerOutput extends Vue {
     }))
   }
 
+  // noinspection JSUnusedLocalSymbols (Used by the watcher below)
+  private get darkThemeSelected() {
+    return vxm.userModule.darkThemeSelected
+  }
+
+  @Watch('darkThemeSelected')
+  private onDarkThemeSelectionChanged() {
+    // The ANSI conversion needs to be redone
+    this.$forceUpdate()
+  }
+
   private mounted() {
     this.update()
     this.timer = setInterval(() => {

--- a/frontend/src/components/TaskRunnerOutput.vue
+++ b/frontend/src/components/TaskRunnerOutput.vue
@@ -22,17 +22,16 @@
       </v-alert>
       <div class="runner-output mx-2">
         <div
-          v-for="{ lineNumber, text, classes } in lines"
+          v-for="{ lineNumber, text } in lines"
           :key="lineNumber"
           class="line"
-          :class="classes"
         >
           <span
             class="mr-2 font-weight-bold align-end text-right d-inline-block"
             style="min-width: 4ch; user-select: none"
             >{{ lineNumber }}</span
           >
-          {{ text }}
+          <span v-html="text"></span>
         </div>
       </div>
       <v-row align="center" justify="center">
@@ -54,6 +53,8 @@ import Component from 'vue-class-component'
 import { Prop, Watch } from 'vue-property-decorator'
 import { StreamedRunnerOutput, TaskId } from '@/store/types'
 import { vxm } from '@/store'
+import Convert from 'ansi-to-html'
+import { escapeHtml } from '@/util/TextUtils'
 
 @Component
 export default class TaskRunnerOutput extends Vue {
@@ -101,34 +102,16 @@ export default class TaskRunnerOutput extends Vue {
   private get lines(): {
     lineNumber: number
     text: string
-    classes: string[]
   }[] {
     const output = this.output
     if (!output) {
       return []
     }
-    const levelRegex = [
-      {
-        level: 'warning',
-        regex: this.startsRoughlyWithLevel('warning')
-      },
-      {
-        level: 'error',
-        regex: this.startsRoughlyWithLevel('error')
-      }
-    ]
+    const convert = new Convert()
     return output.outputLines.map((line, index) => ({
       lineNumber: index + output.indexOfFirstLine + 1,
-      text: line,
-      classes: levelRegex.map(it =>
-        it.regex.exec(line) !== null ? `text--${it.level}` : ''
-      )
+      text: convert.toHtml(escapeHtml(line))
     }))
-  }
-
-  private startsRoughlyWithLevel(level: string): RegExp {
-    const regexString = `^\\s*((\\[${level}\\])|${level})`
-    return new RegExp(regexString, 'iu')
   }
 
   private mounted() {
@@ -154,17 +137,12 @@ export default class TaskRunnerOutput extends Vue {
   max-height: 90vh;
   overflow-y: scroll;
 }
+/*noinspection CssUnusedSymbol*/
 .theme--light .runner-output .line:hover {
   background-color: var(--v-rowHighlight-lighten1) !important;
 }
+/*noinspection CssUnusedSymbol*/
 .theme--dark .runner-output .line:hover {
   background-color: var(--v-rowHighlight-darken1) !important;
-}
-
-.text--warning {
-  color: var(--v-warning-base);
-}
-.text--error {
-  color: var(--v-error-base);
 }
 </style>

--- a/frontend/src/components/rundetail/MeasurementsDisplay.vue
+++ b/frontend/src/components/rundetail/MeasurementsDisplay.vue
@@ -69,7 +69,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import Component from 'vue-class-component'
-import { Prop } from 'vue-property-decorator'
+import { Prop, Watch } from 'vue-property-decorator'
 import {
   Measurement,
   MeasurementError,
@@ -80,6 +80,7 @@ import {
 } from '@/store/types'
 import MeasurementValueDisplay from '@/components/rundetail/MeasurementValueDisplay.vue'
 import { safeConvertAnsi } from '@/util/TextUtils'
+import { vxm } from '@/store'
 
 const numberFormat: Intl.NumberFormat = new Intl.NumberFormat(
   new Intl.NumberFormat().resolvedOptions().locale,
@@ -299,8 +300,22 @@ export default class MeasurementsDisplay extends Vue {
   }
 
   private displayErrorDetail(item: Item) {
+    if (!item.error) {
+      return ''
+    }
     this.detailErrorDialogMessage = safeConvertAnsi(item.error)
     this.showDetailErrorDialog = true
+  }
+
+  // noinspection JSUnusedLocalSymbols (Used by the watcher below)
+  private get darkThemeSelected() {
+    return vxm.userModule.darkThemeSelected
+  }
+
+  @Watch('darkThemeSelected')
+  private onDarkThemeSelectionChanged() {
+    // The ANSI conversion needs to be redone
+    this.$forceUpdate()
   }
 
   private rowClicked(item: Item) {

--- a/frontend/src/components/rundetail/MeasurementsDisplay.vue
+++ b/frontend/src/components/rundetail/MeasurementsDisplay.vue
@@ -8,7 +8,7 @@
         <v-card-text>
           <div
             class="ma-4 error-message"
-            v-html="detailErrorDialogMessage"
+            v-html="safeDetailErrorDialogMessage"
           ></div>
         </v-card-text>
         <v-card-actions>
@@ -195,7 +195,7 @@ export default class MeasurementsDisplay extends Vue {
   private differences?: DimensionDifference[]
 
   private showDetailErrorDialog: boolean = false
-  private detailErrorDialogMessage: string = ''
+  private safeDetailErrorDialogMessage: string = ''
 
   private get headerFormats() {
     return [
@@ -303,7 +303,7 @@ export default class MeasurementsDisplay extends Vue {
     if (!item.error) {
       return ''
     }
-    this.detailErrorDialogMessage = safeConvertAnsi(item.error)
+    this.safeDetailErrorDialogMessage = safeConvertAnsi(item.error)
     this.showDetailErrorDialog = true
   }
 

--- a/frontend/src/components/rundetail/MeasurementsDisplay.vue
+++ b/frontend/src/components/rundetail/MeasurementsDisplay.vue
@@ -6,7 +6,10 @@
           <v-toolbar-title>Full error message</v-toolbar-title>
         </v-toolbar>
         <v-card-text>
-          <div class="ma-4 error-message">{{ detailErrorDialogMessage }}</div>
+          <div
+            class="ma-4 error-message"
+            v-html="detailErrorDialogMessage"
+          ></div>
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
@@ -40,10 +43,7 @@
           class="error-message error-message-tooltip"
           text
           outlined
-          @click.stop="
-            showDetailErrorDialog = true
-            detailErrorDialogMessage = item.error
-          "
+          @click.stop="displayErrorDetail(item)"
         >
           {{ formatErrorShorthand(item.error) }}
         </v-btn>
@@ -79,6 +79,7 @@ import {
   Dimension
 } from '@/store/types'
 import MeasurementValueDisplay from '@/components/rundetail/MeasurementValueDisplay.vue'
+import { safeConvertAnsi } from '@/util/TextUtils'
 
 const numberFormat: Intl.NumberFormat = new Intl.NumberFormat(
   new Intl.NumberFormat().resolvedOptions().locale,
@@ -297,6 +298,11 @@ export default class MeasurementsDisplay extends Vue {
     return error.substring(0, MAX_ERROR_LENGTH) + '…'
   }
 
+  private displayErrorDetail(item: Item) {
+    this.detailErrorDialogMessage = safeConvertAnsi(item.error)
+    this.showDetailErrorDialog = true
+  }
+
   private rowClicked(item: Item) {
     const currentSelection = document.getSelection()
     if (currentSelection && currentSelection.toString()) {
@@ -316,7 +322,6 @@ export default class MeasurementsDisplay extends Vue {
 <!--suppress CssUnresolvedCustomProperty -->
 <style scoped>
 .error-message {
-  color: var(--v-error-base);
   font-family: monospace;
   white-space: pre-line;
   overflow: hidden;
@@ -324,6 +329,7 @@ export default class MeasurementsDisplay extends Vue {
 
 .error-message-tooltip {
   cursor: pointer;
+  color: var(--v-error-base);
 }
 </style>
 

--- a/frontend/src/components/rundetail/RunDetail.vue
+++ b/frontend/src/components/rundetail/RunDetail.vue
@@ -47,10 +47,11 @@ import {
   RunWithDifferences,
   Dimension
 } from '@/store/types'
-import { Prop } from 'vue-property-decorator'
+import { Prop, Watch } from 'vue-property-decorator'
 import MeasurementsDisplay from '@/components/rundetail/MeasurementsDisplay.vue'
 import RunInfo from '@/components/rundetail/RunInfo.vue'
 import { safeConvertAnsi } from '@/util/TextUtils'
+import { vxm } from '@/store'
 
 @Component({
   components: {
@@ -108,6 +109,17 @@ export default class RunDetail extends Vue {
 
   private navigateToDetailGraph(dimension: Dimension) {
     this.$emit('navigate-to-detail-graph', dimension)
+  }
+
+  // noinspection JSUnusedLocalSymbols (Used by the watcher below)
+  private get darkThemeSelected() {
+    return vxm.userModule.darkThemeSelected
+  }
+
+  @Watch('darkThemeSelected')
+  private onDarkThemeSelectionChanged() {
+    // The ANSI conversion needs to be redone
+    this.$forceUpdate()
   }
 }
 </script>

--- a/frontend/src/components/rundetail/RunDetail.vue
+++ b/frontend/src/components/rundetail/RunDetail.vue
@@ -6,7 +6,7 @@
           <v-card-title>
             <v-toolbar dark :color="runColor">{{ errorType }} Error</v-toolbar>
           </v-card-title>
-          <v-card-text class="mx-2 error-text">{{ error }}</v-card-text>
+          <v-card-text class="mx-2 error-text" v-html="error"></v-card-text>
         </v-card>
       </v-col>
     </v-row>
@@ -50,6 +50,7 @@ import {
 import { Prop } from 'vue-property-decorator'
 import MeasurementsDisplay from '@/components/rundetail/MeasurementsDisplay.vue'
 import RunInfo from '@/components/rundetail/RunInfo.vue'
+import { safeConvertAnsi } from '@/util/TextUtils'
 
 @Component({
   components: {
@@ -78,7 +79,7 @@ export default class RunDetail extends Vue {
     if (this.errorType === undefined) {
       return undefined
     }
-    return (this.run.result as RunResultVelcomError).error
+    return safeConvertAnsi((this.run.result as RunResultVelcomError).error)
   }
 
   private get errorType(): string | undefined {

--- a/frontend/src/util/TextUtils.ts
+++ b/frontend/src/util/TextUtils.ts
@@ -1,0 +1,10 @@
+/**
+ * Escapes all HTML in a given string.
+ *
+ * @param input the input string to escape
+ */
+export function escapeHtml(input: string): string {
+  const p = document.createElement('p')
+  p.appendChild(document.createTextNode(input))
+  return p.innerHTML
+}

--- a/frontend/src/util/TextUtils.ts
+++ b/frontend/src/util/TextUtils.ts
@@ -1,6 +1,47 @@
 import Convert from 'ansi-to-html'
+import { vxm } from '@/store'
 
-const convert = new Convert()
+const darkThemeConvert = new Convert({
+  colors: {
+    0: '#1B2B34',
+    1: '#EC5f67',
+    2: '#99C794',
+    3: '#FAC863',
+    4: '#6699CC',
+    5: '#C594C5',
+    6: '#5FB3B3',
+    7: '#C0C5CE',
+    8: '#65737E',
+    9: '#EC5f67',
+    10: '#99C794',
+    11: '#FAC863',
+    12: '#6699CC',
+    13: '#C594C5',
+    14: '#5FB3B3',
+    15: '#D8DEE9'
+  }
+})
+
+const lightThemeConvert = new Convert({
+  colors: {
+    0: '#fafafa',
+    1: '#ca1243',
+    2: '#50a14f',
+    3: '#c18401',
+    4: '#4078f2',
+    5: '#a626a4',
+    6: '#0184bc',
+    7: '#383a42',
+    8: '#a0a1a7',
+    9: '#ca1243',
+    10: '#50a14f',
+    11: '#c18401',
+    12: '#4078f2',
+    13: '#a626a4',
+    14: '#0184bc',
+    15: '#090a0b'
+  }
+})
 
 /**
  * Escapes all HTML in a given string.
@@ -21,5 +62,7 @@ function escapeHtml(input: string): string {
 export function safeConvertAnsi(input: string): string {
   const safeInput = escapeHtml(input)
 
-  return convert.toHtml(safeInput)
+  return vxm.userModule.darkThemeSelected
+    ? darkThemeConvert.toHtml(safeInput)
+    : lightThemeConvert.toHtml(safeInput)
 }

--- a/frontend/src/util/TextUtils.ts
+++ b/frontend/src/util/TextUtils.ts
@@ -1,27 +1,29 @@
 import Convert from 'ansi-to-html'
 import { vxm } from '@/store'
 
+// base16-bright : http://chriskempson.com/projects/base16/
 const darkThemeConvert = new Convert({
   colors: {
-    0: '#1B2B34',
-    1: '#EC5f67',
-    2: '#99C794',
-    3: '#FAC863',
-    4: '#6699CC',
-    5: '#C594C5',
-    6: '#5FB3B3',
-    7: '#C0C5CE',
-    8: '#65737E',
-    9: '#EC5f67',
-    10: '#99C794',
-    11: '#FAC863',
-    12: '#6699CC',
-    13: '#C594C5',
-    14: '#5FB3B3',
-    15: '#D8DEE9'
+    0: '#000000',
+    1: '#fb0120',
+    2: '#a1c659',
+    3: '#fda331',
+    4: '#6fb3d2',
+    5: '#d381c3',
+    6: '#76c7b7',
+    7: '#e0e0e0',
+    8: '#b0b0b0',
+    9: '#fb0120',
+    10: '#a1c659',
+    11: '#fda331',
+    12: '#6fb3d2',
+    13: '#d381c3',
+    14: '#76c7b7',
+    15: '#ffffff'
   }
 })
 
+// base16-one-light: http://chriskempson.com/projects/base16/
 const lightThemeConvert = new Convert({
   colors: {
     0: '#fafafa',

--- a/frontend/src/util/TextUtils.ts
+++ b/frontend/src/util/TextUtils.ts
@@ -1,10 +1,25 @@
+import Convert from 'ansi-to-html'
+
+const convert = new Convert()
+
 /**
  * Escapes all HTML in a given string.
  *
  * @param input the input string to escape
  */
-export function escapeHtml(input: string): string {
+function escapeHtml(input: string): string {
   const p = document.createElement('p')
   p.appendChild(document.createTextNode(input))
   return p.innerHTML
+}
+
+/**
+ * Converts text with ANSI escape codes to HTML.
+ *
+ * @param input the input text
+ */
+export function safeConvertAnsi(input: string): string {
+  const safeInput = escapeHtml(input)
+
+  return convert.toHtml(safeInput)
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1916,6 +1916,13 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
+ansi-to-html@^0.6.14:
+  version "0.6.14"
+  resolved "https://registry.yarnpkg.com/ansi-to-html/-/ansi-to-html-0.6.14.tgz#65fe6d08bba5dd9db33f44a20aec331e0010dad8"
+  integrity sha512-7ZslfB1+EnFSDO5Ju+ue5Y6It19DRnZXWv8jrGHgIlPna5Mh4jz7BV5jCbQneXNFurQcKoolaaAjHtgSBfOIuA==
+  dependencies:
+    entities "^1.1.2"
+
 any-promise@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
@@ -3935,7 +3942,7 @@ enquirer@^2.3.5:
   dependencies:
     ansi-colors "^4.1.1"
 
-entities@^1.1.1:
+entities@^1.1.1, entities@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==


### PR DESCRIPTION
### Preface
This patch is *really* vain but it didn't take too long and helps parse dense log lines when the benchmark script crashes and burns or you are anxiously following the live build log.

### About this patch
This patch introduces support for ANSI colors in all places benchmark script output is shown:
- The popups triggered by the `error` buttons in the Run-Detail-View dialog
- The `Velcom / Benchmark script error` card in the same page
- The task-detail showing the last 100 lines the benchmark script reported so far

ANSI colors are converted using `ansi-to-html` and the resulting HTML is set with the vue equivalent of `innerHTML`. This introduces a trivial XSS vector which a malicious benchmark script could easily exploit. To prevent this, all ANSI escaping is done through a central `safeConvertAnsi` function which uses the dom APIs to safely insert HTML into the document and then read back the escaped version the user's browser prepared. I am reasonably certain this is *actually safe*, as the MDN docs state:
> Creates a new Text node. This method can be used to escape HTML characters.

And the content is just inserted as the innerHTML of a div or span.

### Further notes
This patch does **not** let the runner implement a Pseudo-TTY to fool scripts into outputting colours. If you want colours, you need to write a benchmark script that forces your programs to output colors (e.g. by using `--color=always` flags or some `MAVEN_OPTS` and property trickery)

### Screenshots
#### Light theme
![Light](https://user-images.githubusercontent.com/20284688/97055506-3cd08980-1587-11eb-9d78-efba85bcf1df.png)
#### Dark theme
![Dark](https://user-images.githubusercontent.com/20284688/97055534-4bb73c00-1587-11eb-9c27-b2a63c04b526.png)
