### PR TITLE
Fix graph permanent link and graph tooltip xss

### DIFF
--- a/frontend/src/components/graphs/EchartsDetailGraph.vue
+++ b/frontend/src/components/graphs/EchartsDetailGraph.vue
@@ -51,6 +51,7 @@ import { vxm } from '@/store'
 import DetailDatapointDialog from '@/components/dialogs/DetailDatapointDialog.vue'
 import { DimensionDetailPoint } from '@/store/modules/detailGraphStore'
 import { formatDate } from '@/util/TimeUtil'
+import { escapeHtml } from '@/util/TextUtils'
 
 type ValidEchartsSeries = EChartOption.SeriesLine | EChartOption.SeriesGraph
 type SeriesGenerationFunction = (id: DimensionId) => ValidEchartsSeries
@@ -259,12 +260,14 @@ export default class EchartsDetailGraph extends Vue {
       const dimension = this.dimensions[val.seriesIndex || 0]
       const color = this.dimensionColor(dimension)
       const datapoint = val.data as EchartsDataPoint
+      const safeBenchmark = escapeHtml(dimension.benchmark)
+      const safeMetric = escapeHtml(dimension.metric)
 
       return `
                 <tr>
                   <td>
                     <span class="color-preview" style="background-color: ${color}"></span>
-                    ${dimension.benchmark} - ${dimension.metric}
+                    ${safeBenchmark} - ${safeMetric}
                   </td>
                   <td>${this.numberFormat.format(datapoint.dataValue)}</td>
                 </tr>
@@ -273,20 +276,21 @@ export default class EchartsDetailGraph extends Vue {
 
     const samplePoint = values[0].data as EchartsDataPoint
 
+    const authorDate = formatDate(samplePoint.time)
     return `
                 <table class="echarts-tooltip-table">
                   <tr>
                     <td>Hash</td>
-                    <td>${samplePoint.name}</td>
+                    <td>${escapeHtml(samplePoint.name)}</td>
                   </tr>
                   </tr>
                     <td>Message</td>
-                    <td>${samplePoint.summary}</td>
+                    <td>${escapeHtml(samplePoint.summary)}</td>
                   </tr>
                   <tr>
                     <td>Author</td>
                     <td>
-                      ${samplePoint.author} at ${formatDate(samplePoint.time)}
+                      ${escapeHtml(samplePoint.author)} at ${authorDate}
                     </td>
                   </tr>
                   ${dimensionRows.join('\n')}

--- a/frontend/src/components/graphs/NewDytailGraph.vue
+++ b/frontend/src/components/graphs/NewDytailGraph.vue
@@ -17,6 +17,7 @@ import { DetailDataPoint, Dimension, DimensionId } from '@/store/types'
 import { vxm } from '@/store'
 import 'dygraphs/css/dygraph.css'
 import Crosshair from 'dygraphs/src/extras/crosshair.js'
+import { escapeHtml } from '@/util/TextUtils'
 
 // eslint-disable-next-line no-undef
 type RealOptions = dygraphs.Options & {
@@ -125,14 +126,14 @@ export default class DytailGraph extends Vue {
       data.sort((a, b) => b.y - a.y)
 
       const dimensionRows = data.map(val => {
-        const dimension = val.labelHTML
+        const safeDimension = escapeHtml(val.labelHTML)
         const color = val.color
 
         return `
                 <tr>
                   <td>
                     <span class="color-preview" style="background-color: ${color}"></span>
-                    ${dimension}
+                    ${safeDimension}
                   </td>
                   <td>${this.numberFormat.format(val.y)}</td>
                 </tr>
@@ -142,16 +143,18 @@ export default class DytailGraph extends Vue {
       return `<table class="dygraphs-tooltip-table">
                   <tr>
                     <td>Hash</td>
-                    <td>${datapoint ? datapoint.hash : 'xxx'}</td>
+                    <td>${datapoint ? escapeHtml(datapoint.hash) : 'xxx'}</td>
                   </tr>
                   </tr>
                     <td>Message</td>
-                    <td>${datapoint ? datapoint.summary : 'xxx'}</td>
+                    <td>${
+                      datapoint ? escapeHtml(datapoint.summary) : 'xxx'
+                    }</td>
                   </tr>
                   <tr>
                     <td>Author</td>
                     <td>
-                      ${datapoint ? datapoint.author : 'xxx'} at ${
+                      ${datapoint ? escapeHtml(datapoint.author) : 'xxx'} at ${
         datapoint ? datapoint.authorDate.toLocaleString() : 'xxx'
       }
                     </td>
@@ -198,7 +201,9 @@ export default class DytailGraph extends Vue {
       file: data,
       labels: [
         'x',
-        ...this.dimensions.map(it => it.benchmark + ' - ' + it.metric)
+        ...this.dimensions.map(it =>
+          escapeHtml(it.benchmark + ' - ' + it.metric)
+        )
       ],
       colors: this.dimensionsColors(),
       dateWindow: [

--- a/frontend/src/store/modules/detailGraphStore.ts
+++ b/frontend/src/store/modules/detailGraphStore.ts
@@ -281,7 +281,7 @@ export class DetailGraphStore extends VxModule {
         }
       })
 
-      return decodeURIComponent(location.origin + route.href)
+      return location.origin + route.href
     }
   }
 

--- a/frontend/src/util/TextUtils.ts
+++ b/frontend/src/util/TextUtils.ts
@@ -50,7 +50,7 @@ const lightThemeConvert = new Convert({
  *
  * @param input the input string to escape
  */
-function escapeHtml(input: string): string {
+export function escapeHtml(input: string): string {
   const p = document.createElement('p')
   p.appendChild(document.createTextNode(input))
   return p.innerHTML


### PR DESCRIPTION
This PR closes #149 and also fixes an XSS vulnerability in the graph tooltip code.

Dygraph already escapes label names on its own, so those dimensions will look a bit broken when you insert HTML tags.