### PR TITLE
Commiter date based detail graph

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/newaccess/committaccess/CommitReadAccess.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/newaccess/committaccess/CommitReadAccess.java
@@ -226,6 +226,14 @@ public class CommitReadAccess {
 		}
 	}
 
+	/**
+	 * Gets all tracked commits whose committer date is between the given start and end time.
+	 *
+	 * @param repoId the id of the repo
+	 * @param startTime the start committer time
+	 * @param stopTime the stop committer time
+	 * @return all tracked commits whose committer date is between the given stanrd and end time
+	 */
 	public List<Commit> getTrackedCommitsBetween(RepoId repoId, @Nullable Instant startTime,
 		@Nullable Instant stopTime) {
 
@@ -235,10 +243,10 @@ public class CommitReadAccess {
 				.and(KNOWN_COMMIT.TRACKED);
 
 			if (startTime != null) {
-				query = query.and(KNOWN_COMMIT.AUTHOR_DATE.ge(startTime));
+				query = query.and(KNOWN_COMMIT.COMMITTER_DATE.ge(startTime));
 			}
 			if (stopTime != null) {
-				query = query.and(KNOWN_COMMIT.AUTHOR_DATE.le(stopTime));
+				query = query.and(KNOWN_COMMIT.COMMITTER_DATE.le(stopTime));
 			}
 
 			return query.stream()

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/newaccess/committaccess/CommitReadAccess.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/newaccess/committaccess/CommitReadAccess.java
@@ -227,12 +227,14 @@ public class CommitReadAccess {
 	}
 
 	/**
-	 * Gets all tracked commits whose committer date is between the given start and end time.
+	 * Gets all tracked commits whose <em>committer</em> date is between the given start and end
+	 * time.
 	 *
 	 * @param repoId the id of the repo
 	 * @param startTime the start committer time
 	 * @param stopTime the stop committer time
-	 * @return all tracked commits whose committer date is between the given stanrd and end time
+	 * @return all tracked commits whose committer date is between the given start and end time in no
+	 * 	particular order
 	 */
 	public List<Commit> getTrackedCommitsBetween(RepoId repoId, @Nullable Instant startTime,
 		@Nullable Instant stopTime) {
@@ -255,6 +257,17 @@ public class CommitReadAccess {
 		}
 	}
 
+	/**
+	 * Gets all commits - tracked and untracked - whose <em>author</em> date is between the given
+	 * start and end time.
+	 *
+	 * @param repoId the id of the repo
+	 * @param branchNames the names of all branches to search for commits
+	 * @param startTime the start author time
+	 * @param stopTime the stop author time
+	 * @return all commits whose author date is between the given start and end time in no particular
+	 * 	order
+	 */
 	public List<Commit> getCommitsBetween(RepoId repoId, Collection<BranchName> branchNames,
 		@Nullable Instant startTime, @Nullable Instant stopTime) {
 

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/GraphDetailEndpoint.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/GraphDetailEndpoint.java
@@ -1,5 +1,8 @@
 package de.aaaaaaah.velcom.backend.restapi.endpoints;
 
+import static java.util.stream.Collectors.toCollection;
+import static java.util.stream.Collectors.toMap;
+
 import de.aaaaaaah.velcom.backend.access.BenchmarkReadAccess;
 import de.aaaaaaah.velcom.backend.access.entities.Dimension;
 import de.aaaaaaah.velcom.backend.access.entities.DimensionInfo;
@@ -20,12 +23,16 @@ import de.aaaaaaah.velcom.backend.restapi.jsonobjects.JsonDimension;
 import de.aaaaaaah.velcom.shared.util.Pair;
 import io.micrometer.core.annotation.Timed;
 import java.time.Instant;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -96,11 +103,18 @@ public class GraphDetailEndpoint {
 		List<FullCommit> commits = new ArrayList<>(commitAccess.promoteCommits(
 			commitAccess.getTrackedCommitsBetween(repoId, startTime, endTime)
 		));
-		commits.sort(Comparator.comparing(Commit::getAuthorDate));
-		Set<CommitHash> hashes = commits.stream().map(Commit::getHash).collect(Collectors.toSet());
+
+		Map<CommitHash, FullCommit> hashes = commits.stream()
+			.collect(toMap(
+				Commit::getHash,
+				it -> it
+			));
+
+		commits = topologicalSort(commits, hashes);
+		commits.sort(Comparator.comparing(Commit::getCommitterDate));
 
 		// Obtain the relevant runs
-		Map<CommitHash, Run> runs = benchmarkAccess.getLatestRuns(repoId, hashes);
+		Map<CommitHash, Run> runs = benchmarkAccess.getLatestRuns(repoId, hashes.keySet());
 
 		// Finally, put everything together.
 		List<JsonDimension> jsonDimensions = existingDimensions.stream()
@@ -111,13 +125,79 @@ public class GraphDetailEndpoint {
 				commit.getHash().getHash(),
 				commit.getParentHashes().stream().map(CommitHash::getHash).collect(Collectors.toList()),
 				commit.getAuthor(),
-				commit.getAuthorDate().getEpochSecond(),
+				commit.getCommitterDate().getEpochSecond(),
 				commit.getSummary(),
 				extractValuesFromCommit(existingDimensions, runs, commit)
 			))
 			.collect(Collectors.toList());
 
 		return new GetReply(jsonDimensions, jsonGraphCommits);
+	}
+
+	/**
+	 * @param commits the commits to sort
+	 * @param hashes a map from hash to commit <em>for all commits in the commits list</em>
+	 * @return a mutable list containing a topological ordering of the input commits
+	 */
+	private List<FullCommit> topologicalSort(List<FullCommit> commits,
+		Map<CommitHash, FullCommit> hashes) {
+
+		// Based on Khan's Algorithm
+		// https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm
+
+		List<FullCommit> topologicallySorted = new ArrayList<>();
+
+		Queue<FullCommit> leaves = commits.stream()
+			// Only consider commits in our commits list. Throw away all children *not* in the list, as
+			// we are focusing on a small part of the graph and trying to sort only this part
+			// topologically.
+			// If we do not throw them away, we will find children outside the range, leading to too few
+			// found leaf nodes
+			.filter(it -> it.getChildHashes().stream().noneMatch(hashes::containsKey))
+			.collect(toCollection(ArrayDeque::new));
+
+		// We can not modify the actual children or remove edges. This is one of the pre-requisites for
+		// Khan's Algorithm though, as it deletes all explored edges starting with the leaves.
+		// Furthermore, not all children should be considered - only those that we know are in the
+		// commits list. All other children are outside the time range and irrelevant, as they should
+		// not appear in the graph.
+		// If we do not exclude those here, we will have too many children and won't always end up with
+		// *zero* leftover children, causing the Commit to not be recognized as a new leaf.
+		Map<FullCommit, Set<CommitHash>> parentChildMap = commits.stream()
+			.collect(toMap(
+				it -> it,
+				it -> it.getChildHashes().stream()
+					.filter(hashes::containsKey)
+					.collect(toCollection(HashSet::new))
+			));
+
+		while (!leaves.isEmpty()) {
+			FullCommit commit = leaves.poll();
+			topologicallySorted.add(commit);
+
+			for (CommitHash parentHash : commit.getParentHashes()) {
+				FullCommit parentCommit = hashes.get(parentHash);
+
+				// outside of our time bound (i.e. commits i.e. hashes)
+				if (parentCommit == null) {
+					continue;
+				}
+
+				Set<CommitHash> existingchildren = parentChildMap.get(parentCommit);
+				existingchildren.remove(commit.getHash());
+
+				// This commit has no other children in our time window -> it is now a leaf!
+				if (existingchildren.isEmpty()) {
+					leaves.add(parentCommit);
+				}
+			}
+		}
+
+		// We appended to the end, so we now need to reverse it. Our leaves are the first entries
+		// currently, but they should be the last.
+		Collections.reverse(topologicallySorted);
+
+		return topologicallySorted;
 	}
 
 	private static List<Object> extractValuesFromCommit(List<DimensionInfo> dimensions,
@@ -134,7 +214,7 @@ public class GraphDetailEndpoint {
 		}
 
 		Map<Dimension, Measurement> measurements = optionalMeasurements.get().stream()
-			.collect(Collectors.toMap(Measurement::getDimension, m -> m));
+			.collect(toMap(Measurement::getDimension, m -> m));
 
 		return dimensions.stream()
 			.map(dim -> {
@@ -183,18 +263,18 @@ public class GraphDetailEndpoint {
 		private final String hash;
 		private final List<String> parents;
 		private final String author;
-		private final long authorDate;
+		private final long committerDate;
 		private final String summary;
 		// A list of Doubles and Strings
 		private final List<Object> values;
 
-		public JsonGraphCommit(String hash, List<String> parents, String author, long authorDate,
+		public JsonGraphCommit(String hash, List<String> parents, String author, long comitterDate,
 			String summary, List<Object> values) {
 
 			this.hash = hash;
 			this.parents = parents;
 			this.author = author;
-			this.authorDate = authorDate;
+			this.committerDate = comitterDate;
 			this.summary = summary;
 			this.values = values;
 		}
@@ -211,8 +291,8 @@ public class GraphDetailEndpoint {
 			return author;
 		}
 
-		public long getAuthorDate() {
-			return authorDate;
+		public long getCommitterDate() {
+			return committerDate;
 		}
 
 		public String getSummary() {

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/GraphDetailEndpoint.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/GraphDetailEndpoint.java
@@ -136,7 +136,8 @@ public class GraphDetailEndpoint {
 
 	/**
 	 * @param commits the commits to sort
-	 * @param hashes a map from hash to commit <em>for all commits in the commits list</em>
+	 * @param hashes a map from hash to commit <em>for <strong>exactly</strong> the commits in the
+	 * 	commits list</em>
 	 * @return a mutable list containing a topological ordering of the input commits
 	 */
 	private List<FullCommit> topologicalSort(List<FullCommit> commits,

--- a/docs/public-api/public-api.v2.yaml
+++ b/docs/public-api/public-api.v2.yaml
@@ -518,7 +518,7 @@ paths:
                             $ref: '#/components/schemas/CommitHash'
                         author:
                           type: string
-                        author_date:
+                        committer_date:
                           $ref: '#/components/schemas/Time'
                         summary:
                           type: string
@@ -539,7 +539,7 @@ paths:
                         - hash
                         - parents
                         - author
-                        - author_date
+                        - committer_date
                         - summary
                         - values
                 required:

--- a/frontend/src/components/dialogs/DetailDatapointDialog.vue
+++ b/frontend/src/components/dialogs/DetailDatapointDialog.vue
@@ -132,7 +132,7 @@ export default class DetailDatapointDialog extends Vue {
       vxm.detailGraphModule.selectedRepoId,
       this.selectedDatapoint.hash,
       this.selectedDatapoint.author,
-      this.selectedDatapoint.authorDate,
+      this.selectedDatapoint.committerDate,
       this.selectedDatapoint.summary
     )
   }

--- a/frontend/src/components/graphs/Dygraph-Detail.vue
+++ b/frontend/src/components/graphs/Dygraph-Detail.vue
@@ -56,7 +56,7 @@ export default class DytailGraph extends Vue {
 
     // One array entry per datapoint. That array contains all values: [x, dim1, dim2, ...]
     for (let i = 0; i < this.datapoints.length; i++) {
-      data[i] = [this.datapoints[i].authorDate.getTime()]
+      data[i] = [this.datapoints[i].committerDate.getTime()]
     }
 
     for (const dimension of this.dimensions) {

--- a/frontend/src/components/graphs/EchartsDetailGraph.vue
+++ b/frontend/src/components/graphs/EchartsDetailGraph.vue
@@ -149,7 +149,7 @@ export default class EchartsDetailGraph extends Vue {
   private get minDateValue(): number {
     const min = Math.min.apply(
       Math,
-      this.detailDataPoints.map(it => it.authorDate.getTime())
+      this.detailDataPoints.map(it => it.committerDate.getTime())
     )
     return min || 0
   }
@@ -157,7 +157,7 @@ export default class EchartsDetailGraph extends Vue {
   private get maxDateValue(): number {
     const max = Math.max.apply(
       Math,
-      this.detailDataPoints.map(it => it.authorDate.getTime())
+      this.detailDataPoints.map(it => it.committerDate.getTime())
     )
     return max || 0
   }
@@ -336,7 +336,7 @@ export default class EchartsDetailGraph extends Vue {
       this.detailDataPoints,
       key =>
         // round to day
-        Math.floor(key.authorDate.getTime() / millisInDay) * millisInDay
+        Math.floor(key.committerDate.getTime() / millisInDay) * millisInDay
     )
 
     return Array.from(dayGroups.entries()).flatMap(([day, points]) => {
@@ -403,7 +403,7 @@ export default class EchartsDetailGraph extends Vue {
       }
 
       return new EchartsDataPoint(
-        point.authorDate,
+        point.committerDate,
         pointValue,
         symbol,
         point.hash,

--- a/frontend/src/components/graphs/NewDytailGraph.vue
+++ b/frontend/src/components/graphs/NewDytailGraph.vue
@@ -95,7 +95,7 @@ export default class DytailGraph extends Vue {
   private get minDateValue(): number {
     const min = Math.min.apply(
       Math,
-      this.datapoints.map(it => it.authorDate.getTime())
+      this.datapoints.map(it => it.committerDate.getTime())
     )
     return min || 0
   }
@@ -103,7 +103,7 @@ export default class DytailGraph extends Vue {
   private get maxDateValue(): number {
     const max = Math.max.apply(
       Math,
-      this.datapoints.map(it => it.authorDate.getTime())
+      this.datapoints.map(it => it.committerDate.getTime())
     )
     return max || 0
   }
@@ -118,7 +118,7 @@ export default class DytailGraph extends Vue {
   // eslint-disable-next-line no-undef
   private tooltipFormatter(legendData: dygraphs.LegendData) {
     const datapoint: DetailDataPoint | undefined = this.datapoints.find(
-      point => point.authorDate.getTime() === legendData.x
+      point => point.committerDate.getTime() === legendData.x
     )
     if (datapoint) {
       const data = legendData.series.slice()
@@ -155,7 +155,7 @@ export default class DytailGraph extends Vue {
                     <td>Author</td>
                     <td>
                       ${datapoint ? escapeHtml(datapoint.author) : 'xxx'} at ${
-        datapoint ? datapoint.authorDate.toLocaleString() : 'xxx'
+        datapoint ? datapoint.committerDate.toLocaleString() : 'xxx'
       }
                     </td>
                   </tr>
@@ -181,7 +181,7 @@ export default class DytailGraph extends Vue {
 
     // One array entry per datapoint. That array contains all values: [x, dim1, dim2, ...]
     for (let i = 0; i < this.datapoints.length; i++) {
-      data[i] = [this.datapoints[i].authorDate.getTime()]
+      data[i] = [this.datapoints[i].committerDate.getTime()]
     }
 
     for (const dimension of this.dimensions) {

--- a/frontend/src/components/repodetail/RepoCommitOverview.vue
+++ b/frontend/src/components/repodetail/RepoCommitOverview.vue
@@ -187,7 +187,7 @@ export default class RepoCommitOverview extends Vue {
           this.repo,
           datapoint.hash,
           datapoint.author,
-          datapoint.authorDate,
+          datapoint.committerDate,
           datapoint.summary
         )
       }

--- a/frontend/src/store/modules/detailGraphStore.ts
+++ b/frontend/src/store/modules/detailGraphStore.ts
@@ -316,8 +316,8 @@ export class DetailGraphStore extends VxModule {
     let visibleDataPoints = 0
     for (const point of this._detailGraph) {
       if (
-        (startValue === null || point.authorDate.getTime() >= startValue) &&
-        (endValue === null || point.authorDate.getTime() <= endValue)
+        (startValue === null || point.committerDate.getTime() >= startValue) &&
+        (endValue === null || point.committerDate.getTime() <= endValue)
       ) {
         visibleDataPoints += this._selectedDimensions.length
       }

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -427,7 +427,7 @@ export class DetailDataPoint {
   readonly hash: CommitHash
   readonly parents: CommitHash[]
   readonly author: string
-  readonly authorDate: Date
+  readonly committerDate: Date
   readonly summary: string
   // TODO: Figure out if the map wastes too much memory
   readonly values: Map<DimensionId, DetailDataPointValue>
@@ -436,14 +436,14 @@ export class DetailDataPoint {
     hash: CommitHash,
     parents: CommitHash[],
     author: string,
-    authorDate: Date,
+    committerDate: Date,
     summary: string,
     values: CustomKeyEqualsMap<DimensionId, DetailDataPointValue>
   ) {
     this.hash = hash
     this.parents = parents
     this.author = author
-    this.authorDate = authorDate
+    this.committerDate = committerDate
     this.summary = summary
     this.values = values
   }

--- a/frontend/src/util/GraphJsonHelper.ts
+++ b/frontend/src/util/GraphJsonHelper.ts
@@ -32,7 +32,7 @@ export function detailDataPointFromJson(
     json.hash,
     json.parents,
     json.author,
-    new Date(json.author_date * 1000),
+    new Date(json.committer_date * 1000),
     json.summary,
     map
   )

--- a/frontend/src/util/StorePersistenceUtilities.ts
+++ b/frontend/src/util/StorePersistenceUtilities.ts
@@ -78,7 +78,7 @@ function hydrateDetailPoint(it: DetailDataPoint) {
     it.hash,
     it.parents,
     it.author,
-    new Date(it.authorDate),
+    new Date(it.committerDate),
     it.summary,
     new CustomKeyEqualsMap(
       it.values,

--- a/frontend/src/util/StorePersistenceUtilities.ts
+++ b/frontend/src/util/StorePersistenceUtilities.ts
@@ -135,7 +135,8 @@ export function detailGraphStoreToJson(store: DetailGraphStore): string {
     firstFreeColorIndex: (store as any).firstFreeColorIndex,
     colorIndexMap: Array.from((store as any).colorIndexMap.entries()),
     commitToCompare: serializeDimensionDetailPoint(store.commitToCompare),
-    beginYScaleAtZero: store.beginYScaleAtZero
+    beginYScaleAtZero: store.beginYScaleAtZero,
+    dayEquidistantGraph: store.dayEquidistantGraph
   })
 }
 // </editor-fold>

--- a/frontend/src/views/NewRepoDetail.vue
+++ b/frontend/src/views/NewRepoDetail.vue
@@ -295,7 +295,7 @@ export default class RepoDetail extends Vue {
   /**
    * The value of the "duration" input field. Not applied until saveDuration is called.
    */
-  private temporaryDuration: number = 0
+  private temporaryDuration: string = '' + this.duration
 
   private startDateMenuOpen: boolean = false
   private stopDateMenuOpen: boolean = false
@@ -353,7 +353,7 @@ export default class RepoDetail extends Vue {
   }
 
   private saveDuration() {
-    const duration = this.temporaryDuration
+    const duration = parseInt(this.temporaryDuration)
 
     if (isNaN(duration)) {
       return


### PR DESCRIPTION
## About
Previously the detail graph was based on the author date (maybe to prevent rebases from being as annoying). With the introduction of the Day-Equidistant graph, rebases can actually be displayed in a quite alright-ish manner, even when sorting by committer date.

This makes the detail graph's arrows and layout a bit less confusing in projects where commits are authored long before they are rebased into the main branch(es).

#### Strictly date-based
![grafik](https://user-images.githubusercontent.com/20284688/98024695-f5f55600-1e08-11eb-9a04-4e4c48452077.png)

#### Day-Equidistant
![grafik](https://user-images.githubusercontent.com/20284688/98024717-00175480-1e09-11eb-9778-2bc6051124ff.png)

## Further work
Teach the Dytail Graph what "Day-Equidistant" means.

Closes #151 