### PR TITLE
Sleep for 5 seconds between "get_status" requests

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/Delays.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/Delays.java
@@ -18,6 +18,12 @@ public final class Delays {
 	 */
 	public static final Duration AWAIT_COMMAND_REPLY = Duration.ofSeconds(10);
 
+	/**
+	 * How long to wait between "get_status" commands. This affects the update interval of the live
+	 * build log.
+	 */
+	public static final Duration REQUEST_STATUS_INTERVAL = Duration.ofSeconds(5);
+
 	private Delays() {
 		throw new UnsupportedOperationException();
 	}

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/single/PeriodicStatusRequester.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/single/PeriodicStatusRequester.java
@@ -30,19 +30,12 @@ public class PeriodicStatusRequester {
 	private final RunnerConnection connection;
 	private final StateMachine<TeleRunnerState> stateMachine;
 	private volatile boolean cancelled;
-	private final Duration sleepBetweenIteration;
 
 	public PeriodicStatusRequester(TeleRunner teleRunner, RunnerConnection connection,
 		StateMachine<TeleRunnerState> stateMachine) {
-		this(teleRunner, connection, stateMachine, Duration.ofSeconds(5));
-	}
-
-	public PeriodicStatusRequester(TeleRunner teleRunner, RunnerConnection connection,
-		StateMachine<TeleRunnerState> stateMachine, Duration sleepBetweenIteration) {
 		this.teleRunner = teleRunner;
 		this.connection = connection;
 		this.stateMachine = stateMachine;
-		this.sleepBetweenIteration = sleepBetweenIteration;
 
 		this.worker = new Thread(this::run, "PeriodicStatusRequester");
 		this.worker.setDaemon(true);
@@ -59,8 +52,9 @@ public class PeriodicStatusRequester {
 		while (!cancelled) {
 			try {
 				iteration();
+				// Keep some distance to not overload the runner with too many requests
 				//noinspection BusyWait
-				Thread.sleep(sleepBetweenIteration.toMillis());
+				Thread.sleep(5000);
 			} catch (Exception e) {
 				LOGGER.error("Error communicating with runner or handling results", e);
 				try {

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/single/PeriodicStatusRequester.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/single/PeriodicStatusRequester.java
@@ -1,5 +1,6 @@
 package de.aaaaaaah.velcom.backend.runner.single;
 
+import de.aaaaaaah.velcom.backend.runner.Delays;
 import de.aaaaaaah.velcom.backend.runner.single.state.AwaitClearResultReply;
 import de.aaaaaaah.velcom.backend.runner.single.state.AwaitGetResultReply;
 import de.aaaaaaah.velcom.backend.runner.single.state.AwaitGetStatusReply;
@@ -54,7 +55,7 @@ public class PeriodicStatusRequester {
 				iteration();
 				// Keep some distance to not overload the runner with too many requests
 				//noinspection BusyWait
-				Thread.sleep(5000);
+				Thread.sleep(Delays.REQUEST_STATUS_INTERVAL.toMillis());
 			} catch (Exception e) {
 				LOGGER.error("Error communicating with runner or handling results", e);
 				try {

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/single/PeriodicStatusRequester.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/single/PeriodicStatusRequester.java
@@ -59,6 +59,8 @@ public class PeriodicStatusRequester {
 		while (!cancelled) {
 			try {
 				iteration();
+				//noinspection BusyWait
+				Thread.sleep(sleepBetweenIteration.toMillis());
 			} catch (Exception e) {
 				LOGGER.error("Error communicating with runner or handling results", e);
 				try {
@@ -106,8 +108,6 @@ public class PeriodicStatusRequester {
 			teleRunner.handleResults(requestResults);
 
 			clearResults();
-
-			Thread.sleep(sleepBetweenIteration.toSeconds());
 		} catch (InterruptedException | CancellationException ignored) {
 		}
 	}

--- a/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/runner/single/PeriodicStatusRequesterTest.java
+++ b/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/runner/single/PeriodicStatusRequesterTest.java
@@ -23,7 +23,6 @@ import de.aaaaaaah.velcom.shared.protocol.serialization.clientbound.ClientBoundP
 import de.aaaaaaah.velcom.shared.protocol.serialization.serverbound.GetResultReply;
 import de.aaaaaaah.velcom.shared.protocol.serialization.serverbound.GetStatusReply;
 import de.aaaaaaah.velcom.shared.protocol.statemachine.StateMachine;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
@@ -53,8 +52,7 @@ class PeriodicStatusRequesterTest {
 		this.statusRequester = new PeriodicStatusRequester(
 			teleRunner,
 			runnerConnection,
-			stateMachine,
-			Duration.ofSeconds(3)
+			stateMachine
 		);
 	}
 


### PR DESCRIPTION
Fixes a bug introduced in e3f5905e8270305a7240a3072201f7f55cc7fb5a causing the backend to not sleep *at all* if the runner had no result. If it had one it slept for a very, very short duration due to a unit mismatch. This leads to a lot of useless log output and CPU usage in the runner and backend.