### PR TITLE
Ignore exceptions from closed runners, log runner disconnects

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/single/PeriodicStatusRequester.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/single/PeriodicStatusRequester.java
@@ -56,6 +56,9 @@ public class PeriodicStatusRequester {
 				//noinspection BusyWait
 				Thread.sleep(Delays.REQUEST_STATUS_INTERVAL.toMillis());
 			} catch (Exception e) {
+				if (cancelled) {
+					return;
+				}
 				LOGGER.error("Error communicating with runner or handling results", e);
 				try {
 					clearResults();

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/single/RunnerConnection.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/single/RunnerConnection.java
@@ -60,6 +60,7 @@ public class RunnerConnection implements WebSocketListener, WebSocketFrameListen
 
 		addCloseListener(this.periodicStatusRequester::cancel);
 		addCloseListener(this.heartbeatHandler::shutdown);
+		addCloseListener(() -> LOGGER.info("Connection to '{}' closed", runner.getRunnerName()));
 	}
 
 	/**


### PR DESCRIPTION
Previously the backend would print an exception with stacktrace saying it couldn't tell the runner to clear results. This isn't too surprising, as the runner *just disconnected*. This PR ignores exceptions arising when communicating with the runner, *if the connection was already closed*. Additionally it now logs runner disconnects on the `INFO` level.