### PR TITLE
Reschedule commits on another runner when one leaves

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/single/TeleRunner.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/single/TeleRunner.java
@@ -156,6 +156,7 @@ public class TeleRunner {
 			LOGGER.warn("Had a connection when I was disposed");
 			this.connection.close(StatusCode.INTERNAL_ERROR);
 		}
+		getCurrentTask().ifPresent(task -> dispatcher.getQueue().abortTask(task.getId()));
 	}
 
 	/**


### PR DESCRIPTION
When a runner stays disconnected for long enough (more than the gracePeriod + some leeway) the corresponding TeleRunner will get cleaned up. While doing so, the dispatcher checks if the runner has really disconnected and if so *disposes* it. This patch makes the `dispose` method abort any task the TeleRunner might still cling onto, so another runner can later take over and finish what the first one failed to complete.