### PR TITLE
Fix some small bugs

### DIFF
--- a/frontend/src/components/graphs/DimensionSelection.vue
+++ b/frontend/src/components/graphs/DimensionSelection.vue
@@ -5,8 +5,13 @@
         <v-text-field label="Search" v-model="search"></v-text-field>
       </v-col>
       <v-col cols="auto mr-4 mb-2">
-        <v-btn text color="primary" @click="changed([])"
-          >Deselect all metrics
+        <v-btn
+          text
+          color="primary"
+          @click="changed([])"
+          :disabled="selectedDimensions.length === 0"
+        >
+          Deselect all metrics
         </v-btn>
       </v-col>
     </v-row>

--- a/frontend/src/components/graphs/EchartsDetailGraph.vue
+++ b/frontend/src/components/graphs/EchartsDetailGraph.vue
@@ -541,10 +541,17 @@ export default class EchartsDetailGraph extends Vue {
       }
     }
     if (this.commitToCompare !== null) {
-      markLineData.push({
-        xAxis: this.commitToCompare.dataPoint.authorDate,
-        name: 'Comparing…'
-      })
+      // Day equidistant points might move the point and its author date
+      const displayedPoint = this.echartsDataPoints
+        .get(this.referenceDatapoint!.dimension)!
+        .find(it => it.name === this.commitToCompare!.dataPoint.hash)
+
+      if (displayedPoint) {
+        markLineData.push({
+          xAxis: displayedPoint.time,
+          name: 'Comparing…'
+        })
+      }
     }
     const hasReferenceLine = markLineData.length > 0
 
