### PR TITLE
Show whether a commit and its parents are tracked

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonCommit.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonCommit.java
@@ -8,7 +8,9 @@ public class JsonCommit {
 
 	private final UUID repoId;
 	private final String hash;
-	private final List<JsonCommitDescription> parents;
+	private final boolean tracked;
+	private final List<JsonCommitDescription> trackedParents;
+	private final List<JsonCommitDescription> untrackedParents;
 	private final List<JsonCommitDescription> trackedChildren;
 	private final List<JsonCommitDescription> untrackedChildren;
 	private final String author;
@@ -20,14 +22,17 @@ public class JsonCommit {
 	private final String message;
 	private final List<JsonRunDescription> runs;
 
-	public JsonCommit(UUID repoId, String hash, List<JsonCommitDescription> parents,
+	public JsonCommit(UUID repoId, String hash, boolean tracked,
+		List<JsonCommitDescription> trackedParents, List<JsonCommitDescription> untrackedParents,
 		List<JsonCommitDescription> trackedChildren, List<JsonCommitDescription> untrackedChildren,
 		String author, long authorDate, String committer, long committerDate, String summary,
 		@Nullable String message, List<JsonRunDescription> runs) {
 
 		this.repoId = repoId;
 		this.hash = hash;
-		this.parents = parents;
+		this.tracked = tracked;
+		this.trackedParents = trackedParents;
+		this.untrackedParents = untrackedParents;
 		this.trackedChildren = trackedChildren;
 		this.untrackedChildren = untrackedChildren;
 		this.author = author;
@@ -47,8 +52,16 @@ public class JsonCommit {
 		return hash;
 	}
 
-	public List<JsonCommitDescription> getParents() {
-		return parents;
+	public boolean isTracked() {
+		return tracked;
+	}
+
+	public List<JsonCommitDescription> getTrackedParents() {
+		return trackedParents;
+	}
+
+	public List<JsonCommitDescription> getUntrackedParents() {
+		return untrackedParents;
 	}
 
 	public List<JsonCommitDescription> getTrackedChildren() {

--- a/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonCommitTest.java
+++ b/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonCommitTest.java
@@ -12,6 +12,8 @@ class JsonCommitTest extends SerializingTest {
 		Object object = new JsonCommit(
 			UUID.fromString("24dd4fd3-5c6d-4542-a7a4-b181f37295a6"),
 			"e16272feb472dc4d357cc19dd97112c036a67990",
+			true,
+			List.of(),
 			List.of(),
 			List.of(),
 			List.of(),
@@ -26,7 +28,9 @@ class JsonCommitTest extends SerializingTest {
 		String json = "{"
 			+ "\"repo_id\": \"24dd4fd3-5c6d-4542-a7a4-b181f37295a6\","
 			+ "\"hash\": \"e16272feb472dc4d357cc19dd97112c036a67990\","
-			+ "\"parents\": [],"
+			+ "\"tracked\": true,"
+			+ "\"tracked_parents\": [],"
+			+ "\"untracked_parents\": [],"
 			+ "\"tracked_children\": [],"
 			+ "\"untracked_children\": [],"
 			+ "\"author\": \"authorName\","

--- a/docs/public-api/public-api.v2.yaml
+++ b/docs/public-api/public-api.v2.yaml
@@ -927,8 +927,17 @@ components:
           $ref: '#/components/schemas/RepoId'
         hash:
           $ref: '#/components/schemas/RepoId'
-        parents:
+        tracked:
+          type: boolean
+          description: Whether this commit can be reached from at least one tracked branch
+        tracked_parents:
           type: array
+          description: Parent commits that can be reached from at least one tracked branch
+          items:
+            $ref: '#/components/schemas/CommitDescription'
+        untracked_parents:
+          type: array
+          description: 'Parent commits that can''t be reached from any tracked branch. If the commit is tracked, this list should always be empty.'
           items:
             $ref: '#/components/schemas/CommitDescription'
         tracked_children:
@@ -963,7 +972,9 @@ components:
       required:
         - repo_id
         - hash
-        - parents
+        - tracked
+        - tracked_parents
+        - untracked_parents
         - tracked_children
         - untracked_children
         - author

--- a/frontend/src/components/rundetail/CommitDetail.vue
+++ b/frontend/src/components/rundetail/CommitDetail.vue
@@ -58,8 +58,8 @@
                 <v-col cols="6" class="pr-4">
                   <div v-if="parent" class="d-flex justify-start">
                     <commit-navigation-button
-                      :commitDescription="parent"
-                      :tracked="true"
+                      :commitDescription="parent.description"
+                      :tracked="parent.tracked"
                       type="PARENT"
                     ></commit-navigation-button>
                   </div>
@@ -112,18 +112,20 @@
 import Vue from 'vue'
 import Component from 'vue-class-component'
 import { Prop } from 'vue-property-decorator'
-import { Commit, CommitChild, CommitDescription } from '@/store/types'
+import { Commit, TrackedCommitDescription } from '@/store/types'
 import { formatDateUTC, formatDate } from '@/util/TimeUtil'
 import InlineMinimalRepoNameDisplay from '../InlineMinimalRepoDisplay.vue'
 import CommitBenchmarkActions from '../CommitBenchmarkActions.vue'
 import CommitNavigationButton from './CommitNavigationButton.vue'
-import { vxm } from '@/store'
 
 class NavigationTarget {
-  readonly parent: CommitDescription | null
-  readonly child: CommitChild | null
+  readonly parent: TrackedCommitDescription | null
+  readonly child: TrackedCommitDescription | null
 
-  constructor(parent: CommitDescription | null, child: CommitChild | null) {
+  constructor(
+    parent: TrackedCommitDescription | null,
+    child: TrackedCommitDescription | null
+  ) {
     this.parent = parent
     this.child = child
   }
@@ -146,10 +148,6 @@ export default class CommitDetail extends Vue {
 
   private formatDateUTC(date: Date) {
     return formatDateUTC(date)
-  }
-
-  private get isAdmin(): boolean {
-    return vxm.userModule.isAdmin
   }
 
   private get navigationTargets(): NavigationTarget[] {

--- a/frontend/src/components/rundetail/CommitDetail.vue
+++ b/frontend/src/components/rundetail/CommitDetail.vue
@@ -20,6 +20,14 @@
                         params: { first: commit.repoId, second: commit.hash }
                       }"
                     >
+                      <v-tooltip v-if="!commit.tracked" bottom>
+                        <template #activator="{ on }">
+                          <v-icon v-on="on">
+                            {{ untrackedIcon }}
+                          </v-icon>
+                        </template>
+                        This commit is not reachable from any tracked branch.
+                      </v-tooltip>
                       <span class="mx-2 message font-weight-regular">
                         {{ commit.summary }}
                       </span>
@@ -117,6 +125,7 @@ import { formatDateUTC, formatDate } from '@/util/TimeUtil'
 import InlineMinimalRepoNameDisplay from '../InlineMinimalRepoDisplay.vue'
 import CommitBenchmarkActions from '../CommitBenchmarkActions.vue'
 import CommitNavigationButton from './CommitNavigationButton.vue'
+import { mdiCompassOffOutline } from '@mdi/js'
 
 class NavigationTarget {
   readonly parent: TrackedCommitDescription | null
@@ -175,6 +184,8 @@ export default class CommitDetail extends Vue {
 
     return targets
   }
+
+  private readonly untrackedIcon = mdiCompassOffOutline
 }
 </script>
 

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -141,6 +141,7 @@ export class Commit {
   readonly committerDate: Date
   readonly summary: string
   readonly message: string | ''
+  readonly tracked: boolean
   /**
    * Sorted in reverse start order (newest run first)
    */
@@ -166,6 +167,7 @@ export class Commit {
     committerDate: Date,
     message: string,
     summary: string,
+    tracked: boolean,
     runs: RunDescription[],
     parents: TrackedCommitDescription[],
     children: TrackedCommitDescription[]
@@ -178,6 +180,7 @@ export class Commit {
     this.committerDate = committerDate
     this.message = message
     this.summary = summary
+    this.tracked = tracked
     this.runs = runs
     this.parents = parents
     this.children = children

--- a/frontend/src/util/CommitComparisonJsonHelper.ts
+++ b/frontend/src/util/CommitComparisonJsonHelper.ts
@@ -89,6 +89,7 @@ export function commitFromJson(json: any): Commit {
     new Date(json.committer_date * 1000),
     json.message || '',
     json.summary,
+    json.tracked,
     json.runs.map(runDescriptionFromJson),
     trackedParents.concat(untrackedParents),
     trackedChildren.concat(untrackedChildren)

--- a/frontend/src/util/CommitComparisonJsonHelper.ts
+++ b/frontend/src/util/CommitComparisonJsonHelper.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import {
   Commit,
-  CommitChild,
   DimensionDifference,
   Measurement,
   MeasurementError,
@@ -12,7 +11,8 @@ import {
   RunResult,
   RunResultScriptError,
   RunResultSuccess,
-  RunResultVelcomError
+  RunResultVelcomError,
+  TrackedCommitDescription
 } from '@/store/types'
 import {
   commitDescriptionFromJson,
@@ -66,12 +66,20 @@ export function runDescriptionFromJson(json: any): RunDescription {
 }
 
 export function commitFromJson(json: any): Commit {
-  const trackedChildren = json.tracked_children.map(
-    (it: any) => new CommitChild(true, commitDescriptionFromJson(it))
-  )
+  const toCommitDescription = (tracked: boolean) => {
+    return (it: any) =>
+      new TrackedCommitDescription(tracked, commitDescriptionFromJson(it))
+  }
+
+  const trackedChildren = json.tracked_children.map(toCommitDescription(true))
   const untrackedChildren = json.untracked_children.map(
-    (it: any) => new CommitChild(false, commitDescriptionFromJson(it))
+    toCommitDescription(false)
   )
+  const trackedParents = json.tracked_parents.map(toCommitDescription(true))
+  const untrackedParents = json.untracked_parents.map(
+    toCommitDescription(false)
+  )
+
   return new Commit(
     json.repo_id,
     json.hash,
@@ -82,7 +90,7 @@ export function commitFromJson(json: any): Commit {
     json.message || '',
     json.summary,
     json.runs.map(runDescriptionFromJson),
-    json.parents.map(commitDescriptionFromJson),
+    trackedParents.concat(untrackedParents),
     trackedChildren.concat(untrackedChildren)
   )
 }


### PR DESCRIPTION
This PR extends the API for the `/commit` endpoint to include the information whether the commit is tracked and which of its parents are tracked. This is a breaking change, so the backend and frontend should both be updated in this PR.

- [x] Change API spec
- [x] Implement changes in backend
- [x] Implement changes in frontend

This PR must be merged after #217. Keeping it a draft until then.