### PR TITLE
Stddev without differences

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/ServerMain.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/ServerMain.java
@@ -190,7 +190,8 @@ public class ServerMain extends Application<GlobalConfig> {
 			new AllReposEndpoint(benchmarkAccess, dimensionAccess, repoAccess, tokenAccess,
 				availableDimensionsCache),
 			new CommitEndpoint(commitAccess, repoAccess, benchmarkAccess),
-			new CompareEndpoint(benchmarkAccess, commitAccess, dimensionAccess, runComparator),
+			new CompareEndpoint(benchmarkAccess, commitAccess, dimensionAccess, runComparator,
+				significanceFactors),
 			new DebugEndpoint(dimensionAccess, dispatcher),
 			new GraphComparisonEndpoint(dimensionAccess, comparison),
 			new GraphDetailEndpoint(commitAccess, benchmarkAccess, dimensionAccess, repoAccess),
@@ -200,7 +201,8 @@ public class ServerMain extends Application<GlobalConfig> {
 				significantRunsCollector),
 			new RepoEndpoint(dimensionAccess, repoAccess, tokenAccess, availableDimensionsCache,
 				listener),
-			new RunEndpoint(benchmarkAccess, commitAccess, dimensionAccess, runComparator),
+			new RunEndpoint(benchmarkAccess, commitAccess, dimensionAccess, runComparator,
+				significanceFactors),
 			new TestTokenEndpoint()
 		).forEach(endpoint -> environment.jersey().register(endpoint));
 	}

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/entities/MeasurementValues.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/entities/MeasurementValues.java
@@ -59,6 +59,16 @@ public class MeasurementValues {
 		return Optional.of(result);
 	}
 
