### PR TITLE
Show significance chips in the run detail view

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/ServerMain.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/ServerMain.java
@@ -202,7 +202,7 @@ public class ServerMain extends Application<GlobalConfig> {
 			new RepoEndpoint(dimensionAccess, repoAccess, tokenAccess, availableDimensionsCache,
 				listener),
 			new RunEndpoint(benchmarkAccess, commitAccess, dimensionAccess, runComparator,
-				significanceFactors),
+				significanceFactors, significantRunsCollector),
 			new TestTokenEndpoint()
 		).forEach(endpoint -> environment.jersey().register(endpoint));
 	}

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/runcomparison/DimensionDifference.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/runcomparison/DimensionDifference.java
@@ -58,7 +58,7 @@ public class DimensionDifference {
 	 * @return (second - first) / first, if first != 0
 	 */
 	public Optional<Double> getReldiff() {
-		if (first == 0) {
+		if (first == 0) { // Don't divide by 0
 			return Optional.empty();
 		}
 
@@ -70,6 +70,7 @@ public class DimensionDifference {
 	 */
 	public Optional<Double> getStddevDiff() {
 		return getSecondStddev()
+			.filter(stddev -> stddev != 0) // Don't divide by 0
 			.map(stddev -> getDiff() / stddev);
 	}
 }

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/RunEndpoint.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/RunEndpoint.java
@@ -103,7 +103,7 @@ public class RunEndpoint {
 
 			Optional<List<DimensionDifference>> significantDiffs = significantRunsCollector
 				.getSignificantRun(run)
-				.map(SignificantRun::getDifferences);
+				.map(SignificantRun::getSignificantDifferences);
 
 			Set<Dimension> dimensions = Stream.of(prevRunDiffs, significantDiffs)
 				.flatMap(Optional::stream)

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/RunEndpoint.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/RunEndpoint.java
@@ -2,6 +2,9 @@ package de.aaaaaaah.velcom.backend.restapi.endpoints;
 
 import de.aaaaaaah.velcom.backend.access.BenchmarkReadAccess;
 import de.aaaaaaah.velcom.backend.access.entities.Run;
+import de.aaaaaaah.velcom.backend.data.recentruns.SignificantRun;
+import de.aaaaaaah.velcom.backend.data.recentruns.SignificantRunsCollector;
+import de.aaaaaaah.velcom.backend.data.runcomparison.DimensionDifference;
 import de.aaaaaaah.velcom.backend.data.runcomparison.RunComparator;
 import de.aaaaaaah.velcom.backend.data.runcomparison.RunComparison;
 import de.aaaaaaah.velcom.backend.data.runcomparison.SignificanceFactors;
@@ -20,7 +23,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -38,16 +43,19 @@ public class RunEndpoint {
 	private final DimensionReadAccess dimensionAccess;
 	private final RunComparator comparer;
 	private final SignificanceFactors significanceFactors;
+	private final SignificantRunsCollector significantRunsCollector;
 
 	public RunEndpoint(BenchmarkReadAccess benchmarkAccess, CommitReadAccess commitAccess,
 		DimensionReadAccess dimensionAccess, RunComparator comparer,
-		SignificanceFactors significanceFactors) {
+		SignificanceFactors significanceFactors,
+		SignificantRunsCollector significantRunsCollector) {
 
 		this.benchmarkAccess = benchmarkAccess;
 		this.commitAccess = commitAccess;
 		this.dimensionAccess = dimensionAccess;
 		this.comparer = comparer;
 		this.significanceFactors = significanceFactors;
+		this.significantRunsCollector = significantRunsCollector;
 	}
 
 	private Optional<Run> getPrevRun(Run run) {
@@ -83,6 +91,7 @@ public class RunEndpoint {
 
 		// Obtain differences to previous run
 		Optional<List<JsonDimensionDifference>> differences;
+		Optional<List<JsonDimensionDifference>> significantDifferences;
 		if (diffPrev) {
 			differences = getPrevRun(run)
 				.map(prevRun -> {
@@ -91,13 +100,28 @@ public class RunEndpoint {
 						.getDimensionInfoMap(comparison.getDimensions());
 					return JsonDimensionDifference.fromRunComparison(comparison, infos);
 				});
+			significantDifferences = significantRunsCollector.getSignificantRun(run)
+				.map(SignificantRun::getDifferences)
+				.map(sigDifferences -> {
+					Set<Dimension> dimensions = sigDifferences.stream()
+						.map(DimensionDifference::getDimension)
+						.collect(Collectors.toSet());
+					Map<Dimension, DimensionInfo> dimensionInfos = dimensionAccess.getDimensionInfoMap(
+						dimensions);
+
+					return sigDifferences.stream()
+						.map(it -> JsonDimensionDifference.fromDimensionDifference(it, dimensionInfos))
+						.collect(Collectors.toList());
+				});
 		} else {
 			differences = Optional.empty();
+			significantDifferences = Optional.empty();
 		}
 
 		return new GetReply(
 			EndpointUtils.fromRun(dimensionAccess, commitAccess, run, significanceFactors, allValues),
-			differences.orElse(null)
+			differences.orElse(null),
+			significantDifferences.orElse(null)
 		);
 	}
 
@@ -106,10 +130,14 @@ public class RunEndpoint {
 		public final JsonRun run;
 		@Nullable
 		public final List<JsonDimensionDifference> differences;
+		@Nullable
+		public final List<JsonDimensionDifference> significantDifferences;
 
-		public GetReply(JsonRun run, @Nullable List<JsonDimensionDifference> differences) {
+		public GetReply(JsonRun run, @Nullable List<JsonDimensionDifference> differences,
+			@Nullable List<JsonDimensionDifference> significantDifferences) {
 			this.run = run;
 			this.differences = differences;
+			this.significantDifferences = significantDifferences;
 		}
 	}
 }

--- a/docs/public-api/public-api.v2.yaml
+++ b/docs/public-api/public-api.v2.yaml
@@ -205,6 +205,11 @@ paths:
                     description: Only present if the `diff_prev` parameter is set to `true` and there is an unambiguous previous commit with a run
                     items:
                       $ref: '#/components/schemas/DimensionDifference'
+                  significant_differences:
+                    type: array
+                    description: The runs significant differences to all direct parent runs. Only present if the `diff_prev` parameter is set to `true`.
+                    items:
+                      $ref: '#/components/schemas/DimensionDifference'
                 required:
                   - run
         '404':

--- a/frontend/src/components/RunSignificanceChips.vue
+++ b/frontend/src/components/RunSignificanceChips.vue
@@ -19,7 +19,7 @@
           name: 'run-comparison',
           params: {
             first: relevantChange.oldRunId,
-            second: run.run.runId
+            second: runId
           }
         }"
       >
@@ -42,7 +42,8 @@ import {
   DimensionDifference,
   DimensionInterpretation,
   RunDescriptionWithDifferences,
-  RunId
+  RunId,
+  RunWithDifferences
 } from '@/store/types'
 import {
   mdiChevronDoubleDown,
@@ -153,10 +154,19 @@ class RelevantChange {
 @Component
 export default class RunSignificanceChips extends Vue {
   @Prop()
-  private readonly run!: RunDescriptionWithDifferences
+  private readonly run!: RunDescriptionWithDifferences | RunWithDifferences
 
   private get relevantChanges(): RelevantChange[] {
-    return this.run.differences.map(it => new RelevantChange(it))
+    if (this.run.differences) {
+      return this.run.differences.map(it => new RelevantChange(it))
+    }
+    return []
+  }
+
+  private get runId(): RunId {
+    return this.run instanceof RunWithDifferences
+      ? this.run.run.id
+      : this.run.run.runId
   }
 }
 </script>

--- a/frontend/src/components/RunSignificanceChips.vue
+++ b/frontend/src/components/RunSignificanceChips.vue
@@ -41,9 +41,7 @@ import {
   Dimension,
   DimensionDifference,
   DimensionInterpretation,
-  RunDescriptionWithDifferences,
-  RunId,
-  RunWithDifferences
+  RunId
 } from '@/store/types'
 import {
   mdiChevronDoubleDown,
@@ -154,25 +152,13 @@ class RelevantChange {
 @Component
 export default class RunSignificanceChips extends Vue {
   @Prop()
-  private readonly run!: RunDescriptionWithDifferences | RunWithDifferences
+  private readonly differences!: DimensionDifference[]
+
+  @Prop()
+  private readonly runId!: RunId
 
   private get relevantChanges(): RelevantChange[] {
-    if (
-      this.run instanceof RunWithDifferences &&
-      this.run.significantDifferences
-    ) {
-      return this.run.significantDifferences.map(it => new RelevantChange(it))
-    }
-    if (this.run.differences) {
-      return this.run.differences.map(it => new RelevantChange(it))
-    }
-    return []
-  }
-
-  private get runId(): RunId {
-    return this.run instanceof RunWithDifferences
-      ? this.run.run.id
-      : this.run.run.runId
+    return this.differences.map(it => new RelevantChange(it))
   }
 }
 </script>

--- a/frontend/src/components/RunSignificanceChips.vue
+++ b/frontend/src/components/RunSignificanceChips.vue
@@ -157,6 +157,12 @@ export default class RunSignificanceChips extends Vue {
   private readonly run!: RunDescriptionWithDifferences | RunWithDifferences
 
   private get relevantChanges(): RelevantChange[] {
+    if (
+      this.run instanceof RunWithDifferences &&
+      this.run.significantDifferences
+    ) {
+      return this.run.significantDifferences.map(it => new RelevantChange(it))
+    }
     if (this.run.differences) {
       return this.run.differences.map(it => new RelevantChange(it))
     }

--- a/frontend/src/components/RunSignificanceChips.vue
+++ b/frontend/src/components/RunSignificanceChips.vue
@@ -1,0 +1,162 @@
+<template>
+  <v-row no-gutters class="ma-0">
+    <v-col
+      v-for="relevantChange in relevantChanges"
+      :key="
+        relevantChange.oldRunId +
+        relevantChange.id.benchmark +
+        relevantChange.id.metric
+      "
+      cols="auto"
+      class="mr-2 mt-2"
+    >
+      <v-chip
+        label
+        outlined
+        :color="relevantChange.color"
+        :input-value="true"
+        :to="{
+          name: 'run-comparison',
+          params: {
+            first: relevantChange.oldRunId,
+            second: run.run.runId
+          }
+        }"
+      >
+        <v-icon left>{{ relevantChange.icon }}</v-icon>
+        {{ relevantChange.id.benchmark }} —
+        {{ relevantChange.id.metric }}
+        <span class="font-weight-bold pl-3" style="font-size: 1.1rem">
+          {{ relevantChange.change }}
+        </span>
+      </v-chip>
+    </v-col>
+  </v-row>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import Component from 'vue-class-component'
+import {
+  Dimension,
+  DimensionDifference,
+  DimensionInterpretation,
+  RunDescriptionWithDifferences,
+  RunId
+} from '@/store/types'
+import {
+  mdiChevronDoubleDown,
+  mdiChevronDoubleUp,
+  mdiChevronDown,
+  mdiChevronTripleDown,
+  mdiChevronTripleUp,
+  mdiChevronUp
+} from '@mdi/js'
+import { Prop } from 'vue-property-decorator'
+
+const numberFormat: Intl.NumberFormat = new Intl.NumberFormat(
+  new Intl.NumberFormat().resolvedOptions().locale,
+  { maximumFractionDigits: 3 }
+)
+
+const iconMappings = {
+  up: {
+    small: mdiChevronUp,
+    middle: mdiChevronDoubleUp,
+    large: mdiChevronTripleUp
+  },
+  down: {
+    small: mdiChevronDown,
+    middle: mdiChevronDoubleDown,
+    large: mdiChevronTripleDown
+  }
+}
+
+class RelevantChange {
+  readonly id: Dimension
+  readonly change: string
+  readonly color: string
+  readonly icon: string
+  readonly oldRunId: RunId
+
+  constructor(difference: DimensionDifference) {
+    this.oldRunId = difference.oldRunId
+    this.id = difference.dimension
+    if (difference.stddevDiff !== undefined) {
+      let change = difference.relDiff
+        ? this.formatPercentage(difference.relDiff)
+        : this.formatNumber(difference.absDiff)
+      change += ` (${this.formatNumber(difference.stddevDiff)} σ)`
+
+      this.change = change
+    } else {
+      this.change = difference.relDiff
+        ? this.formatPercentage(difference.relDiff)
+        : this.formatNumber(difference.absDiff)
+    }
+    this.color = this.changeColor(
+      difference.absDiff,
+      difference.dimension.interpretation
+    )
+    this.icon = this.changeIcon(difference.absDiff)
+  }
+
+  private formatPercentage(percentage: number): string {
+    const scaled = Math.round(percentage * 100)
+    return `${scaled}%`
+  }
+
+  private formatNumber(value: number): string {
+    return numberFormat.format(value)
+  }
+
+  private changeColor(change: number, interpretation: DimensionInterpretation) {
+    if (Math.abs(change) === 0 || isNaN(change)) {
+      return ''
+    }
+
+    if (interpretation === 'NEUTRAL') {
+      return ''
+    }
+
+    let bad = false
+    if (interpretation === 'LESS_IS_BETTER') {
+      bad = change > 0
+    } else if (interpretation === 'MORE_IS_BETTER') {
+      bad = change < 0
+    }
+
+    if (bad) {
+      return 'warning'
+    }
+    return 'success'
+  }
+
+  private changeIcon(change: number): string {
+    const MIDDLE_CHANGE_THRESHOLD = 3
+    const LARGE_CHANGE_THRESHOLD = 5
+    const adjustedChange = Math.abs(Math.round(change * 100))
+
+    const direction: 'up' | 'down' = change >= 0 ? 'up' : 'down'
+
+    let magnitude: 'small' | 'middle' | 'large' = 'small'
+    if (adjustedChange >= LARGE_CHANGE_THRESHOLD) {
+      magnitude = 'large'
+    } else if (adjustedChange >= MIDDLE_CHANGE_THRESHOLD) {
+      magnitude = 'middle'
+    }
+
+    return iconMappings[direction][magnitude]
+  }
+}
+
+@Component
+export default class RunSignificanceChips extends Vue {
+  @Prop()
+  private readonly run!: RunDescriptionWithDifferences
+
+  private get relevantChanges(): RelevantChange[] {
+    return this.run.differences.map(it => new RelevantChange(it))
+  }
+}
+</script>

--- a/frontend/src/components/overviews/MultipleRunOverview.vue
+++ b/frontend/src/components/overviews/MultipleRunOverview.vue
@@ -15,42 +15,8 @@
           :key="index"
         >
           <run-overview :run="run(item)">
-            <template #content>
-              <v-row no-gutters class="ma-0">
-                <v-col
-                  v-for="relevantChange in relevantChanges(item)"
-                  :key="
-                    relevantChange.oldRunId +
-                    relevantChange.id.benchmark +
-                    relevantChange.id.metric
-                  "
-                  cols="auto"
-                  class="mr-2 mt-2"
-                >
-                  <v-chip
-                    label
-                    outlined
-                    :color="relevantChange.color"
-                    :input-value="true"
-                    :to="{
-                      name: 'run-comparison',
-                      params: {
-                        first: relevantChange.oldRunId,
-                        second: run(item).runId
-                      }
-                    }"
-                  >
-                    <v-icon left>{{ relevantChange.icon }}</v-icon>
-                    {{ relevantChange.id.benchmark }} —
-                    {{ relevantChange.id.metric }}
-                    <span
-                      class="font-weight-bold pl-3"
-                      style="font-size: 1.1rem"
-                      >{{ relevantChange.change }}</span
-                    >
-                  </v-chip>
-                </v-col>
-              </v-row>
+            <template #content v-if="showSignificantChips(item)">
+              <run-significance-chips :run="item"></run-significance-chips>
             </template>
           </run-overview>
         </v-col>
@@ -63,122 +29,13 @@
 import Vue from 'vue'
 import Component from 'vue-class-component'
 import { Prop } from 'vue-property-decorator'
-import {
-  Dimension,
-  DimensionDifference,
-  DimensionInterpretation,
-  RunDescription,
-  RunDescriptionWithDifferences,
-  RunId
-} from '@/store/types'
+import { RunDescription, RunDescriptionWithDifferences } from '@/store/types'
 import RunOverview from './RunOverview.vue'
-import {
-  mdiChevronDown,
-  mdiChevronDoubleDown,
-  mdiChevronTripleDown,
-  mdiChevronUp,
-  mdiChevronDoubleUp,
-  mdiChevronTripleUp
-} from '@mdi/js'
-
-const numberFormat: Intl.NumberFormat = new Intl.NumberFormat(
-  new Intl.NumberFormat().resolvedOptions().locale,
-  { maximumFractionDigits: 3 }
-)
-
-const iconMappings = {
-  up: {
-    small: mdiChevronUp,
-    middle: mdiChevronDoubleUp,
-    large: mdiChevronTripleUp
-  },
-  down: {
-    small: mdiChevronDown,
-    middle: mdiChevronDoubleDown,
-    large: mdiChevronTripleDown
-  }
-}
-
-class RelevantChange {
-  readonly id: Dimension
-  readonly change: string
-  readonly color: string
-  readonly icon: string
-  readonly oldRunId: RunId
-
-  constructor(difference: DimensionDifference) {
-    this.oldRunId = difference.oldRunId
-    this.id = difference.dimension
-    if (difference.stddevDiff !== undefined) {
-      let change = difference.relDiff
-        ? this.formatPercentage(difference.relDiff)
-        : this.formatNumber(difference.absDiff)
-      change += ` (${this.formatNumber(difference.stddevDiff)} σ)`
-
-      this.change = change
-    } else {
-      this.change = difference.relDiff
-        ? this.formatPercentage(difference.relDiff)
-        : this.formatNumber(difference.absDiff)
-    }
-    this.color = this.changeColor(
-      difference.absDiff,
-      difference.dimension.interpretation
-    )
-    this.icon = this.changeIcon(difference.absDiff)
-  }
-
-  private formatPercentage(percentage: number): string {
-    const scaled = Math.round(percentage * 100)
-    return `${scaled}%`
-  }
-
-  private formatNumber(value: number): string {
-    return numberFormat.format(value)
-  }
-
-  private changeColor(change: number, interpretation: DimensionInterpretation) {
-    if (Math.abs(change) === 0 || isNaN(change)) {
-      return ''
-    }
-
-    if (interpretation === 'NEUTRAL') {
-      return ''
-    }
-
-    let bad = false
-    if (interpretation === 'LESS_IS_BETTER') {
-      bad = change > 0
-    } else if (interpretation === 'MORE_IS_BETTER') {
-      bad = change < 0
-    }
-
-    if (bad) {
-      return 'warning'
-    }
-    return 'success'
-  }
-
-  private changeIcon(change: number): string {
-    const MIDDLE_CHANGE_THRESHOLD = 3
-    const LARGE_CHANGE_THRESHOLD = 5
-    const adjustedChange = Math.abs(Math.round(change * 100))
-
-    const direction: 'up' | 'down' = change >= 0 ? 'up' : 'down'
-
-    let magnitude: 'small' | 'middle' | 'large' = 'small'
-    if (adjustedChange >= LARGE_CHANGE_THRESHOLD) {
-      magnitude = 'large'
-    } else if (adjustedChange >= MIDDLE_CHANGE_THRESHOLD) {
-      magnitude = 'middle'
-    }
-
-    return iconMappings[direction][magnitude]
-  }
-}
+import RunSignificanceChips from '@/components/RunSignificanceChips.vue'
 
 @Component({
   components: {
+    'run-significance-chips': RunSignificanceChips,
     'run-overview': RunOverview
   }
 })
@@ -199,14 +56,10 @@ export default class MultipleRunOverview extends Vue {
     return run instanceof RunDescriptionWithDifferences ? run.run : run
   }
 
-  private relevantChanges(
+  private showSignificantChips(
     run: RunDescription | RunDescriptionWithDifferences
-  ): RelevantChange[] {
-    if (run instanceof RunDescription) {
-      return []
-    }
-
-    return run.differences.map(it => new RelevantChange(it))
+  ) {
+    return run instanceof RunDescriptionWithDifferences
   }
 }
 </script>

--- a/frontend/src/components/overviews/MultipleRunOverview.vue
+++ b/frontend/src/components/overviews/MultipleRunOverview.vue
@@ -15,8 +15,11 @@
           :key="index"
         >
           <run-overview :run="run(item)">
-            <template #content v-if="showSignificantChips(item)">
-              <run-significance-chips :run="item"></run-significance-chips>
+            <template #content v-if="differences(item)">
+              <run-significance-chips
+                :differences="differences(item)"
+                :run-id="run(item).runId"
+              ></run-significance-chips>
             </template>
           </run-overview>
         </v-col>
@@ -29,7 +32,11 @@
 import Vue from 'vue'
 import Component from 'vue-class-component'
 import { Prop } from 'vue-property-decorator'
-import { RunDescription, RunDescriptionWithDifferences } from '@/store/types'
+import {
+  DimensionDifference,
+  RunDescription,
+  RunDescriptionWithDifferences
+} from '@/store/types'
 import RunOverview from './RunOverview.vue'
 import RunSignificanceChips from '@/components/RunSignificanceChips.vue'
 
@@ -56,10 +63,12 @@ export default class MultipleRunOverview extends Vue {
     return run instanceof RunDescriptionWithDifferences ? run.run : run
   }
 
-  private showSignificantChips(
+  private differences(
     run: RunDescription | RunDescriptionWithDifferences
-  ) {
+  ): DimensionDifference[] | undefined {
     return run instanceof RunDescriptionWithDifferences
+      ? run.differences
+      : undefined
   }
 }
 </script>

--- a/frontend/src/components/rundetail/CommitDetail.vue
+++ b/frontend/src/components/rundetail/CommitDetail.vue
@@ -99,6 +99,7 @@
                   </div>
                 </v-col>
               </v-row>
+              <slot name="body-trailing"></slot>
             </v-container>
           </v-card-text>
         </v-card>

--- a/frontend/src/store/modules/commitDetailComparisonStore.ts
+++ b/frontend/src/store/modules/commitDetailComparisonStore.ts
@@ -44,8 +44,15 @@ export class CommitDetailComparisonStore extends VxModule {
       const differences = response.data.differences
         ? response.data.differences.map(differenceFromJson)
         : undefined
+      const significantDifferences = response.data.differences
+        ? response.data.significant_differences.map(differenceFromJson)
+        : undefined
 
-      return new RunWithDifferences(runFromJson(response.data.run), differences)
+      return new RunWithDifferences(
+        runFromJson(response.data.run),
+        differences,
+        significantDifferences
+      )
     } catch (e) {
       if (e.response && e.response.status === 404) {
         throw new NotFoundError()

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -359,10 +359,16 @@ export class RunDescription {
 export class RunWithDifferences {
   readonly run: Run
   readonly differences?: DimensionDifference[]
+  readonly significantDifferences?: DimensionDifference[]
 
-  constructor(run: Run, differences?: DimensionDifference[]) {
+  constructor(
+    run: Run,
+    differences?: DimensionDifference[],
+    significantDifferences?: DimensionDifference[]
+  ) {
     this.run = run
     this.differences = differences
+    this.significantDifferences = significantDifferences
   }
 }
 

--- a/frontend/src/views/RunCommitDetailView.vue
+++ b/frontend/src/views/RunCommitDetailView.vue
@@ -8,9 +8,10 @@
     <v-row v-if="commit" no-gutters>
       <v-col>
         <commit-detail :commit="commit">
-          <template #body-trailing v-if="runWithDifferences">
+          <template #body-trailing v-if="dimensionDifferences">
             <run-significance-chips
-              :run="runWithDifferences"
+              :differences="dimensionDifferences"
+              :run-id="runWithDifferences.run.id"
             ></run-significance-chips>
           </template>
         </commit-detail>
@@ -74,8 +75,9 @@ import {
   Commit,
   CommitTaskSource,
   Dimension,
-  RunWithDifferences,
-  TarTaskSource
+  TarTaskSource,
+  DimensionDifference,
+  RunWithDifferences
 } from '@/store/types'
 import NotFound404 from './NotFound404.vue'
 import RunDetail from '@/components/rundetail/RunDetail.vue'
@@ -109,6 +111,13 @@ export default class RunCommitDetailView extends Vue {
 
   private get secondComponent(): string | undefined {
     return this.$route.params['second']
+  }
+
+  private get dimensionDifferences(): DimensionDifference[] | undefined {
+    if (!this.runWithDifferences) {
+      return undefined
+    }
+    return this.runWithDifferences.significantDifferences
   }
 
   private async navigateToDetailGraph(dimension: Dimension) {

--- a/frontend/src/views/RunCommitDetailView.vue
+++ b/frontend/src/views/RunCommitDetailView.vue
@@ -7,7 +7,13 @@
     </v-row>
     <v-row v-if="commit" no-gutters>
       <v-col>
-        <commit-detail :commit="commit"></commit-detail>
+        <commit-detail :commit="commit">
+          <template #body-trailing v-if="runWithDifferences">
+            <run-significance-chips
+              :run="runWithDifferences"
+            ></run-significance-chips>
+          </template>
+        </commit-detail>
       </v-col>
     </v-row>
     <v-row v-if="tarSource" no-gutters justify="center">
@@ -78,9 +84,11 @@ import RunTimeline from '@/components/rundetail/RunTimeline.vue'
 import { NotFoundError } from '@/store/modules/commitDetailComparisonStore'
 import { showCommitInDetailGraph } from '@/util/GraphNavigation'
 import TarOverview from '@/components/overviews/TarOverview.vue'
+import RunSignificanceChips from '@/components/RunSignificanceChips.vue'
 
 @Component({
   components: {
+    'run-significance-chips': RunSignificanceChips,
     'tar-overview': TarOverview,
     'page-404': NotFound404,
     'run-detail': RunDetail,


### PR DESCRIPTION
## About
Show the significant dimension chips visible on the home page also on the run detail page.

## Todo
- [x] Extract the chips into their own component, show them in the detail page
- [x] This doesn't quite do what you'd expect as it shows the change for *all* dimensions. The backend would need to provide the relevant ones separately or mark them as such.

