### PR TITLE
Fix run detail endpoint by returning repo id for tars attached to repos

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/BenchmarkReadAccess.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/BenchmarkReadAccess.java
@@ -14,6 +14,7 @@ import de.aaaaaaah.velcom.backend.access.entities.MeasurementError;
 import de.aaaaaaah.velcom.backend.access.entities.MeasurementValues;
 import de.aaaaaaah.velcom.backend.access.entities.Run;
 import de.aaaaaaah.velcom.backend.access.entities.RunId;
+import de.aaaaaaah.velcom.backend.newaccess.AccessUtils;
 import de.aaaaaaah.velcom.backend.newaccess.benchmarkaccess.entities.CommitSource;
 import de.aaaaaaah.velcom.backend.newaccess.benchmarkaccess.entities.RunError;
 import de.aaaaaaah.velcom.backend.newaccess.benchmarkaccess.entities.RunErrorType;
@@ -273,17 +274,11 @@ public class BenchmarkReadAccess {
 			.map(runRecord -> {
 				RunId runId = new RunId(UUID.fromString(runRecord.getId()));
 
-				final Either<CommitSource, TarSource> source;
-
-				if (runRecord.getCommitHash() != null) {
-					source = Either.ofLeft(new CommitSource(
-						new RepoId(UUID.fromString(runRecord.getRepoId())),
-						new CommitHash(runRecord.getCommitHash())
-					));
-				} else {
-					// If commit hash is null, tar desc must be present
-					source = Either.ofRight(new TarSource(runRecord.getTarDesc()));
-				}
+				final Either<CommitSource, TarSource> source = AccessUtils.readSource(
+					runRecord.getRepoId(),
+					runRecord.getCommitHash(),
+					runRecord.getTarDesc()
+				);
 
 				if (runRecord.getError() != null) {
 					RunError error = new RunError(

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/newaccess/AccessUtils.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/newaccess/AccessUtils.java
@@ -5,6 +5,7 @@ import de.aaaaaaah.velcom.backend.newaccess.benchmarkaccess.entities.TarSource;
 import de.aaaaaaah.velcom.backend.newaccess.committaccess.entities.CommitHash;
 import de.aaaaaaah.velcom.backend.newaccess.repoaccess.entities.RepoId;
 import de.aaaaaaah.velcom.shared.util.Either;
+import java.util.Optional;
 import javax.annotation.Nullable;
 
 public class AccessUtils {
@@ -34,13 +35,13 @@ public class AccessUtils {
 				RepoId.fromString(repoId),
 				new CommitHash(commitHash)
 			));
-		} else if (repoId != null) { // Must be tar source with repo id
+		} else { // Must be tar source
 			return Either.ofRight(new TarSource(
 				tarDesc,
-				RepoId.fromString(repoId)
+				Optional.ofNullable(repoId)
+					.map(RepoId::fromString)
+					.orElse(null)
 			));
-		} else { // Must be tar source without repo id
-			return Either.ofRight(new TarSource(tarDesc));
 		}
 	}
 

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/newaccess/benchmarkaccess/entities/TarSource.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/newaccess/benchmarkaccess/entities/TarSource.java
@@ -11,10 +11,6 @@ public class TarSource {
 	@Nullable
 	private final RepoId repoId;
 
-	public TarSource(String description) {
-		this(description, null);
-	}
-
 	public TarSource(String description, @Nullable RepoId repoId) {
 		this.description = Objects.requireNonNull(description);
 		this.repoId = repoId;


### PR DESCRIPTION
Fixes a bug where the run detail endpoint would incorrectly return tar sources without repo id even though the tars were attached to a repo.