### PR TITLE
Re-add "One up" endpoint

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/newaccess/committaccess/CommitReadAccess.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/newaccess/committaccess/CommitReadAccess.java
@@ -265,20 +265,22 @@ public class CommitReadAccess {
 	public List<CommitHash> getDescendantCommits(Commit root) {
 		String query = "WITH RECURSIVE rec(hash) AS (\n"
 			+ "  VALUES (?)\n"                                    // <-- Binding #1 - Root hash
-			+ "\n"
+			+ "  \n"
 			+ "  UNION\n"
-			+ "\n"
+			+ "  \n"
 			+ "  SELECT commit_relationship.child_hash\n"
 			+ "  FROM commit_relationship\n"
 			+ "  JOIN rec\n"
-			+ "  ON rec.hash = commit_relationship.parent_hash\n"
+			+ "    ON rec.hash = commit_relationship.parent_hash\n"
 			+ "  WHERE repo_id = ?\n"                             // <-- Binding #2 - repo id
 			+ ")\n"
 			+ "\n"
-			+ "SELECT rec.hash "
-			+ " FROM rec\n"
-			+ "JOIN known_commit ON rec.hash = known_commit.hash\n"
-			+ "WHERE known_commit.tracked;";
+			+ "SELECT rec.hash \n"
+			+ "FROM rec\n"
+			+ "JOIN known_commit\n"
+			+ "  ON rec.hash = known_commit.hash\n"
+			+ "WHERE known_commit.tracked\n"
+			+ "";
 
 		try (DBReadAccess db = databaseStorage.acquireReadAccess()) {
 			return db.dsl().fetchLazy(query, root.getHashAsString(), root.getRepoId().getIdAsString())

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/newaccess/committaccess/CommitReadAccess.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/newaccess/committaccess/CommitReadAccess.java
@@ -259,6 +259,37 @@ public class CommitReadAccess {
 	}
 
 	/**
+	 * @param root the root commit
+	 * @return all tracked commits descending from the given root.
+	 */
+	public List<CommitHash> getDescendantCommits(Commit root) {
+		String query = "WITH RECURSIVE rec(hash) AS (\n"
+			+ "  VALUES (?)\n"                                    // <-- Binding #1 - Root hash
+			+ "\n"
+			+ "  UNION\n"
+			+ "\n"
+			+ "  SELECT commit_relationship.child_hash\n"
+			+ "  FROM commit_relationship\n"
+			+ "  JOIN rec\n"
+			+ "  ON rec.hash = commit_relationship.parent_hash\n"
+			+ "  WHERE repo_id = ?\n"                             // <-- Binding #2 - repo id
+			+ ")\n"
+			+ "\n"
+			+ "SELECT rec.hash "
+			+ " FROM rec\n"
+			+ "JOIN known_commit ON rec.hash = known_commit.hash\n"
+			+ "WHERE known_commit.tracked;";
+
+		try (DBReadAccess db = databaseStorage.acquireReadAccess()) {
+			return db.dsl().fetchLazy(query, root.getHashAsString(), root.getRepoId().getIdAsString())
+				.stream()
+				.map(record -> (String) record.getValue(0))
+				.map(CommitHash::new)
+				.collect(toList());
+		}
+	}
+
+	/**
 	 * Gets all commits - tracked and untracked - whose <em>author</em> date is between the given
 	 * start and end time.
 	 *

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/newaccess/committaccess/CommitReadAccess.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/newaccess/committaccess/CommitReadAccess.java
@@ -259,10 +259,11 @@ public class CommitReadAccess {
 	}
 
 	/**
-	 * @param root the root commit
+	 * @param repoId the id of the root commit's repo
+	 * @param rootHash the hash of the root commit
 	 * @return all tracked commits descending from the given root.
 	 */
-	public List<CommitHash> getDescendantCommits(Commit root) {
+	public List<CommitHash> getDescendantCommits(RepoId repoId, CommitHash rootHash) {
 		String query = "WITH RECURSIVE rec(hash) AS (\n"
 			+ "  VALUES (?)\n"                                    // <-- Binding #1 - Root hash
 			+ "  \n"
@@ -283,7 +284,7 @@ public class CommitReadAccess {
 			+ "";
 
 		try (DBReadAccess db = databaseStorage.acquireReadAccess()) {
-			return db.dsl().fetchLazy(query, root.getHashAsString(), root.getRepoId().getIdAsString())
+			return db.dsl().fetchLazy(query, rootHash.getHash(), repoId.getIdAsString())
 				.stream()
 				.map(record -> (String) record.getValue(0))
 				.map(CommitHash::new)

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/newaccess/committaccess/CommitReadAccess.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/newaccess/committaccess/CommitReadAccess.java
@@ -13,6 +13,7 @@ import de.aaaaaaah.velcom.backend.newaccess.committaccess.entities.FullCommit;
 import de.aaaaaaah.velcom.backend.newaccess.committaccess.exceptions.NoSuchCommitException;
 import de.aaaaaaah.velcom.backend.newaccess.repoaccess.entities.BranchName;
 import de.aaaaaaah.velcom.backend.newaccess.repoaccess.entities.RepoId;
+import de.aaaaaaah.velcom.backend.restapi.exception.NoSuchDimensionException;
 import de.aaaaaaah.velcom.backend.storage.db.DBReadAccess;
 import de.aaaaaaah.velcom.backend.storage.db.DatabaseStorage;
 import java.time.Instant;
@@ -99,6 +100,12 @@ public class CommitReadAccess {
 		} catch (DataAccessException e) {
 			throw new NoSuchCommitException(e, repoId, commitHash);
 		}
+	}
+
+	public void guardCommitExists(RepoId repoId, CommitHash commitHash)
+		throws NoSuchDimensionException {
+
+		getCommit(repoId, commitHash);
 	}
 
 	public List<Commit> getCommits(RepoId repoId, Collection<CommitHash> commitHashes) {

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/QueueEndpoint.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/QueueEndpoint.java
@@ -136,9 +136,9 @@ public class QueueEndpoint {
 	}
 
 	@DELETE
-	@Path("{taskId}")
+	@Path("{taskid}")
 	@Timed(histogram = true)
-	public void deleteTask(@Auth RepoUser user, @PathParam("taskId") UUID taskId)
+	public void deleteTask(@Auth RepoUser user, @PathParam("taskid") UUID taskId)
 		throws NoSuchTaskException {
 		Task task = queue.getTask(new TaskId(taskId));
 		if (task.getRepoId().isEmpty()) {
@@ -151,9 +151,9 @@ public class QueueEndpoint {
 	}
 
 	@PATCH
-	@Path("{taskId}")
+	@Path("{taskid}")
 	@Timed(histogram = true)
-	public void patchTask(@Auth RepoUser user, @PathParam("taskId") UUID taskId)
+	public void patchTask(@Auth RepoUser user, @PathParam("taskid") UUID taskId)
 		throws NoSuchTaskException {
 		user.guardAdminAccess();
 
@@ -164,11 +164,11 @@ public class QueueEndpoint {
 	}
 
 	@POST
-	@Path("commit/{repoId}/{hash}")
+	@Path("commit/{repoid}/{hash}")
 	@Timed(histogram = true)
 	public PostCommitReply addCommit(
 		@Auth RepoUser user,
-		@PathParam("repoId") UUID repoUuid,
+		@PathParam("repoid") UUID repoUuid,
 		@PathParam("hash") String commitHashString
 	) throws NoSuchRepoException {
 		RepoId repoId = new RepoId(repoUuid);
@@ -201,11 +201,11 @@ public class QueueEndpoint {
 
 
 	@POST
-	@Path("commit/{repoId}/{hash}/one-up")
+	@Path("commit/{repoid}/{hash}/one-up")
 	@Timed(histogram = true)
 	public PostOneUpReply PostOneUpReply(
 		@Auth RepoUser user,
-		@PathParam("repoId") UUID repoUuid,
+		@PathParam("repoid") UUID repoUuid,
 		@PathParam("hash") String commitHashString
 	) throws NoSuchRepoException {
 		RepoId repoId = new RepoId(repoUuid);
@@ -256,10 +256,10 @@ public class QueueEndpoint {
 		return new UploadTarReply(JsonTask.fromTask(task.get(), commitReadAccess));
 	}
 
-	@Path("task/{taskId}")
+	@Path("task/{taskid}")
 	@GET
 	@Timed(histogram = true)
-	public GetTaskInfoReply getTask(@PathParam("taskId") UUID taskId) {
+	public GetTaskInfoReply getTask(@PathParam("taskid") UUID taskId) {
 		int indexOfTask = 0;
 		Optional<Task> foundTask = Optional.empty();
 		for (Task task : queue.getAllTasksInOrder()) {
@@ -289,10 +289,10 @@ public class QueueEndpoint {
 		);
 	}
 
-	@Path("task/{taskId}/progress")
+	@Path("task/{taskid}/progress")
 	@GET
 	@Timed(histogram = true)
-	public GetTaskOutputReply getRunnerOutput(@PathParam("taskId") UUID taskId) {
+	public GetTaskOutputReply getRunnerOutput(@PathParam("taskid") UUID taskId) {
 		Optional<KnownRunner> worker = dispatcher.getKnownRunners().stream()
 			.filter(it -> it.getCurrentTask().isPresent())
 			.filter(it -> it.getCurrentTask().get().getId().getId().equals(taskId))

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/QueueEndpoint.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/QueueEndpoint.java
@@ -211,8 +211,8 @@ public class QueueEndpoint {
 		RepoId repoId = new RepoId(repoUuid);
 		user.guardRepoAccess(repoId);
 
-		Commit rootCommit = commitReadAccess.getCommit(repoId, new CommitHash(commitHashString));
-		List<CommitHash> hashes = commitReadAccess.getDescendantCommits(rootCommit);
+		CommitHash rootHash = new CommitHash(commitHashString);
+		List<CommitHash> hashes = commitReadAccess.getDescendantCommits(repoId, rootHash);
 
 		String author = user.isAdmin() ? "Admin" : "Repo-Admin";
 		queue.addCommits(author, repoId, hashes, TaskPriority.MANUAL);

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/QueueEndpoint.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/QueueEndpoint.java
@@ -184,8 +184,7 @@ public class QueueEndpoint {
 		user.guardRepoAccess(repoId);
 
 		repoReadAccess.guardRepoExists(repoId);
-		// Ensure the commit exists, 404s otherwise
-		Commit commit = commitReadAccess.getCommit(repoId, commitHash);
+		commitReadAccess.guardCommitExists(repoId, commitHash);
 		// If at any point between these checks and inserting the task the repo is deleted, JOOQ will
 		// throw a DataAccessException (I believe) and this endpoint will return a 500. But the chance
 		// of that happening is low enough that putting in the effort to perform the checks in an atomic

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/QueueEndpoint.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/QueueEndpoint.java
@@ -213,9 +213,11 @@ public class QueueEndpoint {
 		@PathParam("hash") String commitHashString
 	) throws NoSuchRepoException {
 		RepoId repoId = new RepoId(repoUuid);
-		user.guardRepoAccess(repoId);
-
 		CommitHash rootHash = new CommitHash(commitHashString);
+
+		user.guardRepoAccess(repoId);
+		commitReadAccess.guardCommitExists(repoId, rootHash);
+
 		List<CommitHash> hashes = commitReadAccess.getDescendantCommits(repoId, rootHash);
 
 		String author = getAuthor(user.isAdmin());

--- a/docs/public-api/public-api.v2.yaml
+++ b/docs/public-api/public-api.v2.yaml
@@ -761,11 +761,11 @@ paths:
 
         The `start_time`, `end_time` and `duration` parameters work the same as for the `/graph/detail/{repoid}` endpoint.
         If some of the repos don't exist, they may be omitted from the response.
-  '/queue/task/{taskId}/progress':
+  '/queue/task/{taskid}/progress':
     parameters:
       - schema:
           type: string
-        name: taskId
+        name: taskid
         in: path
         required: true
     get:
@@ -792,7 +792,7 @@ paths:
                   - output
         '404':
           description: If the given task is not in the queue or not currently worked on by a runner.
-      operationId: get-queue-task-taskId-progress
+      operationId: get-queue-task-taskid-progress
       description: Returns the last 100 lines the benchmark script working on the given task reported on its standard error stream.
   /listener/fetch-all:
     post:

--- a/docs/public-api/public-api.v2.yaml
+++ b/docs/public-api/public-api.v2.yaml
@@ -863,6 +863,8 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Task'
+        '404':
+          description: Commit Not Found
       description: Benchmarks the given commit and all tracked descendants.
       security:
         - repo_admin_credentials: []

--- a/docs/public-api/public-api.v2.yaml
+++ b/docs/public-api/public-api.v2.yaml
@@ -836,6 +836,36 @@ paths:
           description: Not Found
       operationId: get-queue-task-taskId
       description: Return the task and its position in the queue.
+  '/queue/commit/{repoid}/{hash}/one-up':
+    parameters:
+      - schema:
+          type: string
+        name: repoid
+        in: path
+        required: true
+      - schema:
+          type: string
+        name: hash
+        in: path
+        required: true
+    post:
+      summary: One-up benchmark
+      operationId: post-queue-commit-repoid-hash-one-up
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tasks:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Task'
+      description: Benchmarks the given commit and all tracked descendants.
+      security:
+        - repo_admin_credentials: []
 components:
   schemas:
     CommitHash:

--- a/frontend/src/components/CommitBenchmarkActions.vue
+++ b/frontend/src/components/CommitBenchmarkActions.vue
@@ -3,17 +3,17 @@
     <v-tooltip top v-if="isAdmin">
       <template #activator="{ on }">
         <v-btn v-on="on" icon @click="benchmark">
-          <v-icon class="rocket">{{
-            hasExistingBenchmark ? rebenchmarkIcon : benchmarkIcon
-          }}</v-icon>
+          <v-icon class="rocket">
+            {{ hasExistingBenchmark ? rebenchmarkIcon : benchmarkIcon }}
+          </v-icon>
         </v-btn>
       </template>
-      <span v-if="hasExistingBenchmark"
-        >Re-runs all benchmarks for this commit</span
-      >
+      <span v-if="hasExistingBenchmark">
+        Re-runs all benchmarks for this commit
+      </span>
       <span v-else>Runs all benchmarks for this commit</span>
     </v-tooltip>
-    <v-tooltip top v-if="isAdmin && oneUpImplemented">
+    <v-tooltip top v-if="isAdmin">
       <template #activator="{ on }">
         <v-btn icon v-on="on" @click="benchmarkUpwards">
           <v-icon>{{ benchmarkUpwardsIcon }}</v-icon>
@@ -61,11 +61,6 @@ export default class CommitBenchmarkActions extends Vue {
     return vxm.userModule.isAdmin
   }
 
-  // FIXME: Implement One-Up in backend and then re-enable it
-  private get oneUpImplemented() {
-    return false
-  }
-
   private benchmark() {
     vxm.queueModule.startManualTask({
       repoId: this.commitDescription.repoId,
@@ -73,8 +68,11 @@ export default class CommitBenchmarkActions extends Vue {
     })
   }
 
-  private benchmarkUpwards() {
-    vxm.queueModule.dispatchQueueUpwardsOf(this.commitDescription)
+  private async benchmarkUpwards() {
+    const taskCount = await vxm.queueModule.dispatchQueueUpwardsOf(
+      this.commitDescription
+    )
+    this.$globalSnackbar.setSuccess('one-up', `One upped ${taskCount} commits!`)
   }
 
   private get repo(): Repo | undefined {


### PR DESCRIPTION
Previous patches disabled the one-up endpoint as backend support was dropped -- this patch enables it again.