### PR TITLE
Remove stddev colors and other minor issues

### DIFF
--- a/frontend/src/axios-config-userdata.d.ts
+++ b/frontend/src/axios-config-userdata.d.ts
@@ -45,6 +45,13 @@ declare module 'axios' {
     snackbarTag?: string
 
     /**
+     * The priority of this message. Higher priority
+     * (i.e. the snackbarPriority is larger) messages prevent lower ones from
+     * showing up.
+     */
+    snackbarPriority?: number
+
+    /**
      * A number uniquely identifying this request.
      *
      * @type {number}

--- a/frontend/src/components/Snackbar.vue
+++ b/frontend/src/components/Snackbar.vue
@@ -62,7 +62,7 @@ export default class Snackbar extends Vue implements ISnackbar {
     this.displayNormalText(
       this.appendTag('Please stand by, processing', `'${tag}'`) + '...',
       'info',
-      60 * 60 * 1000,
+      1000 * 60 * 5, // ms * seconds * minutes
       priority
     )
     this.loading = true

--- a/frontend/src/components/rundetail/MeasurementsDisplay.vue
+++ b/frontend/src/components/rundetail/MeasurementsDisplay.vue
@@ -49,7 +49,7 @@
         </v-btn>
       </template>
       <template
-        v-for="{ slotName, displayField, tooltip } in headerFormats"
+        v-for="{ slotName, displayField, tooltip, colored } in headerFormats"
         v-slot:[slotName]="{ item }"
       >
         <span :key="slotName">
@@ -58,7 +58,7 @@
             :tooltip-message="
               typeof tooltip === 'string' ? tooltip : tooltip(item)
             "
-            :color="item.changeColor"
+            :color="colored ? item.changeColor : undefined"
           ></measurement-value>
         </span>
       </template>
@@ -206,7 +206,8 @@ export default class MeasurementsDisplay extends Vue {
       {
         slotName: 'item.change',
         displayField: 'changeFormatted',
-        tooltip: 'No unambiguous parent commit found'
+        tooltip: 'No unambiguous parent commit found',
+        colored: true
       },
       {
         slotName: 'item.changePercent',
@@ -216,19 +217,22 @@ export default class MeasurementsDisplay extends Vue {
             return 'No unambiguous parent commit found'
           }
           return "The old value was zero. I can't divide by it :/"
-        }
+        },
+        colored: true
       },
       {
         slotName: 'item.standardDeviation',
         displayField: 'standardDeviationFormatted',
         tooltip:
-          'Not applicable as the benchmark script did not report enough values'
+          'Not applicable as the benchmark script did not report enough values',
+        colored: false
       },
       {
         slotName: 'item.standardDeviationPercent',
         displayField: 'standardDeviationPercentFormatted',
         tooltip:
-          'Not applicable as the benchmark script did not report enough values'
+          'Not applicable as the benchmark script did not report enough values',
+        colored: false
       }
     ]
   }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -57,7 +57,7 @@ axios.interceptors.request.use(
 
       setTimeout(() => {
         if (loadingElements.has(randomTag)) {
-          vue.$globalSnackbar.setLoading(prefix)
+          vue.$globalSnackbar.setLoading(prefix, config.snackbarPriority)
         }
       }, 1000)
     }
@@ -69,7 +69,11 @@ axios.interceptors.request.use(
     // Always display network errors
     if (!error.response) {
       const prefix = error.config.snackbarTag || ''
-      vue.$globalSnackbar.setError(prefix, extractErrorMessage(error))
+      vue.$globalSnackbar.setError(
+        prefix,
+        extractErrorMessage(error),
+        error.config.snackbarPriority
+      )
     }
     return Promise.reject(error)
   }
@@ -81,10 +85,17 @@ axios.interceptors.response.use(
     loadingElements.delete(response.config.randomTag!)
 
     const prefix = response.config.snackbarTag || ''
-    vue.$globalSnackbar.finishedLoading(prefix)
+    vue.$globalSnackbar.finishedLoading(
+      prefix,
+      response.config.snackbarPriority
+    )
 
     if (response.config.showSuccessSnackbar) {
-      vue.$globalSnackbar.setSuccess(prefix, 'Success!')
+      vue.$globalSnackbar.setSuccess(
+        prefix,
+        'Success!',
+        response.config.snackbarPriority
+      )
     }
 
     return response
@@ -94,7 +105,11 @@ axios.interceptors.response.use(
 
     if (!error.config.hideFromSnackbar && !error.config.hideErrorSnackbar) {
       const prefix = error.config.snackbarTag || ''
-      vue.$globalSnackbar.setError(prefix, extractErrorMessage(error))
+      vue.$globalSnackbar.setError(
+        prefix,
+        extractErrorMessage(error),
+        error.config.snackbarPriority
+      )
     }
     return Promise.reject(error)
   }

--- a/frontend/src/store/modules/commitDetailComparisonStore.ts
+++ b/frontend/src/store/modules/commitDetailComparisonStore.ts
@@ -44,7 +44,7 @@ export class CommitDetailComparisonStore extends VxModule {
       const differences = response.data.differences
         ? response.data.differences.map(differenceFromJson)
         : undefined
-      const significantDifferences = response.data.differences
+      const significantDifferences = response.data.significant_differences
         ? response.data.significant_differences.map(differenceFromJson)
         : undefined
 

--- a/frontend/src/store/modules/repoStore.ts
+++ b/frontend/src/store/modules/repoStore.ts
@@ -96,7 +96,9 @@ export class RepoStore extends VxModule {
 
   @action
   async triggerListenerFetch(): Promise<void> {
-    await axios.post(`/listener/fetch-all`)
+    await axios.post(`/listener/fetch-all`, undefined, {
+      snackbarPriority: 2
+    })
   }
 
   @mutation

--- a/frontend/src/views/Queue.vue
+++ b/frontend/src/views/Queue.vue
@@ -154,7 +154,8 @@ export default class Queue extends Vue {
 
     this.$globalSnackbar.setSuccess(
       'listener',
-      'Re-fetched repo and updated benchrepo'
+      'Re-fetched repo and updated benchrepo',
+      2
     )
   }
 


### PR DESCRIPTION
This PR removes the colors from the stddev and stddev percent columns (and also fixes a deserialization bug with significant differences).
Additionally, the "loading" snackbar shown when re-fetching repos now stays up, even if other snackbar messages show up.

Closes #215 