### PR TITLE
Display tar sources in run detail / comparison

### DIFF
--- a/frontend/src/components/comparison/ComparisonRunInfo.vue
+++ b/frontend/src/components/comparison/ComparisonRunInfo.vue
@@ -1,0 +1,71 @@
+<template>
+  <run-info :run="run">
+    <template #title>
+      <span>{{ title }}</span>
+      <v-spacer></v-spacer>
+      <v-chip
+        :to="{
+          name: 'run-detail',
+          params: { first: run.id }
+        }"
+        outlined
+        label
+      >
+        Run id: {{ run.id }}
+      </v-chip>
+    </template>
+    <template #before-body>
+      <v-row class="mx-1" v-if="commit">
+        <v-col>
+          <commit-overview-base
+            :commit="commit"
+            :outlined="true"
+          ></commit-overview-base>
+        </v-col>
+      </v-row>
+      <v-row class="mx-1" v-if="tar">
+        <v-col cols="auto">
+          <tar-overview :tar-source="tar"></tar-overview>
+        </v-col>
+      </v-row>
+    </template>
+  </run-info>
+</template>
+<script lang="ts">
+import Vue from 'vue'
+import Component from 'vue-class-component'
+import CommitOverviewBase from '@/components/overviews/CommitOverviewBase.vue'
+import RunInfo from '@/components/rundetail/RunInfo.vue'
+import TarOverview from '@/components/overviews/TarOverview.vue'
+import { CommitTaskSource, Run, TarTaskSource } from '@/store/types'
+import { Prop } from 'vue-property-decorator'
+
+@Component({
+  components: {
+    'commit-overview-base': CommitOverviewBase,
+    'tar-overview': TarOverview,
+    'run-info': RunInfo
+  }
+})
+export default class ComparisonRunInfo extends Vue {
+  @Prop()
+  private readonly run!: Run
+
+  @Prop()
+  private readonly title!: string
+
+  private get commit() {
+    if (this.run.source instanceof CommitTaskSource) {
+      return this.run.source.commitDescription
+    }
+    return null
+  }
+
+  private get tar() {
+    if (this.run.source instanceof TarTaskSource) {
+      return this.run.source
+    }
+    return null
+  }
+}
+</script>

--- a/frontend/src/components/overviews/TarOverview.vue
+++ b/frontend/src/components/overviews/TarOverview.vue
@@ -1,0 +1,29 @@
+<template>
+  <v-card outlined>
+    <v-card-title> Tar '{{ tarSource.description }}' </v-card-title>
+    <v-card-subtitle v-if="tarSource.repoId">
+      Attached to
+      <inline-minimal-repo-display
+        :repo-id="tarSource.repoId"
+      ></inline-minimal-repo-display>
+    </v-card-subtitle>
+  </v-card>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import Component from 'vue-class-component'
+import { Prop } from 'vue-property-decorator'
+import { TarTaskSource } from '@/store/types'
+import InlineMinimalRepoNameDisplay from '@/components/InlineMinimalRepoDisplay.vue'
+
+@Component({
+  components: {
+    'inline-minimal-repo-display': InlineMinimalRepoNameDisplay
+  }
+})
+export default class TarOverview extends Vue {
+  @Prop()
+  private readonly tarSource!: TarTaskSource
+}
+</script>

--- a/frontend/src/views/RunCommitDetailView.vue
+++ b/frontend/src/views/RunCommitDetailView.vue
@@ -10,6 +10,11 @@
         <commit-detail :commit="commit"></commit-detail>
       </v-col>
     </v-row>
+    <v-row v-if="tarSource" no-gutters justify="center">
+      <v-col cols="auto">
+        <tar-overview :tar-source="tarSource"></tar-overview>
+      </v-col>
+    </v-row>
     <v-row v-if="runWithDifferences" no-gutters>
       <v-col>
         <run-detail
@@ -63,7 +68,8 @@ import {
   Commit,
   CommitTaskSource,
   Dimension,
-  RunWithDifferences
+  RunWithDifferences,
+  TarTaskSource
 } from '@/store/types'
 import NotFound404 from './NotFound404.vue'
 import RunDetail from '@/components/rundetail/RunDetail.vue'
@@ -71,9 +77,11 @@ import CommitDetail from '@/components/rundetail/CommitDetail.vue'
 import RunTimeline from '@/components/rundetail/RunTimeline.vue'
 import { NotFoundError } from '@/store/modules/commitDetailComparisonStore'
 import { showCommitInDetailGraph } from '@/util/GraphNavigation'
