### PR TITLE
Allow up to 2GB in POST request payloads (TAR upload)

### DIFF
--- a/docs/nginx.conf
+++ b/docs/nginx.conf
@@ -50,6 +50,10 @@ http {
         access_log /var/log/nginx/access.log;
         error_log /var/log/nginx/error.log;
 
+
+        ## Allow large POSTs (needed for TAR uploads)
+        client_max_body_size 2000M;
+
         ##
         # Gzip Settings
         ##


### PR DESCRIPTION
The default nginx request payload (1MB) is too small to fit any proper tar.