+	/**
+	 * @return stddev / averageValue
+	 */
+	public Optional<Double> getStddevPercent() {
+		if (getAverageValue() == 0) {
+			return Optional.empty();
+		}
+		return getStddev().map(it -> it / getAverageValue());
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/entities/MeasurementValues.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/entities/MeasurementValues.java
@@ -1,5 +1,6 @@
 package de.aaaaaaah.velcom.backend.access.entities;
 
+import de.aaaaaaah.velcom.backend.data.runcomparison.SignificanceFactors;
 import de.aaaaaaah.velcom.backend.newaccess.dimensionaccess.entities.Interpretation;
 import de.aaaaaaah.velcom.backend.newaccess.dimensionaccess.entities.Unit;
 import java.util.Collections;
@@ -45,7 +46,24 @@ public class MeasurementValues {
 		return calculateAverage(values);
 	}
 
-	public Optional<Double> getStddev() {
+	/**
+	 * @return the standard deviation of the values, if there are more than {@link
+	 *  SignificanceFactors#getMinStddevAmount()} values
+	 */
+	public Optional<Double> getStddevWith(SignificanceFactors significanceFactors) {
+		if (values.size() >= significanceFactors.getMinStddevAmount()) {
+			return getStddev();
+		} else {
+			return Optional.empty();
+		}
+	}
+
+	/**
+	 * @return the standard deviation of the values, if there are at least two values. WARNING: When
+	 * 	calling this function, always use {@link SignificanceFactors#getMinStddevAmount()} to see
+	 * 	whether a standard deviation even makes sense in this situation.
+	 */
+	private Optional<Double> getStddev() {
 		int n = values.size();
 		if (n < 2) {
 			return Optional.empty();
@@ -60,13 +78,12 @@ public class MeasurementValues {
 	}
 
 	/**
-	 * @return stddev / averageValue
+	 * @return stddev / averageValue, if there are more than {@link SignificanceFactors#getMinStddevAmount()}
+	 * 	values
 	 */
-	public Optional<Double> getStddevPercent() {
-		if (getAverageValue() == 0) {
-			return Optional.empty();
-		}
-		return getStddev().map(it -> it / getAverageValue());
+	public Optional<Double> getStddevPercentWith(SignificanceFactors significanceFactors) {
+		return getStddevWith(significanceFactors)
+			.map(it -> it / getAverageValue());
 	}
 
 	@Override

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/runcomparison/DimensionDifference.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/runcomparison/DimensionDifference.java
@@ -14,8 +14,8 @@ public class DimensionDifference {
 	@Nullable
 	private final Double secondStddev;
 
-	public DimensionDifference(Dimension dimension, double first, double second,
-		RunId oldRunId, @Nullable Double secondStddev) {
+	public DimensionDifference(Dimension dimension, double first, double second, RunId oldRunId,
+		@Nullable Double secondStddev) {
 
 		this.dimension = dimension;
 		this.first = first;
@@ -44,15 +44,29 @@ public class DimensionDifference {
 		return Optional.ofNullable(secondStddev);
 	}
 
+	/**
+	 * @return second - first
+	 */
 	public double getDiff() {
 		return second - first;
 	}
 
+	/**
+	 * @return (second - first) / first, if first != 0
+	 */
 	public Optional<Double> getReldiff() {
 		if (first == 0) {
 			return Optional.empty();
 		}
 
 		return Optional.of((second - first) / first);
+	}
+
+	/**
+	 * @return (second - first) / second stddev, if second stddev exists
+	 */
+	public Optional<Double> getStddevDiff() {
+		return getSecondStddev()
+			.map(stddev -> getDiff() / stddev);
 	}
 }

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/runcomparison/RunComparator.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/runcomparison/RunComparator.java
@@ -43,7 +43,7 @@ public class RunComparator {
 				firstValues.getAverageValue(),
 				secondValues.getAverageValue(),
 				first.getId(),
-				getStddev(secondValues).orElse(null)
+				secondValues.getStddevWith(significanceFactors).orElse(null)
 			);
 			differences.add(difference);
 		}
@@ -66,13 +66,5 @@ public class RunComparator {
 		}
 
 		return measurements;
-	}
-
-	private Optional<Double> getStddev(MeasurementValues measurementValues) {
-		if (measurementValues.getValues().size() < significanceFactors.getMinStddevAmount()) {
-			return Optional.empty();
-		}
-
-		return measurementValues.getStddev();
 	}
 }

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/CompareEndpoint.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/CompareEndpoint.java
@@ -4,6 +4,7 @@ import de.aaaaaaah.velcom.backend.access.BenchmarkReadAccess;
 import de.aaaaaaah.velcom.backend.access.entities.Run;
 import de.aaaaaaah.velcom.backend.data.runcomparison.RunComparator;
 import de.aaaaaaah.velcom.backend.data.runcomparison.RunComparison;
+import de.aaaaaaah.velcom.backend.data.runcomparison.SignificanceFactors;
 import de.aaaaaaah.velcom.backend.newaccess.benchmarkaccess.exceptions.NoSuchRunException;
 import de.aaaaaaah.velcom.backend.newaccess.committaccess.CommitReadAccess;
 import de.aaaaaaah.velcom.backend.newaccess.dimensionaccess.DimensionReadAccess;
@@ -35,14 +36,17 @@ public class CompareEndpoint {
 	private final CommitReadAccess commitAccess;
 	private final DimensionReadAccess dimensionAccess;
 	private final RunComparator comparer;
+	private final SignificanceFactors significanceFactors;
 
 	public CompareEndpoint(BenchmarkReadAccess benchmarkAccess, CommitReadAccess commitAccess,
-		DimensionReadAccess dimensionAccess, RunComparator comparer) {
+		DimensionReadAccess dimensionAccess, RunComparator comparer,
+		SignificanceFactors significanceFactors) {
 
 		this.benchmarkAccess = benchmarkAccess;
 		this.commitAccess = commitAccess;
 		this.dimensionAccess = dimensionAccess;
 		this.comparer = comparer;
+		this.significanceFactors = significanceFactors;
 	}
 
 	@GET
@@ -68,8 +72,8 @@ public class CompareEndpoint {
 			.fromRunComparison(comparison, infos);
 
 		return new GetReply(
-			EndpointUtils.fromRun(dimensionAccess, commitAccess, run1, allValues),
-			EndpointUtils.fromRun(dimensionAccess, commitAccess, run2, allValues),
+			EndpointUtils.fromRun(dimensionAccess, commitAccess, run1, significanceFactors, allValues),
+			EndpointUtils.fromRun(dimensionAccess, commitAccess, run2, significanceFactors, allValues),
 			differences
 		);
 	}

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/RunEndpoint.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/RunEndpoint.java
@@ -4,6 +4,7 @@ import de.aaaaaaah.velcom.backend.access.BenchmarkReadAccess;
 import de.aaaaaaah.velcom.backend.access.entities.Run;
 import de.aaaaaaah.velcom.backend.data.runcomparison.RunComparator;
 import de.aaaaaaah.velcom.backend.data.runcomparison.RunComparison;
+import de.aaaaaaah.velcom.backend.data.runcomparison.SignificanceFactors;
 import de.aaaaaaah.velcom.backend.newaccess.benchmarkaccess.entities.CommitSource;
 import de.aaaaaaah.velcom.backend.newaccess.benchmarkaccess.exceptions.NoSuchRunException;
 import de.aaaaaaah.velcom.backend.newaccess.committaccess.CommitReadAccess;
@@ -36,14 +37,17 @@ public class RunEndpoint {
 	private final CommitReadAccess commitAccess;
 	private final DimensionReadAccess dimensionAccess;
 	private final RunComparator comparer;
+	private final SignificanceFactors significanceFactors;
 
 	public RunEndpoint(BenchmarkReadAccess benchmarkAccess, CommitReadAccess commitAccess,
-		DimensionReadAccess dimensionAccess, RunComparator comparer) {
+		DimensionReadAccess dimensionAccess, RunComparator comparer,
+		SignificanceFactors significanceFactors) {
 
 		this.benchmarkAccess = benchmarkAccess;
 		this.commitAccess = commitAccess;
 		this.dimensionAccess = dimensionAccess;
 		this.comparer = comparer;
+		this.significanceFactors = significanceFactors;
 	}
 
 	private Optional<Run> getPrevRun(Run run) {
@@ -92,7 +96,7 @@ public class RunEndpoint {
 		}
 
 		return new GetReply(
-			EndpointUtils.fromRun(dimensionAccess, commitAccess, run, allValues),
+			EndpointUtils.fromRun(dimensionAccess, commitAccess, run, significanceFactors, allValues),
 			differences.orElse(null)
 		);
 	}

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/utils/EndpointUtils.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/utils/EndpointUtils.java
@@ -3,6 +3,7 @@ package de.aaaaaaah.velcom.backend.restapi.endpoints.utils;
 import de.aaaaaaah.velcom.backend.access.BenchmarkReadAccess;
 import de.aaaaaaah.velcom.backend.access.entities.Run;
 import de.aaaaaaah.velcom.backend.access.entities.RunId;
+import de.aaaaaaah.velcom.backend.data.runcomparison.SignificanceFactors;
 import de.aaaaaaah.velcom.backend.newaccess.benchmarkaccess.exceptions.NoSuchRunException;
 import de.aaaaaaah.velcom.backend.newaccess.committaccess.CommitReadAccess;
 import de.aaaaaaah.velcom.backend.newaccess.committaccess.entities.CommitHash;
@@ -60,12 +61,14 @@ public class EndpointUtils {
 	 * @param dimensionAccess a {@link DimensionReadAccess}
 	 * @param commitAccess a {@link CommitReadAccess}
 	 * @param run the run
+	 * @param significanceFactors the current significance factors (required for stddev
+	 * 	calculations)
 	 * @param allValues whether the full lists of values should also be included for each
 	 * 	measurement
 	 * @return the created {@link JsonRun}
 	 */
 	public static JsonRun fromRun(DimensionReadAccess dimensionAccess, CommitReadAccess commitAccess,
-		Run run, boolean allValues) {
+		Run run, SignificanceFactors significanceFactors, boolean allValues) {
 
 		JsonSource source = JsonSource.fromSource(run.getSource(), commitAccess);
 		Map<Dimension, DimensionInfo> dimensionInfos = dimensionAccess
@@ -94,6 +97,7 @@ public class EndpointUtils {
 				JsonResult.fromMeasurements(
 					run.getResult().getRight().get(),
 					dimensionInfos,
+					significanceFactors,
 					allValues
 				)
 			);

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonDimensionDifference.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonDimensionDifference.java
@@ -17,17 +17,14 @@ public class JsonDimensionDifference {
 	private final double diff;
 	@Nullable
 	private final Double reldiff;
-	@Nullable
-	private final Double stddev;
 
 	public JsonDimensionDifference(JsonDimension dimension, UUID oldRunId, double diff,
-		@Nullable Double reldiff, @Nullable Double stddev) {
+		@Nullable Double reldiff) {
 
 		this.dimension = dimension;
 		this.oldRunId = oldRunId;
 		this.diff = diff;
 		this.reldiff = reldiff;
-		this.stddev = stddev;
 	}
 
 	/**
@@ -43,8 +40,7 @@ public class JsonDimensionDifference {
 			JsonDimension.fromDimensionInfo(dimensionInfos.get(difference.getDimension())),
 			difference.getOldRunId().getId(),
 			difference.getDiff(),
-			difference.getReldiff().orElse(null),
-			difference.getSecondStddev().orElse(null)
+			difference.getReldiff().orElse(null)
 		);
 	}
 
@@ -71,10 +67,5 @@ public class JsonDimensionDifference {
 	@Nullable
 	public Double getReldiff() {
 		return reldiff;
-	}
-
-	@Nullable
-	public Double getStddev() {
-		return stddev;
 	}
 }

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonDimensionDifference.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonDimensionDifference.java
@@ -17,14 +17,17 @@ public class JsonDimensionDifference {
 	private final double diff;
 	@Nullable
 	private final Double reldiff;
+	@Nullable
+	private final Double stddevDiff;
 
 	public JsonDimensionDifference(JsonDimension dimension, UUID oldRunId, double diff,
-		@Nullable Double reldiff) {
+		@Nullable Double reldiff, @Nullable Double stddevDiff) {
 
 		this.dimension = dimension;
 		this.oldRunId = oldRunId;
 		this.diff = diff;
 		this.reldiff = reldiff;
+		this.stddevDiff = stddevDiff;
 	}
 
 	/**
@@ -40,7 +43,8 @@ public class JsonDimensionDifference {
 			JsonDimension.fromDimensionInfo(dimensionInfos.get(difference.getDimension())),
 			difference.getOldRunId().getId(),
 			difference.getDiff(),
-			difference.getReldiff().orElse(null)
+			difference.getReldiff().orElse(null),
+			difference.getStddevDiff().orElse(null)
 		);
 	}
 
@@ -67,5 +71,10 @@ public class JsonDimensionDifference {
 	@Nullable
 	public Double getReldiff() {
 		return reldiff;
+	}
+
+	@Nullable
+	public Double getStddevDiff() {
+		return stddevDiff;
 	}
 }

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonMeasurement.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonMeasurement.java
@@ -17,29 +17,34 @@ public class JsonMeasurement {
 	private final List<Double> values;
 	@Nullable
 	private final String error;
+	@Nullable
+	private final Double stddev;
+	@Nullable
+	private final Double stddevPercent;
 
 	private JsonMeasurement(JsonDimension dimension, @Nullable Double value,
-		@Nullable List<Double> values, @Nullable String error) {
+		@Nullable List<Double> values, @Nullable String error, @Nullable Double stddev,
+		@Nullable Double stddevPercent) {
 
 		this.dimension = dimension;
 		this.value = value;
 		this.values = values;
 		this.error = error;
+		this.stddev = stddev;
+		this.stddevPercent = stddevPercent;
 	}
 
 	public static JsonMeasurement successful(JsonDimension dimension, double value,
-		List<Double> values) {
-
-		return new JsonMeasurement(dimension, value, values, null);
+		List<Double> values, Double stddev, Double stddevPercent) {
+		return new JsonMeasurement(dimension, value, values, null, stddev, stddevPercent);
 	}
 
 	public static JsonMeasurement successful(JsonDimension dimension, double value) {
-
-		return new JsonMeasurement(dimension, value, null, null);
+		return new JsonMeasurement(dimension, value, null, null, null, null);
 	}
 
 	public static JsonMeasurement failed(JsonDimension dimension, String error) {
-		return new JsonMeasurement(dimension, null, null, error);
+		return new JsonMeasurement(dimension, null, null, error, null, null);
 	}
 
 	/**
@@ -64,11 +69,13 @@ public class JsonMeasurement {
 			return failed(dimension, left.getErrorMessage());
 		} else {
 			MeasurementValues right = content.getRight().get();
-			if (allValues) {
-				return successful(dimension, right.getAverageValue(), right.getValues());
-			} else {
-				return successful(dimension, right.getAverageValue());
-			}
+			return successful(
+				dimension,
+				right.getAverageValue(),
+				allValues ? right.getValues() : null,
+				right.getStddev().orElse(null),
+				right.getStddevPercent().orElse(null)
+			);
 		}
 	}
 
@@ -89,5 +96,15 @@ public class JsonMeasurement {
 	@Nullable
 	public String getError() {
 		return error;
+	}
+
+	@Nullable
+	public Double getStddev() {
+		return stddev;
+	}
+
+	@Nullable
+	public Double getStddevPercent() {
+		return stddevPercent;
 	}
 }

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonResult.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonResult.java
@@ -1,6 +1,7 @@
 package de.aaaaaaah.velcom.backend.restapi.jsonobjects;
 
 import de.aaaaaaah.velcom.backend.access.entities.Measurement;
+import de.aaaaaaah.velcom.backend.data.runcomparison.SignificanceFactors;
 import de.aaaaaaah.velcom.backend.newaccess.benchmarkaccess.entities.RunError;
 import de.aaaaaaah.velcom.backend.newaccess.dimensionaccess.entities.Dimension;
 import de.aaaaaaah.velcom.backend.newaccess.dimensionaccess.entities.DimensionInfo;
@@ -63,16 +64,23 @@ public class JsonResult {
 	 *
 	 * @param measurements the measurements to use
 	 * @param dimensionInfos the dimensions for each measurement
+	 * @param significanceFactors the current significance factors (required for stddev
+	 * 	calculations)
 	 * @param allValues whether the full lists of values should also be included for each
 	 * 	measurement
 	 * @return the newly created {@link JsonResult}
 	 */
 	public static JsonResult fromMeasurements(Collection<Measurement> measurements,
-		Map<Dimension, DimensionInfo> dimensionInfos, boolean allValues) {
+		Map<Dimension, DimensionInfo> dimensionInfos, SignificanceFactors significanceFactors,
+		boolean allValues) {
 
 		List<JsonMeasurement> jsonMeasurements = measurements.stream()
-			.map(measurement -> JsonMeasurement
-				.fromMeasurement(measurement, dimensionInfos.get(measurement.getDimension()), allValues))
+			.map(measurement -> JsonMeasurement.fromMeasurement(
+				measurement,
+				dimensionInfos.get(measurement.getDimension()),
+				significanceFactors,
+				allValues
+			))
 			.collect(Collectors.toList());
 		return successful(jsonMeasurements);
 	}

--- a/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonMeasurementTest.java
+++ b/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonMeasurementTest.java
@@ -12,7 +12,33 @@ class JsonMeasurementTest extends SerializingTest {
 		Object object = JsonMeasurement.successful(
 			new JsonDimension("b", "m", "u", Interpretation.NEUTRAL),
 			1.0,
-			List.of(2.0, 3.0)
+			List.of(2.0, 3.0),
+			10.0,
+			0.5
+		);
+		String json = "{"
+			+ "\"dimension\": {"
+			+ "  \"benchmark\": \"b\","
+			+ "  \"metric\": \"m\","
+			+ "  \"unit\": \"u\","
+			+ "  \"interpretation\": \"NEUTRAL\""
+			+ "},"
+			+ "\"value\": 1.0,"
+			+ "\"values\": [2.0, 3.0],"
+			+ "\"stddev\": 10.0,"
+			+ "\"stddev_percent\": 0.5"
+			+ "}";
+		serializedEquals(object, json);
+	}
+
+	@Test
+	void serializeSuccessfulWithoutStddev() throws JsonProcessingException {
+		Object object = JsonMeasurement.successful(
+			new JsonDimension("b", "m", "u", Interpretation.NEUTRAL),
+			1.0,
+			List.of(2.0, 3.0),
+			null,
+			null
 		);
 		String json = "{"
 			+ "\"dimension\": {"

--- a/docs/public-api/public-api.v2.yaml
+++ b/docs/public-api/public-api.v2.yaml
@@ -1221,7 +1221,13 @@ components:
           description: |-
             (new value - old value) / old value
 
-            Only present if the old_value is non-zero.
+            Only present if the old value is non-zero.
+        stddev_diff:
+          type: string
+          description: |-
+            (new value - old value) / stddev of new values
+
+            Only present if the old value is non-zero and the amount of new values is above the min stddev limit.
         old_run_id:
           $ref: '#/components/schemas/RunId'
       required:

--- a/docs/public-api/public-api.v2.yaml
+++ b/docs/public-api/public-api.v2.yaml
@@ -1109,6 +1109,12 @@ components:
               description: All measured values
               items:
                 type: number
+            stddev:
+              description: The standard deviation of the run the new value is from. Only present if the amount of values in the sample is above the minimum stddev amount.
+              type: number
+            stddev_percent:
+              type: number
+              description: stddev / value. Only present if the amount of values in the sample is above the minimum stddev amount.
           required:
             - dimension
             - value
@@ -1216,9 +1222,6 @@ components:
             (new value - old value) / old value
 
             Only present if the old_value is non-zero.
-        stddev:
-          type: number
-          description: The standard deviation of the run the new value is from. Only present if the amount of values in the sample is above the minimum stddev amount.
         old_run_id:
           $ref: '#/components/schemas/RunId'
       required:

--- a/frontend/src/components/overviews/MultipleRunOverview.vue
+++ b/frontend/src/components/overviews/MultipleRunOverview.vue
@@ -109,13 +109,11 @@ class RelevantChange {
   constructor(difference: DimensionDifference) {
     this.oldRunId = difference.oldRunId
     this.id = difference.dimension
-    if (difference.stddev !== undefined) {
+    if (difference.stddevDiff !== undefined) {
       let change = difference.relDiff
         ? this.formatPercentage(difference.relDiff)
         : this.formatNumber(difference.absDiff)
-      change += ` (${this.formatNumber(
-        difference.absDiff / difference.stddev
-      )} σ)`
+      change += ` (${this.formatNumber(difference.stddevDiff)} σ)`
 
       this.change = change
     } else {

--- a/frontend/src/components/rundetail/MeasurementsDisplay.vue
+++ b/frontend/src/components/rundetail/MeasurementsDisplay.vue
@@ -193,10 +193,10 @@ class Item {
 })
 export default class MeasurementsDisplay extends Vue {
   @Prop()
-  private measurements!: Measurement[]
+  private readonly measurements!: Measurement[]
 
   @Prop()
-  private differences?: DimensionDifference[]
+  private readonly differences?: DimensionDifference[]
 
   private showDetailErrorDialog: boolean = false
   private safeDetailErrorDialogMessage: string = ''
@@ -292,6 +292,7 @@ export default class MeasurementsDisplay extends Vue {
       measurementError.dimension.metric,
       measurementError.dimension.unit,
       measurementError.dimension.interpretation,
+      undefined,
       undefined,
       undefined,
       undefined,

--- a/frontend/src/components/rundetail/MeasurementsDisplay.vue
+++ b/frontend/src/components/rundetail/MeasurementsDisplay.vue
@@ -106,6 +106,7 @@ class Item {
     interpretation: DimensionInterpretation,
     value?: number,
     standardDeviation?: number,
+    standardDeviationPercent?: number,
     change?: number,
     changePercent?: number,
     error?: string
@@ -115,10 +116,7 @@ class Item {
     this.unit = unit
     this.value = value
     this.standardDeviation = standardDeviation
-    this.standardDeviationPercent = this.computeStandardDeviationPercent(
-      value,
-      standardDeviation
-    )
+    this.standardDeviationPercent = standardDeviationPercent
     this.change = change
     this.changePercent = changePercent
     this.error = error
@@ -160,20 +158,6 @@ class Item {
       return this.formatNumber(number)
     }
     return this.formatNumber(number * 100) + '%'
-  }
-
-  private computeStandardDeviationPercent(
-    value?: number,
-    standardDeviation?: number
-  ): number | undefined {
-    if (value === undefined || standardDeviation === undefined) {
-      return undefined
-    }
-    // divide by zero :(
-    if (value === 0) {
-      return undefined
-    }
-    return standardDeviation / value
   }
 
   private computeChangeColor(
@@ -286,7 +270,8 @@ export default class MeasurementsDisplay extends Vue {
       measurement.dimension.unit,
       measurement.dimension.interpretation,
       measurement.value,
-      difference ? difference.stddev : undefined,
+      measurement.stddev,
+      measurement.stddevPercent,
       difference ? difference.absDiff : undefined,
       difference ? difference.relDiff : undefined
     )

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -400,17 +400,20 @@ export class DimensionDifference {
   readonly oldRunId: RunId
   readonly absDiff: number
   readonly relDiff?: number
+  readonly stddevDiff?: number
 
   constructor(
     dimension: Dimension,
     oldRunId: RunId,
     absDiff: number,
-    relDiff?: number
+    relDiff?: number,
+    stddevDiff?: number
   ) {
     this.dimension = dimension
     this.oldRunId = oldRunId
     this.absDiff = absDiff
     this.relDiff = relDiff
+    this.stddevDiff = stddevDiff
   }
 }
 

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -243,11 +243,21 @@ export class MeasurementSuccess {
   readonly dimension: Dimension
   readonly value: number
   readonly values: number[]
+  readonly stddev?: number
+  readonly stddevPercent?: number
 
-  constructor(dimension: Dimension, value: number, values: number[]) {
+  constructor(
+    dimension: Dimension,
+    value: number,
+    values: number[],
+    stddev?: number,
+    stddevPercent?: number
+  ) {
     this.dimension = dimension
     this.value = value
     this.values = values
+    this.stddev = stddev
+    this.stddevPercent = stddevPercent
   }
 }
 
@@ -390,20 +400,17 @@ export class DimensionDifference {
   readonly oldRunId: RunId
   readonly absDiff: number
   readonly relDiff?: number
-  readonly stddev?: number
 
   constructor(
     dimension: Dimension,
     oldRunId: RunId,
     absDiff: number,
-    relDiff?: number,
-    stddev?: number
+    relDiff?: number
   ) {
     this.dimension = dimension
     this.oldRunId = oldRunId
     this.absDiff = absDiff
     this.relDiff = relDiff
-    this.stddev = stddev
   }
 }
 

--- a/frontend/src/util/CommitComparisonJsonHelper.ts
+++ b/frontend/src/util/CommitComparisonJsonHelper.ts
@@ -50,7 +50,9 @@ function measurementFromJson(json: any): Measurement {
   return new MeasurementSuccess(
     dimensionFromJson(json.dimension),
     json.value,
-    json.values
+    json.values,
+    json.stddev,
+    json.stddev_percent
   )
 }
 
@@ -90,8 +92,7 @@ export function differenceFromJson(json: any): DimensionDifference {
     dimensionFromJson(json.dimension),
     json.old_run_id,
     json.diff,
-    json.reldiff,
-    json.stddev
+    json.reldiff
   )
 }
 

--- a/frontend/src/util/CommitComparisonJsonHelper.ts
+++ b/frontend/src/util/CommitComparisonJsonHelper.ts
@@ -92,7 +92,8 @@ export function differenceFromJson(json: any): DimensionDifference {
     dimensionFromJson(json.dimension),
     json.old_run_id,
     json.diff,
-    json.reldiff
+    json.reldiff,
+    json.stddev_diff
   )
 }
 


### PR DESCRIPTION
## About
This PR moves the `stddev` and `stddevPercent` fields from ´DimensionDifference` to `Measurement` as they are also useful without a diff to the parent run.

## Todo
- [x] Make the home page work again, as it relies on the stddev in the DimensionDifference for its formatting