@@ -585,10 +592,13 @@ export default class EchartsDetailGraph extends Vue {
 
     if (this.showReferenceMarkers) {
       const point = this.referenceDatapoint!.dataPoint
+      const displayedPoint = this.echartsDataPoints
+        .get(this.referenceDatapoint!.dimension)!
+        .find(it => it.name === point.hash)
 
       markPointData.push({
         coord: [
-          point.authorDate,
+          displayedPoint!.time,
           point.values.get(this.referenceDatapoint!.dimension)
         ],
         label: {

--- a/frontend/src/components/graphs/GraphPlaceholder.vue
+++ b/frontend/src/components/graphs/GraphPlaceholder.vue
@@ -1,7 +1,7 @@
 <template>
   <v-skeleton-loader
     class="graph-placeholder-loader mt-5"
-    height="500"
+    :height="placeholderHeight"
     loading
     type="image"
   ></v-skeleton-loader>
@@ -10,9 +10,13 @@
 <script lang="ts">
 import Vue from 'vue'
 import Component from 'vue-class-component'
+import { Prop } from 'vue-property-decorator'
 
 @Component
-export default class GraphPlaceholder extends Vue {}
+export default class GraphPlaceholder extends Vue {
+  @Prop({ default: 500 })
+  private placeholderHeight!: number
+}
 </script>
 
 <style>

--- a/frontend/src/components/rundetail/MeasurementsDisplay.vue
+++ b/frontend/src/components/rundetail/MeasurementsDisplay.vue
@@ -374,6 +374,14 @@ export default class MeasurementsDisplay extends Vue {
 
 <!--suppress CssUnresolvedCustomProperty -->
 <style>
+.error-message-tooltip > span {
+  display: inline-block;
+  width: 25ch;
+
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 .measurement-table tbody tr:hover {
   cursor: pointer;
 }

--- a/frontend/src/components/rundetail/MeasurementsDisplay.vue
+++ b/frontend/src/components/rundetail/MeasurementsDisplay.vue
@@ -117,7 +117,7 @@ class Item {
     this.standardDeviation = standardDeviation
     this.standardDeviationPercent = this.computeStandardDeviationPercent(
       value,
-      changePercent
+      standardDeviation
     )
     this.change = change
     this.changePercent = changePercent

--- a/frontend/src/store/modules/detailGraphStore.ts
+++ b/frontend/src/store/modules/detailGraphStore.ts
@@ -56,6 +56,7 @@ export class DetailGraphStore extends VxModule {
   endTime: Date = new Date()
 
   beginYScaleAtZero: boolean = false
+  dayEquidistantGraph: boolean = false
 
   /**
    * Fetches the data necessary to display the data points
@@ -175,6 +176,10 @@ export class DetailGraphStore extends VxModule {
       this.zoomYEndValue = value
     })
 
+    if (link.query.dayEquidistant === 'true') {
+      this.dayEquidistantGraph = true
+    }
+
     if (link.query.dimensions && typeof link.query.dimensions === 'string') {
       const dimensionString = link.query.dimensions
       const parts = dimensionString.split('::')
@@ -278,7 +283,8 @@ export class DetailGraphStore extends VxModule {
             options && options.includeXZoom
               ? orElse(this.zoomXEndValue, this.endTime.getTime())
               : orUndefined(this.endTime.getTime()),
-          dimensions: respectOptions('includeDimensions', this.dimensionString)
+          dimensions: respectOptions('includeDimensions', this.dimensionString),
+          dayEquidistant: this.dayEquidistantGraph ? 'true' : undefined
         }
       })
 

--- a/frontend/src/views/NewRepoDetail.vue
+++ b/frontend/src/views/NewRepoDetail.vue
@@ -317,7 +317,6 @@ export default class RepoDetail extends Vue {
   ]
 
   private selectedGraphComponent: typeof Vue | null = GraphPlaceholder
-  private dayEquidistantGraphSelected: boolean = false
 
   private get repo(): Repo {
     return vxm.repoModule.repoById(this.id)!
@@ -403,6 +402,14 @@ export default class RepoDetail extends Vue {
 
   private get graphSupportsDayEquidistantDisplay() {
     return this.selectedGraphComponent === EchartsDetailGraph
+  }
+
+  private get dayEquidistantGraphSelected() {
+    return vxm.detailGraphModule.dayEquidistantGraph
+  }
+
+  private set dayEquidistantGraphSelected(selected: boolean) {
+    vxm.detailGraphModule.dayEquidistantGraph = selected
   }
 
   private lockDates(date: 'start' | 'end'): void {

--- a/frontend/src/views/NewRepoDetail.vue
+++ b/frontend/src/views/NewRepoDetail.vue
@@ -32,6 +32,8 @@
           </v-card-title>
           <v-card-text>
             <component
+              ref="graphComponent"
+              :placeholderHeight="graphPlaceholderHeight"
               :is="selectedGraphComponent"
               :dimensions="selectedDimensions"
               :beginYAtZero="yStartsAtZero"
@@ -286,6 +288,7 @@ export default class RepoDetail extends Vue {
 
   private today = new Date().toISOString().substr(0, 10)
 
+  private graphPlaceholderHeight: number = 100
   private useMatrixSelector: boolean = false
 
   private startDateMenuOpen: boolean = false
@@ -431,6 +434,11 @@ export default class RepoDetail extends Vue {
   private async retrieveGraphData(): Promise<void> {
     if (this.stopAfterStart()) {
       this.selectedGraphComponent = GraphPlaceholder
+
+      const height = (this.$refs.graphComponent as Vue).$el.clientHeight
+      console.log('Set to', height)
+      this.graphPlaceholderHeight = height
+
       await vxm.detailGraphModule.fetchDetailGraph()
       const correctSeries = this.availableGraphComponents.find(it =>
         it.predicate()

--- a/frontend/src/views/NewRepoDetail.vue
+++ b/frontend/src/views/NewRepoDetail.vue
@@ -352,13 +352,15 @@ export default class RepoDetail extends Vue {
       return
     }
 
+    const durationAsMillis = duration * 1000 * 60 * 60 * 24 // ms * minutes * hours * days
+
     if (this.dateLocked === 'start') {
       vxm.detailGraphModule.endTime = new Date(
-        new Date().setDate(vxm.detailGraphModule.startTime.getDate() + duration)
+        vxm.detailGraphModule.startTime.getTime() + durationAsMillis
       )
     } else {
       vxm.detailGraphModule.startTime = new Date(
-        new Date().setDate(vxm.detailGraphModule.endTime.getDate() - duration)
+        vxm.detailGraphModule.endTime.getTime() - durationAsMillis
       )
     }
     this.retrieveGraphData()

--- a/frontend/src/views/NewRepoDetail.vue
+++ b/frontend/src/views/NewRepoDetail.vue
@@ -442,9 +442,10 @@ export default class RepoDetail extends Vue {
     if (this.stopAfterStart()) {
       this.selectedGraphComponent = GraphPlaceholder
 
-      const height = (this.$refs.graphComponent as Vue).$el.clientHeight
-      console.log('Set to', height)
-      this.graphPlaceholderHeight = height
+      if (this.$refs.graphComponent) {
+        this.graphPlaceholderHeight = (this.$refs
+          .graphComponent as Vue).$el.clientHeight
+      }
 
       await vxm.detailGraphModule.fetchDetailGraph()
       const correctSeries = this.availableGraphComponents.find(it =>

--- a/frontend/src/views/NewRepoDetail.vue
+++ b/frontend/src/views/NewRepoDetail.vue
@@ -79,9 +79,9 @@
                     "
                   >
                     <span v-if="dayEquidistantGraphSelected">
-                      Disable Day-Equistant Graph
+                      Disable Day-Equidistant Graph
                     </span>
-                    <span v-else>Enable Day-Equistant Graph</span>
+                    <span v-else>Enable Day-Equidistant Graph</span>
                   </v-btn>
                   <v-btn
                     @click="yStartsAtZero = !yStartsAtZero"

--- a/frontend/src/views/Queue.vue
+++ b/frontend/src/views/Queue.vue
@@ -30,7 +30,7 @@
             <v-card-text>
               <v-container fluid class="ma-0 pa-0">
                 <v-row justify="end" no-gutters>
-                  <v-col cols="auto">
+                  <v-col cols="auto" class="mb-5" v-if="isWebsiteAdmin">
                     <v-tooltip bottom>
                       <template #activator="{ on }">
                         <v-btn
@@ -40,7 +40,6 @@
                           color="primary"
                           text
                           @click="refetchRepos"
-                          v-if="isWebsiteAdmin"
                         >
                           Refetch all repos
                         </v-btn>
@@ -51,7 +50,7 @@
                       seconds to complete.
                     </v-tooltip>
                   </v-col>
-                  <v-col cols="auto">
+                  <v-col cols="auto" class="mb-5" v-if="isWebsiteAdmin">
                     <v-tooltip left>
                       <template #activator="{ on }">
                         <v-btn


### PR DESCRIPTION
## About
This PR aggregates a few fixes for bugs in #152 and should be able to be merged ~~at any time, when it feels big enough.~~

## Fixes
- Clicking into the duration field and letting it lose focus increments the days fetched by one (or breaks it in other ways)
- Fix spelling of `equidistant`
- Disable "Deselect all metrics if you have none selected"
- The graph placeholder does not have the correct size, so the UI jumps around when updating the graph
- Correctly display Refetch and Cancel all Tasks buttons in the queue when logging in / out
- Include "Day-Equidistant" setting in the permanent link
- Reference marker and compare line do not adjust to day-equidistant mode
- Error button text in Run-Detail is cut off after shrinking the table