### PR TITLE
Suppress double page refresh when using navigation buttons

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app>
     <v-main>
-      <nav-bar v-on:refresh="refresh"></nav-bar>
+      <nav-bar @refresh-view="routerViewKey++"></nav-bar>
       <snackbar ref="global-snackbar"></snackbar>
       <router-view :key="routerViewKey" />
       <theme-selector @use-dark-theme="setDarkTheme"></theme-selector>
@@ -29,12 +29,6 @@ import { storeToLocalStorage } from './store/persistence'
 export default class App extends Vue {
   private clickHandler: any = this.checkClick
   private routerViewKey: number = 0
-
-  private refresh(routeName: string) {
-    if (this.$route.name === routeName) {
-      this.routerViewKey++
-    }
-  }
 
   private checkClick(event: Event) {
     if (!event.srcElement) {

--- a/frontend/src/components/NavigationBar.vue
+++ b/frontend/src/components/NavigationBar.vue
@@ -7,12 +7,9 @@
       ></v-app-bar-nav-icon>
       <v-tooltip bottom color="rgba(0,0,0,0)" class="logoTooltip">
         <template #activator="{ on }">
-          <router-link
-            class="concealed-link"
-            :to="{ name: 'home' }"
-            @click="$emit('refresh', 'home')"
-          >
+          <router-link class="concealed-link" :to="{ name: 'home' }">
             <img
+              @click="refresh('home')"
               id="logo"
               v-on="on"
               width="45px"
@@ -26,10 +23,10 @@
         <img src="@/assets/mini-logo.png" alt="logo" class="mx-4" id="logo" />
       </v-tooltip>
       <router-link class="concealed-link" :to="{ name: 'home' }">
-        <v-toolbar-title id="title" @click="$emit('refresh', 'home')"
-          >{{ title }}
-        </v-toolbar-title></router-link
-      >
+        <v-toolbar-title id="title" @click="refresh('home')">
+          {{ title }}
+        </v-toolbar-title>
+      </router-link>
 
       <v-spacer></v-spacer>
 
@@ -40,7 +37,7 @@
         :key="item.routeName"
         text
         :to="{ name: item.routeName }"
-        @click="$emit('refresh', item.routeName)"
+        @click="refresh(item.routeName)"
       >
         {{ item.label }}
         <v-icon right dark :size="iconFontSize">{{ item.icon }}</v-icon>
@@ -105,6 +102,7 @@ import router from '../router'
 import LoginDialog from '../components/dialogs/LoginDialog.vue'
 import { mdiAccountCircleOutline, mdiLogout } from '@mdi/js'
 import { vxm } from '@/store'
+import { Watch } from 'vue-property-decorator'
 
 class NavigationItem {
   readonly routeName: string
@@ -127,6 +125,7 @@ export default class NavigationBar extends Vue {
   private iconFontSize = 22
   private title = 'VelCom'
 
+  private lastNavigatedRoute: string | null = null
   private drawerShown = false
 
   get validRoutes(): NavigationItem[] {
@@ -148,12 +147,29 @@ export default class NavigationBar extends Vue {
     return route.meta.navigable
   }
 
+  private get currentRouteName(): string {
+    return this.$route.name!
+  }
+
+  @Watch('currentRouteName')
+  private onRouteChange(newValue: string, oldValue: string) {
+    this.lastNavigatedRoute = newValue
+  }
+
   get loggedIn(): boolean {
     return vxm.userModule.loggedIn
   }
 
-  logout(): void {
+  private logout(): void {
     vxm.userModule.logOut()
+  }
+
+  private refresh(routeName: string): void {
+    if (this.lastNavigatedRoute === routeName) {
+      this.lastNavigatedRoute = null
+      return
+    }
+    this.$emit('refresh-view')
   }
 
   // ============== ICONS ==============


### PR DESCRIPTION
### Premise
Clicking one of the navigation buttons should refresh the view.

### Constraint
Do not emit a refresh event when first *navigating* to the page, as that
is unnecessary: The page was just loaded, so it is "fresh".

### Before this patch
To do this the navigation buttons emitted a "refresh" event when
clicked and then the route name was checked against the current route
name. If the names matched, the view was refreshed. If they differed we
detected a real navigation and suppressed the refetch.

### Problem
The custom click handler is fired *after* the navigation was complete.
This means it will *always* see a matching route name, no matter whether
there actually was a navigation. This renders the whole check useless
and every page is refreshed twice.

### Solution
We now watch for route changes. This watcher is triggered *before* the
click event. The watcher then sets a special flag the click handler will
later read. If this flag is set, the click handler will not trigger a
refresh.