### PR TITLE
Respect `tracked` in `getTrackedCommitsBetween`

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/newaccess/committaccess/CommitReadAccess.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/newaccess/committaccess/CommitReadAccess.java
@@ -231,7 +231,8 @@ public class CommitReadAccess {
 
 		try (DBReadAccess db = databaseStorage.acquireReadAccess()) {
 			SelectConditionStep<KnownCommitRecord> query = db.selectFrom(KNOWN_COMMIT)
-				.where(KNOWN_COMMIT.REPO_ID.eq(repoId.getIdAsString()));
+				.where(KNOWN_COMMIT.REPO_ID.eq(repoId.getIdAsString()))
+				.and(KNOWN_COMMIT.TRACKED);
 
 			if (startTime != null) {
 				query = query.and(KNOWN_COMMIT.AUTHOR_DATE.ge(startTime));


### PR DESCRIPTION
Before this patch, `getTrackedCommitsBetween` ignored the `tracked` status of commits and returned *all* commits in the given date range.