### PR TITLE
Empty queue using a dedicated endpoint

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/QueueEndpoint.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/QueueEndpoint.java
@@ -39,7 +39,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
 @Path("/queue")
@@ -111,11 +110,11 @@ public class QueueEndpoint {
 
 	@DELETE
 	@Timed(histogram = true)
-	public Response emptyQueue(@Auth RepoUser user) throws NoSuchTaskException {
+	public void emptyQueue(@Auth RepoUser user) throws NoSuchTaskException {
 		if (user.getRepoId().isEmpty()) {
 			user.guardAdminAccess();
 			queue.deleteAllTasks();
-			return Response.ok().build();
+			return;
 		}
 
 		RepoId repoId = user.getRepoId().get();
@@ -128,14 +127,12 @@ public class QueueEndpoint {
 			.collect(Collectors.toList());
 
 		queue.deleteTasks(tasksToDelete);
-
-		return Response.ok().build();
 	}
 
 	@DELETE
 	@Path("{taskId}")
 	@Timed(histogram = true)
-	public Response deleteTask(@Auth RepoUser user, @PathParam("taskId") UUID taskId)
+	public void deleteTask(@Auth RepoUser user, @PathParam("taskId") UUID taskId)
 		throws NoSuchTaskException {
 		Task task = queue.getTask(new TaskId(taskId));
 		if (task.getRepoId().isEmpty()) {
@@ -145,14 +142,12 @@ public class QueueEndpoint {
 		}
 
 		queue.deleteTasks(List.of(new TaskId(taskId)));
-
-		return Response.ok().build();
 	}
 
 	@PATCH
 	@Path("{taskId}")
 	@Timed(histogram = true)
-	public Response patchTask(@Auth RepoUser user, @PathParam("taskId") UUID taskId)
+	public void patchTask(@Auth RepoUser user, @PathParam("taskId") UUID taskId)
 		throws NoSuchTaskException {
 		user.guardAdminAccess();
 
@@ -160,8 +155,6 @@ public class QueueEndpoint {
 		Task task = queue.getTask(new TaskId(taskId));
 
 		queue.prioritizeTask(task.getId(), TaskPriority.MANUAL);
-
-		return Response.ok().build();
 	}
 
 	@POST

--- a/docs/public-api/public-api.v2.yaml
+++ b/docs/public-api/public-api.v2.yaml
@@ -33,8 +33,8 @@ paths:
       summary: prioritize task
       operationId: patch-queue-taskid
       responses:
-        '200':
-          description: OK
+        '204':
+          description: No Content
         '404':
           description: Not Found
       description: Prioritize a task such that it moves to (or near) the top of the queue.
@@ -89,14 +89,15 @@ paths:
       summary: empty queue
       operationId: delete-queue
       responses:
-        '200':
-          description: OK
+        '204':
+          description: No Content
       security:
         - admin_credentials: []
       description: |-
-        Deletes *all tasks* in the Queue the user has access to. If a Repo-Admin executes this, only tasks in their repo will be cancelled.
+        Deletes *all tasks* in the Queue the user has access to.
 
-        If the website admin executes this, *all* tasks in the queue will be cancelled and the queue will be empty afterwards.
+        If a repo admin executes this, only tasks in *their repo* will be cancelled.
+        If the website admin executes this, *all* tasks in the queue will be cancelled.
   /queue/upload/tar:
     post:
       summary: benchmark tar file

--- a/docs/public-api/public-api.v2.yaml
+++ b/docs/public-api/public-api.v2.yaml
@@ -27,7 +27,7 @@ paths:
           description: Not Found
       operationId: delete-queue-taskid
       security:
-        - admin_credentials: []
+        - repo_admin_credentials: []
       description: 'Delete a task from the queue. If the task is currently being benchmarked, this also tries to abort the task.'
     patch:
       summary: prioritize task
@@ -84,7 +84,19 @@ paths:
                   - tasks
                   - runners
       operationId: get-queue
-      description: "Query the queue's current status"
+      description: Query the queue's current status
+    delete:
+      summary: empty queue
+      operationId: delete-queue
+      responses:
+        '200':
+          description: OK
+      security:
+        - admin_credentials: []
+      description: |-
+        Deletes *all tasks* in the Queue the user has access to. If a Repo-Admin executes this, only tasks in their repo will be cancelled.
+
+        If the website admin executes this, *all* tasks in the queue will be cancelled and the queue will be empty afterwards.
   /queue/upload/tar:
     post:
       summary: benchmark tar file

--- a/frontend/src/store/modules/queueStore.ts
+++ b/frontend/src/store/modules/queueStore.ts
@@ -114,6 +114,17 @@ export class QueueStore extends VxModule {
   }
 
   /**
+   * Cancels all tasks currently in the queue the user has access to.
+   *
+   * @returns {Promise<void>} a promise completing with an optional error
+   */
+  @action
+  async dispatchDeleteAllOpenTasks(): Promise<void> {
+    await axios.delete(`/queue/`)
+    await this.fetchQueue()
+  }
+
+  /**
    * Fetches the runner output for a given task. Returns null if the task is not
    * currently being executed.
    *


### PR DESCRIPTION
## About
Before this patch the "Empty Queue" functionality was implemented in the frontend by making one HTTP request per task.

Now a proper endpoint was added that deletes all commits in the database in one go.


### View as repo admin
![image](https://user-images.githubusercontent.com/20284688/99000722-08bf0780-253a-11eb-9099-4f6b43e9c892.png)


### View as site admin
![image](https://user-images.githubusercontent.com/20284688/99000703-fe047280-2539-11eb-9698-eba74f41710f.png)
