### PR TITLE
Make runner log messages less verbose

### DIFF
--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/Connection.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/Connection.java
@@ -53,7 +53,7 @@ public class Connection implements WebSocket.Listener, HeartbeatWebsocket {
 			.get();
 		// At this point, #onOpen() should have been called already, so the socket and heartbeatHandler
 		// have been initialized.
-		LOGGER.info("Successfully opened connection to {}", address);
+		LOGGER.debug("Successfully opened connection to {}", address);
 	}
 
 	public synchronized void sendPacket(ServerBoundPacket packet) {

--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/Connection.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/Connection.java
@@ -53,7 +53,7 @@ public class Connection implements WebSocket.Listener, HeartbeatWebsocket {
 			.get();
 		// At this point, #onOpen() should have been called already, so the socket and heartbeatHandler
 		// have been initialized.
-		LOGGER.debug("Successfully opened connection to {}", address);
+		LOGGER.info("Successfully opened connection to {}", address);
 	}
 
 	public synchronized void sendPacket(ServerBoundPacket packet) {
@@ -182,7 +182,7 @@ public class Connection implements WebSocket.Listener, HeartbeatWebsocket {
 	@Override
 	public synchronized void onError(WebSocket webSocket, Throwable error) {
 		// For some reason, this function is not called after a socket.abort().
-		LOGGER.debug("Connection closed abnormally");
+		LOGGER.warn("Connection closed abnormally");
 		cleanupAfterClosed();
 	}
 

--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/TeleBackend.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/TeleBackend.java
@@ -172,9 +172,14 @@ public class TeleBackend {
 		}
 
 		if (reply.getRunId().isPresent()) {
-			LOGGER.info("{} - Starting benchmark", address);
-			startBenchmark(reply.getRunId().get()).get();
-			LOGGER.info("{} - Benchmark completed", address);
+			UUID taskId = reply.getRunId().get();
+			LOGGER.info("{} - Starting benchmark for task {}", address, taskId);
+			Boolean success = startBenchmark(taskId).get();
+			if (success) {
+				LOGGER.info("{} - Benchmark for task {} completed successfully", address, taskId);
+			} else {
+				LOGGER.info("{} - Benchmark for task {} completed unsuccessfully", address, taskId);
+			}
 			return true;
 		}
 
@@ -214,11 +219,11 @@ public class TeleBackend {
 		return replyFuture;
 	}
 
-	private CompletableFuture<Void> startBenchmark(UUID runId) {
+	private CompletableFuture<Boolean> startBenchmark(UUID runId) {
 		// The benchmarker is guaranteed to be null. For more detail, see the comment at the
 		// top of maybePerformBenchmark.
 
-		CompletableFuture<Void> benchmarkFinished = new CompletableFuture<>();
+		CompletableFuture<Boolean> benchmarkFinished = new CompletableFuture<>();
 
 		Benchmarker newBenchmarker = new Benchmarker(
 			benchmarkFinished,

--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/TeleBackend.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/TeleBackend.java
@@ -83,13 +83,14 @@ public class TeleBackend {
 		//noinspection InfiniteLoopStatement
 		while (true) {
 			try {
-				LOGGER.info("Connecting to {}", address);
+				LOGGER.info("{} - Connecting", address);
 				Connection conn = new Connection(this, address, name, token);
+				LOGGER.info("{} - Connected", address);
 				connection = conn;
 				conn.getClosedFuture().get();
-				LOGGER.info("Disconnected from {}, reconnecting immediately", address);
+				LOGGER.info("{} - Disconnected, reconnecting immediately", address);
 			} catch (ExecutionException | InterruptedException e) {
-				LOGGER.warn("Failed to connect to {}, retrying soon", address);
+				LOGGER.warn("{} - Failed to connect, retrying soon", address);
 				//noinspection BusyWait
 				Thread.sleep(Delays.RECONNECT_AFTER_FAILED_CONNECTION.toMillis());
 			}
@@ -136,7 +137,7 @@ public class TeleBackend {
 		try {
 			clearTmpFiles();
 		} catch (IOException e) {
-			LOGGER.warn("Could not clear temporary files", e);
+			LOGGER.warn("{} - Could not clear temporary files", address, e);
 			return false;
 		}
 
@@ -148,7 +149,9 @@ public class TeleBackend {
 			reply = replyFuture.get();
 		} catch (ExecutionException | CancellationException e) {
 			LOGGER.debug(
-				"Backend has no new files or something went wrong while trying to download them");
+				"{} - Backend has no new files or something went wrong while trying to download them",
+				address
+			);
 			return false;
 		}
 
@@ -158,20 +161,20 @@ public class TeleBackend {
 				benchRepoDir.setHash(reply.getBenchHash().get());
 			}
 		} catch (IOException e) {
-			LOGGER.warn("Could not unpack tar files", e);
+			LOGGER.warn("{} - Could not unpack tar files", address, e);
 			return false;
 		}
 		try {
 			clearTmpFiles();
 		} catch (IOException e) {
-			LOGGER.warn("Could not clear temporary files", e);
+			LOGGER.warn("{} - Could not clear temporary files", address, e);
 			return false;
 		}
 
 		if (reply.getRunId().isPresent()) {
-			LOGGER.info("{}: Starting benchmark", this);
+			LOGGER.info("{} - Starting benchmark", address);
 			startBenchmark(reply.getRunId().get()).get();
-			LOGGER.info("{}: Benchmark completed", this);
+			LOGGER.info("{} - Benchmark completed", address);
 			return true;
 		}
 
@@ -305,6 +308,10 @@ public class TeleBackend {
 
 	public Path getTaskRepoTmpPath() {
 		return taskRepoDir.getTmpFilePath();
+	}
+
+	public URI getAddress() {
+		return address;
 	}
 
 	@Override

--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/benchmarking/Benchmarker.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/benchmarking/Benchmarker.java
@@ -39,7 +39,7 @@ public class Benchmarker {
 	private final AtomicReference<BenchResult> result; // nullable inside the reference
 	private final AtomicReference<Supplier<LinesWithOffset>> outputFetcher; // nullable inside the reference
 
-	private final CompletableFuture<Void> finishFuture;
+	private final CompletableFuture<Boolean> finishFuture;
 
 	private final UUID taskId;
 	private final Path taskRepoPath;
@@ -69,7 +69,7 @@ public class Benchmarker {
 	 * @param runnerName the name of this runner
 	 * @param systemInfo the system information of this runner
 	 */
-	public Benchmarker(CompletableFuture<Void> finishFuture, UUID taskId, Path taskRepoPath,
+	public Benchmarker(CompletableFuture<Boolean> finishFuture, UUID taskId, Path taskRepoPath,
 		@Nullable String benchRepoHash, Path benchRepoPath, Instant startTime, String runnerName,
 		LinuxSystemInfo systemInfo) {
 
@@ -213,7 +213,7 @@ public class Benchmarker {
 	 */
 	private void setResult(@Nonnull BenchResult result) {
 		this.result.compareAndSet(null, result);
-		finishFuture.complete(null);
+		finishFuture.complete(result.isSuccess());
 	}
 
 	private StreamsProcessOutput<ProgramResult> startBenchExecution(NamedRows generalInfo,

--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/states/AwaitingBench.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/states/AwaitingBench.java
@@ -35,14 +35,14 @@ public class AwaitingBench extends RunnerState {
 
 	@Override
 	public void onEnter() {
-		LOGGER.info("{}: Receiving bench repo", teleBackend);
+		LOGGER.info("{} - Receiving bench repo", teleBackend.getAddress());
 
 		try {
 			Path benchRepoTmpPath = teleBackend.getBenchRepoTmpPath();
 			Files.createDirectories(benchRepoTmpPath.getParent());
 			tmpFile = Files.newOutputStream(benchRepoTmpPath);
 		} catch (IOException e) {
-			LOGGER.warn("{}: Could not open stream to bench repo tmp file", teleBackend, e);
+			LOGGER.warn("{} - Could not open stream to bench repo tmp file", teleBackend.getAddress(), e);
 		}
 	}
 
@@ -54,7 +54,7 @@ public class AwaitingBench extends RunnerState {
 			try {
 				tmpFile.write(bytes);
 			} catch (IOException e) {
-				LOGGER.warn("{}: Could not stream to bench repo tmp file", teleBackend, e);
+				LOGGER.warn("{} - Could not stream to bench repo tmp file", teleBackend.getAddress(), e);
 				tmpFile = null;
 			}
 		}
@@ -79,7 +79,8 @@ public class AwaitingBench extends RunnerState {
 			try {
 				tmpFile.close();
 			} catch (IOException e) {
-				LOGGER.warn("{}: Could not close stream to bench repo tmp file", teleBackend, e);
+				LOGGER
+					.warn("{} - Could not close stream to bench repo tmp file", teleBackend.getAddress(), e);
 			}
 		}
 

--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/states/AwaitingRequestRunReply.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/states/AwaitingRequestRunReply.java
@@ -3,12 +3,12 @@ package de.aaaaaaah.velcom.runner.states;
 import de.aaaaaaah.velcom.runner.Connection;
 import de.aaaaaaah.velcom.runner.Delays;
 import de.aaaaaaah.velcom.runner.TeleBackend;
-import de.aaaaaaah.velcom.shared.util.Timeout;
 import de.aaaaaaah.velcom.shared.protocol.StatusCode;
 import de.aaaaaaah.velcom.shared.protocol.serialization.Serializer;
 import de.aaaaaaah.velcom.shared.protocol.serialization.clientbound.ClientBoundPacket;
 import de.aaaaaaah.velcom.shared.protocol.serialization.clientbound.ClientBoundPacketType;
 import de.aaaaaaah.velcom.shared.protocol.serialization.clientbound.RequestRunReply;
+import de.aaaaaaah.velcom.shared.util.Timeout;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
@@ -40,7 +40,7 @@ public class AwaitingRequestRunReply extends RunnerState {
 
 	@Override
 	public void onEnter() {
-		LOGGER.debug("Waiting for request_run_reply from {}", teleBackend);
+		LOGGER.debug("{} - Waiting for request_run_reply", teleBackend.getAddress());
 		timeout.start();
 	}
 
@@ -52,7 +52,8 @@ public class AwaitingRequestRunReply extends RunnerState {
 			.filter(p -> p.getType() == ClientBoundPacketType.REQUEST_RUN_REPLY)
 			.flatMap(p -> serializer.deserialize(p.getData(), RequestRunReply.class))
 			.map(p -> {
-				LOGGER.debug("{}: hasBench {}, hasRun {}", teleBackend, p.hasBench(), p.hasRun());
+				LOGGER
+					.debug("{} - hasBench {}, hasRun {}", teleBackend.getAddress(), p.hasBench(), p.hasRun());
 				if (p.hasBench()) {
 					owningReplyFuture = false;
 					return new AwaitingBench(teleBackend, connection, p, replyFuture);

--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/states/AwaitingRun.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/states/AwaitingRun.java
@@ -32,14 +32,14 @@ public class AwaitingRun extends RunnerState {
 
 	@Override
 	public void onEnter() {
-		LOGGER.info("{}: Receiving task repo", teleBackend);
+		LOGGER.info("{} - Receiving task repo", teleBackend.getAddress());
 
 		try {
 			Path taskRepoTmpPath = teleBackend.getTaskRepoTmpPath();
 			Files.createDirectories(taskRepoTmpPath.getParent());
 			tmpFile = Files.newOutputStream(taskRepoTmpPath);
 		} catch (IOException e) {
-			LOGGER.warn("{}: Could not open stream to task repo tmp file", teleBackend, e);
+			LOGGER.warn("{} - Could not open stream to task repo tmp file", teleBackend.getAddress(), e);
 		}
 	}
 
@@ -51,7 +51,7 @@ public class AwaitingRun extends RunnerState {
 			try {
 				tmpFile.write(bytes);
 			} catch (IOException e) {
-				LOGGER.warn("{}: Could not stream to task repo tmp file", teleBackend, e);
+				LOGGER.warn("{} - Could not stream to task repo tmp file", teleBackend.getAddress(), e);
 				tmpFile = null;
 			}
 		}
@@ -72,7 +72,8 @@ public class AwaitingRun extends RunnerState {
 			try {
 				tmpFile.close();
 			} catch (IOException e) {
-				LOGGER.warn("{}: Could not close stream to task repo tmp file", teleBackend, e);
+				LOGGER
+					.warn("{} - Could not close stream to task repo tmp file", teleBackend.getAddress(), e);
 			}
 		}
 

--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/states/AwaitingRun.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/states/AwaitingRun.java
@@ -32,7 +32,8 @@ public class AwaitingRun extends RunnerState {
 
 	@Override
 	public void onEnter() {
-		LOGGER.info("{} - Receiving task repo", teleBackend.getAddress());
+		LOGGER.info("{} - Receiving task repo for task {}", teleBackend.getAddress(),
+			reply.getRunId().get());
 
 		try {
 			Path taskRepoTmpPath = teleBackend.getTaskRepoTmpPath();

--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/states/RunnerState.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/states/RunnerState.java
@@ -89,7 +89,7 @@ public abstract class RunnerState implements State {
 	}
 
 	protected Optional<RunnerState> onGetStatus(GetStatus getStatus) {
-		LOGGER.debug("Replying to get_status for {}", teleBackend);
+		LOGGER.debug("{} - Replying to get_status", teleBackend.getAddress());
 
 		GetStatusReply getStatusReply = new GetStatusReply(
 			teleBackend.getInfo().format(),
@@ -100,14 +100,14 @@ public abstract class RunnerState implements State {
 			teleBackend.getCurrentRunId().orElse(null),
 			teleBackend.getLastOutputLines().orElse(null)
 		);
-		LOGGER.debug("Replying with {}", getStatusReply);
+		LOGGER.debug("{} - Replying with {}", teleBackend.getAddress(), getStatusReply);
 		connection.sendPacket(getStatusReply.asPacket(connection.getSerializer()));
 
 		return Optional.of(this);
 	}
 
 	protected Optional<RunnerState> onGetResult(GetResult getResult) {
-		LOGGER.debug("Replying to get_result for {}", teleBackend);
+		LOGGER.debug("{} - Replying to get_result", teleBackend.getAddress());
 
 		Optional<BenchResult> resultOptional = teleBackend.getBenchResult();
 		if (resultOptional.isEmpty()) {
@@ -115,7 +115,8 @@ public abstract class RunnerState implements State {
 			return Optional.empty();
 		}
 		BenchResult result = resultOptional.get();
-		LOGGER.debug("Replying with result for run {}", result.getRunId());
+		LOGGER
+			.debug("{} - Replying with result for run {}", teleBackend.getAddress(), result.getRunId());
 
 		GetResultReply getResultReply = new GetResultReply(
 			result.getRunId(),
@@ -131,7 +132,7 @@ public abstract class RunnerState implements State {
 	}
 
 	protected Optional<RunnerState> onClearResult(ClearResult clearResult) {
-		LOGGER.debug("Replying to clear_result for {}", teleBackend);
+		LOGGER.debug("{} - Replying to clear_result", teleBackend.getAddress());
 
 		if (!teleBackend.clearBenchResult()) {
 			connection.close(StatusCode.NO_RESULT);
@@ -143,7 +144,7 @@ public abstract class RunnerState implements State {
 	}
 
 	protected Optional<RunnerState> onAbortRun(AbortRun abortRun) {
-		LOGGER.debug("Replying to abort_run for {}", teleBackend);
+		LOGGER.debug("{} - Replying to abort_run", teleBackend.getAddress());
 
 		teleBackend.abortCurrentRun();
 		connection.sendPacket(new AbortRunReply().asPacket(connection.getSerializer()));
@@ -160,7 +161,7 @@ public abstract class RunnerState implements State {
 	 * @return the state to switch to next
 	 */
 	public RunnerState onBinary(ByteBuffer data, boolean last) {
-		LOGGER.debug("Received invalid binary data from {}", teleBackend);
+		LOGGER.debug("{} - Received invalid binary data", teleBackend.getAddress());
 
 		// Binary packets are only expected in certain circumstances, but usually they are invalid
 		// behaviour.

--- a/backend/runner/src/main/resources/logback.xml
+++ b/backend/runner/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 
 <configuration scan="true">
   <!-- Configure my logging level -->
-  <logger name="de.aaaaaaah.velcom.runner" level="DEBUG"/>
+  <logger name="de.aaaaaaah.velcom.runner" level="INFO"/>
 
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
@@ -10,24 +10,7 @@
     </encoder>
   </appender>
 
-  <!--  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">-->
-  <!--    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">-->
-  <!--      <fileNamePattern>logs/bot.%d{yyyy-MM-dd}.log</fileNamePattern>-->
-  <!--      <maxHistory>90</maxHistory>-->
-  <!--    </rollingPolicy>-->
-  <!--    <encoder>-->
-  <!--      <charset>UTF-8</charset>-->
-  <!--      <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %-40.40logger{39} : %msg%n</Pattern>-->
-  <!--    </encoder>-->
-  <!--    <prudent>true</prudent>-->
-  <!--  </appender>-->
-
-  <!--  <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">-->
-  <!--    <queueSize>512</queueSize>-->
-  <!--    <appender-ref ref="FILE"/>-->
-  <!--  </appender>-->
-
-  <root level="debug">
+  <root level="INFO">
     <appender-ref ref="CONSOLE"/>
   </root>
 </configuration>


### PR DESCRIPTION
The runner's default log level is now INFO. Cleaned up the log messages a bit to make them more consistent and show a bit more info.