+import TarOverview from '@/components/overviews/TarOverview.vue'
 
 @Component({
   components: {
+    'tar-overview': TarOverview,
     'page-404': NotFound404,
     'run-detail': RunDetail,
     'commit-detail': CommitDetail,
@@ -83,6 +91,7 @@ import { showCommitInDetailGraph } from '@/util/GraphNavigation'
 export default class RunCommitDetailView extends Vue {
   private runWithDifferences: RunWithDifferences | null = null
   private commit: Commit | null = null
+  private tarSource: TarTaskSource | null = null
   private show404: boolean = false
   private finishedLoading: boolean = false
 
@@ -125,6 +134,7 @@ export default class RunCommitDetailView extends Vue {
     this.show404 = false
     this.runWithDifferences = null
     this.commit = null
+    this.tarSource = null
     this.finishedLoading = false
 
     if (this.firstComponent && !this.secondComponent) {
@@ -139,6 +149,8 @@ export default class RunCommitDetailView extends Vue {
           repoId: run.source.commitDescription.repoId,
           commitHash: run.source.commitDescription.hash
         })
+      } else {
+        this.tarSource = run.source
       }
     } else if (this.firstComponent && this.secondComponent) {
       // we have a repo id and commit hash

--- a/frontend/src/views/RunComparison.vue
+++ b/frontend/src/views/RunComparison.vue
@@ -18,62 +18,18 @@
     </v-row>
     <v-row v-if="comparison && comparison.run1">
       <v-col>
-        <run-info :run="comparison.run1">
-          <template #title>
-            <span>First Run Information</span>
-            <v-spacer></v-spacer>
-            <v-chip
-              :to="{
-                name: 'run-detail',
-                params: { first: comparison.run1.id }
-              }"
-              outlined
-              label
-            >
-              Run id: {{ comparison.run1.id }}
-            </v-chip>
-          </template>
-          <template #before-body v-if="firstCommit">
-            <v-row class="mx-1">
-              <v-col>
-                <commit-overview-base
-                  :commit="firstCommit"
-                  :outlined="true"
-                ></commit-overview-base>
-              </v-col>
-            </v-row>
-          </template>
-        </run-info>
+        <comparison-run-info
+          :run="comparison.run1"
+          title="First Run Information"
+        />
       </v-col>
     </v-row>
     <v-row v-if="comparison && comparison.run2">
       <v-col>
-        <run-info :run="comparison.run2">
-          <template #title>
-            <span>Second Run Information</span>
-            <v-spacer></v-spacer>
-            <v-chip
-              :to="{
-                name: 'run-detail',
-                params: { first: comparison.run2.id }
-              }"
-              outlined
-              label
-            >
-              Run id: {{ comparison.run2.id }}
-            </v-chip>
-          </template>
-          <template #before-body v-if="secondCommit">
-            <v-row class="mx-1">
-              <v-col>
-                <commit-overview-base
-                  :commit="secondCommit"
-                  :outlined="true"
-                ></commit-overview-base>
-              </v-col>
-            </v-row>
-          </template>
-        </run-info>
+        <comparison-run-info
+          :run="comparison.run2"
+          title="Second Run Information"
+        />
       </v-col>
     </v-row>
   </v-container>
@@ -84,18 +40,17 @@ import Vue from 'vue'
 import Component from 'vue-class-component'
 import { vxm } from '@/store'
 import { Watch } from 'vue-property-decorator'
-import {
-  CommitDescription,
-  CommitTaskSource,
-  Run,
-  RunComparison
-} from '@/store/types'
+import { RunComparison } from '@/store/types'
 import RunComparisonTable from '@/components/comparison/RunComparisonTable.vue'
 import CommitOverviewBase from '@/components/overviews/CommitOverviewBase.vue'
 import RunInfo from '@/components/rundetail/RunInfo.vue'
+import TarOverview from '@/components/overviews/TarOverview.vue'
+import ComparisonRunInfo from '@/components/comparison/ComparisonRunInfo.vue'
 
 @Component({
   components: {
+    ComparisonRunInfo,
+    'tar-overview': TarOverview,
     'commit-overview-base': CommitOverviewBase,
     'run-info': RunInfo,
     'comparison-table': RunComparisonTable
@@ -133,27 +88,6 @@ export default class RunComparisonView extends Vue {
       hash1: this.hash1,
       hash2: this.hash2
     })
-  }
-
-  private get firstCommit() {
-    if (!this.comparison) {
-      return null
-    }
-    return this.commitForRun(this.comparison.run1)
-  }
-
-  private get secondCommit() {
-    if (!this.comparison) {
-      return null
-    }
-    return this.commitForRun(this.comparison.run2)
-  }
-
-  private commitForRun(run: Run): CommitDescription | null {
-    if (!(run.source instanceof CommitTaskSource)) {
-      return null
-    }
-    return run.source.commitDescription
   }
 
   mounted(): void {

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -31,15 +31,7 @@
     </v-row>
     <v-row v-if="tarSource" justify="center">
       <v-col cols="auto">
-        <v-card outlined>
-          <v-card-title> Tar '{{ tarSource.description }}' </v-card-title>
-          <v-card-subtitle v-if="tarSource.repoId">
-            Attached to
-            <inline-minimal-repo-display
-              :repo-id="tarSource.repoId"
-            ></inline-minimal-repo-display>
-          </v-card-subtitle>
-        </v-card>
+        <tar-overview :tar-source="tarSource"></tar-overview>
       </v-col>
     </v-row>
     <v-row v-if="taskInfo" no-gutters>
@@ -98,9 +90,11 @@ import TaskRunnerOutput from '@/components/TaskRunnerOutput.vue'
 import InlineMinimalRepoDisplay from '@/components/InlineMinimalRepoDisplay.vue'
 import { TaskInfo } from '@/store/modules/queueStore'
 import { formatDurationShort } from '@/util/TimeUtil'
+import TarOverview from '@/components/overviews/TarOverview.vue'
 
 @Component({
   components: {
+    'tar-overview': TarOverview,
     'inline-minimal-repo-display': InlineMinimalRepoDisplay,
     'task-runner-output': TaskRunnerOutput,
     'page-404': NotFound404,


### PR DESCRIPTION
This commits shows the tar information in the run detail or run comparison views:

### Run detail
![image](https://user-images.githubusercontent.com/20284688/102018761-aa22be80-3d6f-11eb-8807-4ffa0feb3824.png)

### Run comparison
![image](https://user-images.githubusercontent.com/20284688/102018839-0e458280-3d70-11eb-9003-2440f475081f.png)

