### PR TITLE
Link chips on home page to relevant run comparison

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/runcomparison/DimensionDifference.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/runcomparison/DimensionDifference.java
@@ -1,6 +1,7 @@
 package de.aaaaaaah.velcom.backend.data.runcomparison;
 
 import de.aaaaaaah.velcom.backend.access.entities.Dimension;
+import de.aaaaaaah.velcom.backend.access.entities.RunId;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -9,15 +10,17 @@ public class DimensionDifference {
 	private final Dimension dimension;
 	private final double first;
 	private final double second;
+	private final RunId oldRunId;
 	@Nullable
 	private final Double secondStddev;
 
 	public DimensionDifference(Dimension dimension, double first, double second,
-		@Nullable Double secondStddev) {
+		RunId oldRunId, @Nullable Double secondStddev) {
 
 		this.dimension = dimension;
 		this.first = first;
 		this.second = second;
+		this.oldRunId = oldRunId;
 		this.secondStddev = secondStddev;
 	}
 
@@ -31,6 +34,10 @@ public class DimensionDifference {
 
 	public double getSecond() {
 		return second;
+	}
+
+	public RunId getOldRunId() {
+		return oldRunId;
 	}
 
 	public Optional<Double> getSecondStddev() {

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/runcomparison/RunComparator.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/runcomparison/RunComparator.java
@@ -42,6 +42,7 @@ public class RunComparator {
 				dimension,
 				firstValues.getAverageValue(),
 				secondValues.getAverageValue(),
+				first.getId(),
 				getStddev(secondValues).orElse(null)
 			);
 			differences.add(difference);

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonDimensionDifference.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonDimensionDifference.java
@@ -6,22 +6,25 @@ import de.aaaaaaah.velcom.backend.data.runcomparison.DimensionDifference;
 import de.aaaaaaah.velcom.backend.data.runcomparison.RunComparison;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 public class JsonDimensionDifference {
 
 	private final JsonDimension dimension;
+	private final UUID oldRunId;
 	private final double diff;
 	@Nullable
 	private final Double reldiff;
 	@Nullable
 	private final Double stddev;
 
-	public JsonDimensionDifference(JsonDimension dimension, double diff, @Nullable Double reldiff,
-		@Nullable Double stddev) {
+	public JsonDimensionDifference(JsonDimension dimension, UUID oldRunId, double diff,
+		@Nullable Double reldiff, @Nullable Double stddev) {
 
 		this.dimension = dimension;
+		this.oldRunId = oldRunId;
 		this.diff = diff;
 		this.reldiff = reldiff;
 		this.stddev = stddev;
@@ -38,6 +41,7 @@ public class JsonDimensionDifference {
 
 		return new JsonDimensionDifference(
 			JsonDimension.fromDimensionInfo(dimensionInfos.get(difference.getDimension())),
+			difference.getOldRunId().getId(),
 			difference.getDiff(),
 			difference.getReldiff().orElse(null),
 			difference.getSecondStddev().orElse(null)
@@ -54,6 +58,10 @@ public class JsonDimensionDifference {
 
 	public JsonDimension getDimension() {
 		return dimension;
+	}
+
+	public UUID getOldRunId() {
+		return oldRunId;
 	}
 
 	public double getDiff() {

--- a/docs/public-api/public-api.v2.yaml
+++ b/docs/public-api/public-api.v2.yaml
@@ -1155,9 +1155,12 @@ components:
         stddev:
           type: number
           description: The standard deviation of the run the new value is from. Only present if the amount of values in the sample is above the minimum stddev amount.
+        old_run_id:
+          $ref: '#/components/schemas/RunId'
       required:
         - dimension
         - diff
+        - old_run_id
   securitySchemes:
     admin_credentials:
       type: http

--- a/frontend/src/components/overviews/MultipleRunOverview.vue
+++ b/frontend/src/components/overviews/MultipleRunOverview.vue
@@ -19,7 +19,11 @@
               <v-row no-gutters class="ma-0">
                 <v-col
                   v-for="relevantChange in relevantChanges(item)"
-                  :key="relevantChange.id.benchmark + relevantChange.id.metric"
+                  :key="
+                    relevantChange.oldRunId +
+                    relevantChange.id.benchmark +
+                    relevantChange.id.metric
+                  "
                   cols="auto"
                   class="mr-2 mt-2"
                 >
@@ -28,6 +32,13 @@
                     outlined
                     :color="relevantChange.color"
                     :input-value="true"
+                    :to="{
+                      name: 'run-comparison',
+                      params: {
+                        first: relevantChange.oldRunId,
+                        second: run(item).runId
+                      }
+                    }"
                   >
                     <v-icon left>{{ relevantChange.icon }}</v-icon>
                     {{ relevantChange.id.benchmark }} —
@@ -57,7 +68,8 @@ import {
   DimensionDifference,
   DimensionInterpretation,
   RunDescription,
-  RunDescriptionWithDifferences
+  RunDescriptionWithDifferences,
+  RunId
 } from '@/store/types'
 import RunOverview from './RunOverview.vue'
 import {
@@ -92,8 +104,10 @@ class RelevantChange {
   readonly change: string
   readonly color: string
   readonly icon: string
+  readonly oldRunId: RunId
 
   constructor(difference: DimensionDifference) {
+    this.oldRunId = difference.oldRunId
     this.id = difference.dimension
     if (difference.stddev !== undefined) {
       let change = difference.relDiff

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -387,17 +387,20 @@ export class Worker {
 
 export class DimensionDifference {
   readonly dimension: Dimension
+  readonly oldRunId: RunId
   readonly absDiff: number
   readonly relDiff?: number
   readonly stddev?: number
 
   constructor(
     dimension: Dimension,
+    oldRunId: RunId,
     absDiff: number,
     relDiff?: number,
     stddev?: number
   ) {
     this.dimension = dimension
+    this.oldRunId = oldRunId
     this.absDiff = absDiff
     this.relDiff = relDiff
     this.stddev = stddev

--- a/frontend/src/util/CommitComparisonJsonHelper.ts
+++ b/frontend/src/util/CommitComparisonJsonHelper.ts
@@ -88,6 +88,7 @@ export function commitFromJson(json: any): Commit {
 export function differenceFromJson(json: any): DimensionDifference {
   return new DimensionDifference(
     dimensionFromJson(json.dimension),
+    json.old_run_id,
     json.diff,
     json.reldiff,
     json.stddev


### PR DESCRIPTION
For significant runs we display small chips with the significant metrics -- but if a run has more than one parent you might see the same dimension and metric with *two* different values. This commits links each chip to a run comparison with the relevant parent, so you can click on them and see where they belong to.