### PR TITLE
Persist task output in task detail view

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/QueueEndpoint.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/QueueEndpoint.java
@@ -312,35 +312,15 @@ public class QueueEndpoint {
 	@GET
 	@Timed(histogram = true)
 	public GetTaskOutputReply getRunnerOutput(@PathParam("taskid") UUID taskId) {
-		Optional<LinesWithOffset> lastOutputLinesOpt = findLinesForTask(taskId);
+		Optional<LinesWithOffset> lastOutputLinesOpt = dispatcher.findLinesForTask(taskId);
 
 		if (lastOutputLinesOpt.isEmpty()) {
 			throw new WebApplicationException(Status.NOT_FOUND);
 		}
 
-		LinesWithOffset lastOutputLines = lastOutputLinesOpt
-			.orElse(new LinesWithOffset(0, List.of()));
+		LinesWithOffset lastOutputLines = lastOutputLinesOpt.orElseThrow();
 
 		return new GetTaskOutputReply(lastOutputLines.getLines(), lastOutputLines.getFirstLineOffset());
-	}
-
-	private Optional<LinesWithOffset> findLinesForTask(UUID taskId) {
-		Optional<KnownRunner> activeWorker = dispatcher.getKnownRunners().stream()
-			.filter(it -> it.getCurrentTask().isPresent())
-			.filter(it -> it.getCurrentTask().get().getId().getId().equals(taskId))
-			.findAny();
-
-		if (activeWorker.isPresent()) {
-			LinesWithOffset lastOutputLines = activeWorker.get().getLastOutputLines()
-				.orElse(new LinesWithOffset(0, List.of()));
-			return Optional.of(lastOutputLines);
-		}
-
-		return dispatcher.getKnownRunners().stream()
-			.flatMap(it -> it.getCompletedTasks().stream())
-			.filter(it -> it.getTaskId().getId().equals(taskId))
-			.findFirst()
-			.map(it -> it.getLastLogLines().orElse(new LinesWithOffset(0, List.of())));
 	}
 
 	private static class PostOneUpReply {

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/IDispatcher.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/IDispatcher.java
@@ -1,6 +1,9 @@
 package de.aaaaaaah.velcom.backend.runner;
 
+import de.aaaaaaah.velcom.shared.util.LinesWithOffset;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 /**
  * The dispatcher interface other modules can compile against.
@@ -11,4 +14,11 @@ public interface IDispatcher {
 	 * @return a list with all known runners
 	 */
 	List<KnownRunner> getKnownRunners();
+
+	/**
+	 * @param taskId the task to find the last log lines for
+	 * @return the last output lines for a given task. Considers live runners and the last few
+	 * 	finished results of each runner.
+	 */
+	Optional<LinesWithOffset> findLinesForTask(UUID taskId);
 }

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/KnownRunner.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/KnownRunner.java
@@ -1,9 +1,11 @@
 package de.aaaaaaah.velcom.backend.runner;
 
 import de.aaaaaaah.velcom.backend.access.taskaccess.entities.Task;
+import de.aaaaaaah.velcom.backend.access.taskaccess.entities.TaskId;
 import de.aaaaaaah.velcom.shared.protocol.serialization.Status;
 import de.aaaaaaah.velcom.shared.util.LinesWithOffset;
 import java.time.Instant;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -25,6 +27,7 @@ public class KnownRunner {
 	final LinesWithOffset lastOutputLines;
 	@Nullable
 	private final Instant workingSince;
+	private final List<CompletedTask> completedTasks;
 
 	/**
 	 * Creates a new known runner.
@@ -37,10 +40,12 @@ public class KnownRunner {
 	 * @param lostConnection true if the connection to the runner is lost
 	 * @param workingSince the time the runner is working on a run now
 	 * @param lastOutputLines the last output lines
+	 * @param completedTasks the last few completed tasks
 	 */
 	public KnownRunner(String name, String information, @Nullable String versionHash,
 		Status lastStatus, @Nullable Task task, boolean lostConnection,
-		@Nullable Instant workingSince, @Nullable LinesWithOffset lastOutputLines) {
+		@Nullable Instant workingSince, @Nullable LinesWithOffset lastOutputLines,
+		List<CompletedTask> completedTasks) {
 		this.name = Objects.requireNonNull(name, "name can not be null!");
 		this.information = Objects.requireNonNull(information, "information can not be null!");
 		this.versionHash = versionHash;
@@ -49,6 +54,7 @@ public class KnownRunner {
 		this.lostConnection = lostConnection;
 		this.workingSince = workingSince;
 		this.lastOutputLines = lastOutputLines;
+		this.completedTasks = completedTasks;
 	}
 
 	public String getName() {
@@ -95,6 +101,13 @@ public class KnownRunner {
 		return Optional.ofNullable(workingSince);
 	}
 
+	/**
+	 * @return the last few completed tasks
+	 */
+	public List<CompletedTask> getCompletedTasks() {
+		return completedTasks;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
@@ -131,5 +144,25 @@ public class KnownRunner {
 			", currentTask=" + currentTask +
 			", workingSince=" + workingSince +
 			'}';
+	}
+
+	public static class CompletedTask {
+
+		private final TaskId taskId;
+		@Nullable
+		private final LinesWithOffset lastLogLines;
+
+		public CompletedTask(TaskId taskId, @Nullable LinesWithOffset lastLogLines) {
+			this.taskId = taskId;
+			this.lastLogLines = lastLogLines;
+		}
+
+		public TaskId getTaskId() {
+			return taskId;
+		}
+
+		public Optional<LinesWithOffset> getLastLogLines() {
+			return Optional.ofNullable(lastLogLines);
+		}
 	}
 }

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/single/TeleRunner.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/single/TeleRunner.java
@@ -255,7 +255,7 @@ public class TeleRunner {
 				runnerInformation.get().getLastOutputLines().orElse(null)
 			));
 
-			while (lastResults.size() >= MAX_CACHED_COMPLETED_TASKS) {
+			while (lastResults.size() > MAX_CACHED_COMPLETED_TASKS) {
 				lastResults.poll();
 			}
 		}

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/single/TeleRunner.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/single/TeleRunner.java
@@ -45,6 +45,11 @@ import org.slf4j.LoggerFactory;
 public class TeleRunner {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(TeleRunner.class);
+	/**
+	 * Completed tasks are cached so we can continue to show output lines in the frontend even if the
+	 * task has finished. This variable controls *how many* are ached.
+ 	 */
+	private static final int MAX_CACHED_COMPLETED_TASKS = 2;
 
 	private final AtomicReference<GetStatusReply> runnerInformation;
 	private final Queue<CompletedTask> lastResults;
@@ -245,14 +250,14 @@ public class TeleRunner {
 		}
 
 		synchronized (lastResults) {
-			// TODO: Find a sensible value. Currently it keeps 2 results around
-			while (lastResults.size() >= 2) {
-				lastResults.poll();
-			}
 			lastResults.offer(new CompletedTask(
 				new TaskId(resultReply.getRunId()),
 				runnerInformation.get().getLastOutputLines().orElse(null)
 			));
+
+			while (lastResults.size() >= MAX_CACHED_COMPLETED_TASKS) {
+				lastResults.poll();
+			}
 		}
 
 		NewRun run;

--- a/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/runner/DispatcherTest.java
+++ b/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/runner/DispatcherTest.java
@@ -13,6 +13,7 @@ import de.aaaaaaah.velcom.backend.runner.single.TeleRunner;
 import de.aaaaaaah.velcom.shared.protocol.serialization.Status;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,7 +41,8 @@ class DispatcherTest {
 			null,
 			false,
 			null,
-			null
+			null,
+			List.of()
 		);
 	}
 

--- a/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/runner/single/TeleRunnerTest.java
+++ b/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/runner/single/TeleRunnerTest.java
@@ -134,8 +134,7 @@ class TeleRunnerTest {
 		runner.setRunnerInformation(first);
 
 		assertThat(runner.getRunnerInformation()).isEqualTo(new KnownRunner(
-			runner.getRunnerName(), "hey", "there", Status.IDLE, null, true, null, null
-		));
+			runner.getRunnerName(), "hey", "there", Status.IDLE, null, true, null, null,			List.of()));
 
 		GetStatusReply second = new GetStatusReply(
 			"hey2", "there2", "my2", false, Status.IDLE, null, null
@@ -143,8 +142,7 @@ class TeleRunnerTest {
 		runner.setRunnerInformation(second);
 
 		assertThat(runner.getRunnerInformation()).isEqualTo(new KnownRunner(
-			runner.getRunnerName(), "hey2", "there2", Status.IDLE, null, true, null, null
-		));
+			runner.getRunnerName(), "hey2", "there2", Status.IDLE, null, true, null, null, List.of()));
 	}
 
 	// FIXME: This is questionable below here

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -129,12 +129,14 @@ export default class TaskDetailView extends Vue {
   private async update() {
     this.show404 = false
 
-    this.taskInfo = await vxm.queueModule.fetchTaskInfo(this.taskId)
+    const newInfo = await vxm.queueModule.fetchTaskInfo(this.taskId)
 
-    if (!this.taskInfo) {
+    if (!newInfo) {
       await this.handleTaskNotFound()
       return
     }
+
+    this.taskInfo = newInfo
     await this.handleSource(this.taskInfo.task.source)
   }
 


### PR DESCRIPTION
The runner output on the task detail page is no longer cleared. Additionally, the backend now keeps track of the last two tasks per runner and allows fetching their last lines after they have finished.