### PR TITLE
Change significance criteria

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/recentruns/SignificantRunsCollector.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/recentruns/SignificantRunsCollector.java
@@ -139,7 +139,7 @@ public class SignificantRunsCollector {
 			.filter(difference -> isDifferenceSignificant(difference, significantDimensions))
 			.collect(toList());
 
-		if (hasFails(run) || !significantDifferences.isEmpty()) {
+		if (hasSignificantFails(run, significantDimensions) || !significantDifferences.isEmpty()) {
 			return Optional.of(new SignificantRun(run, significantDifferences));
 		} else {
 			return Optional.empty();
@@ -147,11 +147,13 @@ public class SignificantRunsCollector {
 	}
 
 	/**
-	 * @return true if the run has failed measurements or is entirely failed
+	 * @return true if the run has failed significant measurements or is entirely failed
 	 */
-	private boolean hasFails(Run run) {
+	private boolean hasSignificantFails(Run run, Set<Dimension> significantDimensions) {
 		return run.getResult().getRight()
-			.map(ms -> ms.stream().anyMatch(m -> m.getContent().isLeft()))
+			.map(ms -> ms.stream()
+				.filter(m -> significantDimensions.contains(m.getDimension()))
+				.anyMatch(m -> m.getContent().isLeft()))
 			.orElse(true);
 	}
 


### PR DESCRIPTION
Now, partially successful runs where only insignificant dimensions failed are no longer significant. However, the list of significant runs is still often full of failed or partially failed runs, which can be annoying. Possible solutions would be:

1. Only successful runs can be significant
2. Partly failed runs (yellow) are treated like successful runs (i. e. the failed dimensions are ignored). Completely failed runs are still automatically significant.

I'm not sure whether this is really an issue that needs to be solved, or whether it's fine as is. Any opinions, @Kha?