### PR TITLE
Use "xl" breakpoint earlier

### DIFF
--- a/frontend/src/scss/variables.scss
+++ b/frontend/src/scss/variables.scss
@@ -1,7 +1,17 @@
+@import '~vuetify/src/styles/styles.sass';
+
 $material-dark: (
-  "background": #2f3136,
-  "cards": #2f3136,
-  "text": (
-    "primary": rgba(255,255,255, 0.87)
+  'background': #2f3136,
+  'cards': #2f3136,
+  'text': (
+    'primary': rgba(255, 255, 255, 0.87)
+  )
+);
+
+// You need to map-merge your new SASS variables
+$grid-breakpoints: map-merge(
+  $grid-breakpoints,
+  (
+    xl: 1300px
   )
 );


### PR DESCRIPTION
This might be a bit of a controversial change, but the xl breakpoint is now triggered at 1300 instead of 1900 pixels.

Due to this VelCom will now use nearly the full width of the window a lot earlier and not have as much space around it, even if you open it on a smaller monitor or split/resize the window.

If most feel this is a "Verschlimmbesserung", the PR can be closed.

## Before
![image](https://user-images.githubusercontent.com/20284688/102533516-d0b16400-40a5-11eb-8dc7-20882d5f3262.png)


## After
![image](https://user-images.githubusercontent.com/20284688/102533754-1e2dd100-40a6-11eb-98c3-35556c3e5496.png)
