### PR TITLE
Support uploading of gzipped tars

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/queue/Queue.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/queue/Queue.java
@@ -184,7 +184,7 @@ public class Queue {
 	 * @param repoId the id of the repo the tar file should to (or null)
 	 * @param description the tar file's description
 	 * @param inputStream the tar file's contents
-	 * @return the new task or empty if no task was created
+	 * @return the new task or empty if the tar file could not be stored and no task was created
 	 */
 	public Optional<Task> addTar(String author, TaskPriority priority, @Nullable RepoId repoId,
 		String description, InputStream inputStream) {

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/newaccess/taskaccess/TaskWriteAccess.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/newaccess/taskaccess/TaskWriteAccess.java
@@ -121,7 +121,8 @@ public class TaskWriteAccess extends TaskReadAccess {
 	 * @param description the tar file's description
 	 * @param repoId the associated repo id, if any
 	 * @param inputStream the tar file contents
-	 * @return the newly created task (if a task was created)
+	 * @return the newly created task or empty if the tar file could not be stored for some reason and
+	 * 	no task was created
 	 */
 	public Optional<Task> insertTar(String author, TaskPriority priority, String description,
 		@Nullable RepoId repoId, InputStream inputStream) {

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/QueueEndpoint.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/QueueEndpoint.java
@@ -266,6 +266,8 @@ public class QueueEndpoint {
 			);
 
 			if (task.isEmpty()) {
+				// The task is empty if the tar could not be stored in the data dir, which should not happen
+				// during normal operation.
 				throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
 			}
 

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/QueueEndpoint.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/QueueEndpoint.java
@@ -25,6 +25,7 @@ import de.aaaaaaah.velcom.shared.util.Pair;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.jersey.PATCH;
 import io.micrometer.core.annotation.Timed;
+import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
 import java.util.List;
@@ -33,6 +34,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.ws.rs.Consumes;
@@ -45,6 +47,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response.Status;
+import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 
 @Path("/queue")
@@ -241,25 +244,33 @@ public class QueueEndpoint {
 		@Auth RepoUser user,
 		@Nonnull @FormDataParam("description") String description,
 		@Nullable @FormDataParam("repo_id") UUID repoUuid,
-		@FormDataParam("file") InputStream inputStream
-	) {
+		@FormDataParam("file") InputStream inputStream,
+		@FormDataParam("file") FormDataContentDisposition fileDisposition
+	) throws IOException {
 		user.guardAdminAccess();
 
 		Optional<RepoId> repoId = Optional.ofNullable(repoUuid).map(RepoId::new);
 
-		Optional<Task> task = queue.addTar(
-			AUTHOR_NAME_ADMIN,
-			TaskPriority.MANUAL,
-			repoId.orElse(null),
-			description,
-			inputStream
-		);
+		final InputStream uncompressedInput =
+			fileDisposition.getFileName().endsWith(".tar.gz")
+				? new GZIPInputStream(inputStream)
+				: inputStream;
 
-		if (task.isEmpty()) {
-			throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
+		try (uncompressedInput) {
+			Optional<Task> task = queue.addTar(
+				AUTHOR_NAME_ADMIN,
+				TaskPriority.MANUAL,
+				repoId.orElse(null),
+				description,
+				uncompressedInput
+			);
+
+			if (task.isEmpty()) {
+				throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
+			}
+
+			return new UploadTarReply(JsonTask.fromTask(task.get(), commitReadAccess));
 		}
-
-		return new UploadTarReply(JsonTask.fromTask(task.get(), commitReadAccess));
 	}
 
 	@Path("task/{taskid}")

--- a/docs/public-api/public-api.v2.yaml
+++ b/docs/public-api/public-api.v2.yaml
@@ -117,7 +117,10 @@ paths:
       security:
         - admin_credentials: []
       parameters: []
-      description: This endpoint allows users to upload a tar file that the server should benchmark. The tar file is added to the queue with a relatively high priority.
+      description: |-
+        This endpoint allows users to upload a tar file that the server should benchmark. The tar file is added to the queue with a relatively high priority.
+
+        If the filename specified in the form-data body ends with `.tar.gz`, the tar file will be automatically uncompressed. If it doesn't it is treated as a normal, uncompressed tar file.
       tags:
         - queue
       requestBody:

--- a/frontend/src/components/FileSelectComponent.vue
+++ b/frontend/src/components/FileSelectComponent.vue
@@ -11,7 +11,7 @@
           <span class="font-weight-bold pl-1">{{ selectedFileName }}</span>
         </label>
         <input
-          accept=".tar"
+          accept=".tar,.tar.gz"
           @change="fileSelected"
           id="file-upload"
           type="file"


### PR DESCRIPTION
This PR adds support for `tar.gz` files, iff the user actually ends the file name with `.tar.gz` as no magic probing is done.

Files are uncompressed on-the-fly and then written to disk, so the storage benefits only apply to the in-flight request.

TODO:
- [x] Add tar.gz to the file filter in the frontend

Closes: #189 