### PR TITLE
Minor graph alterations

### DIFF
--- a/frontend/src/components/graphs/DytailGraph.vue
+++ b/frontend/src/components/graphs/DytailGraph.vue
@@ -74,7 +74,7 @@ export default class DytailGraph extends Vue {
 
   /**
    * The only possibility one has to find the (abstract) data point for a given
-   * point in the graph is to go by x axis position ( = the author date).
+   * point in the graph is to go by x axis position ( = the committer date).
    * This is not guaranteed to give the correct data point, but it's accurate
    * enough to display a fitting tooltip
    *
@@ -450,7 +450,7 @@ export default class DytailGraph extends Vue {
   }
 
   /**
-   * draw a little flag to merk the reference data point, if specified and in the
+   * draw a little flag to mark the reference data point, if specified and in the
    * current timespan
    */
   private drawMarkers() {
@@ -476,7 +476,7 @@ export default class DytailGraph extends Vue {
   // <!--<editor-fold desc="CUSTOM GRAPH INTERACTIONS">-->
 
   /**
-   * what to when interacting with a point in the graph:
+   * what to do when interacting with a point in the graph:
    * left click: navigate to corresponding commit detail page
    * right click: open data point dialog
    *

--- a/frontend/src/components/graphs/MatrixDimensionSelection.vue
+++ b/frontend/src/components/graphs/MatrixDimensionSelection.vue
@@ -146,12 +146,6 @@ export default class MatrixMeasurementIdSelection extends Vue {
 
   private metricColor(benchmark: string, metric: string): string {
     if (this.selectedDimensionSet.has(benchmark + ' - ' + metric)) {
-      console.log(
-        vxm.detailGraphModule.colorIndex({
-          benchmark: benchmark,
-          metric: metric
-        })
-      )
       return vxm.colorModule.colorByIndex(
         vxm.detailGraphModule.colorIndex({
           benchmark: benchmark,

--- a/frontend/src/components/graphs/OverscrollToZoom.ts
+++ b/frontend/src/components/graphs/OverscrollToZoom.ts
@@ -3,15 +3,28 @@ import { vxm } from '@/store'
 export default class OverscrollToZoom {
   private scrollToZoomInProgress = false
 
+  private isZoomedOut(): boolean {
+    if (
+      vxm.detailGraphModule.zoomXStartValue == null &&
+      vxm.detailGraphModule.zoomXEndValue == null
+    ) {
+      return true
+    }
+
+    return (
+      vxm.detailGraphModule.zoomXStartValue ===
+        vxm.detailGraphModule.startTime.getTime() &&
+      vxm.detailGraphModule.zoomXEndValue ===
+        vxm.detailGraphModule.endTime.getTime()
+    )
+  }
+
   /**
    * Should be called when a wheel event was triggered.
    * @param e the wheel event
    */
   public scrolled(e: WheelEvent): void {
-    if (
-      vxm.detailGraphModule.zoomXEndValue !== null ||
-      vxm.detailGraphModule.zoomXStartValue !== null
-    ) {
+    if (!this.isZoomedOut()) {
       return
     }
 

--- a/frontend/src/store/modules/detailGraphStore.ts
+++ b/frontend/src/store/modules/detailGraphStore.ts
@@ -173,7 +173,7 @@ export class DetailGraphStore extends VxModule {
     // Anchors to the current date
     extractDate('zoomXEnd', new Date(), value => {
       this.zoomXEndValue = value
-      this.endTime = new Date(value)
+      vxm.detailGraphModule.endTime = new Date(value)
     })
     // Anchors to the end date (or the current one if not specified)
     extractDate(
@@ -181,7 +181,7 @@ export class DetailGraphStore extends VxModule {
       new Date(this.zoomXEndValue || new Date().getTime()),
       value => {
         this.zoomXStartValue = value
-        this.startTime = new Date(value)
+        vxm.detailGraphModule.startTime = new Date(value)
       }
     )
     extractFloat('zoomYStart', value => {

--- a/frontend/src/store/modules/detailGraphStore.ts
+++ b/frontend/src/store/modules/detailGraphStore.ts
@@ -219,7 +219,6 @@ export class DetailGraphStore extends VxModule {
   // <!--<editor-fold desc="GET / SET TIME">-->
 
   get startTime(): Date {
-    console.log('start: ' + this._startTime.getHours())
     return this._startTime
   }
 
@@ -231,12 +230,10 @@ export class DetailGraphStore extends VxModule {
   }
 
   get endTime(): Date {
-    console.log('end: ' + this._startTime.getHours())
     return this._endTime
   }
 
   set endTime(time: Date) {
-    console.log(time.getHours())
     if (!(time.getHours() !== 0)) {
       time.setHours(24, 0, 0, 0) // next midnight
     }

--- a/frontend/src/store/modules/detailGraphStore.ts
+++ b/frontend/src/store/modules/detailGraphStore.ts
@@ -33,6 +33,7 @@ export type PermanentLinkOptions = Partial<{
 }>
 
 export class DetailGraphStore extends VxModule {
+  // <!--<editor-fold desc="STATE">-->
   private _detailGraph: DetailDataPoint[] = []
   private _selectedRepoId: RepoId = ''
   private _selectedDimensions: Dimension[] = []
@@ -47,6 +48,13 @@ export class DetailGraphStore extends VxModule {
   referenceDatapoint: DimensionDetailPoint | null = null
   commitToCompare: DimensionDetailPoint | null = null
 
+  // One week in the past, as elegant as ever
+  private _startTime: Date = new Date(
+    new Date(new Date().setDate(new Date().getDate() - 7)).setHours(0, 0, 0, 0)
+  )
+
+  private _endTime: Date = new Date(new Date().setHours(24, 0, 0, 0))
+
   zoomXStartValue: number | null = null
   zoomXEndValue: number | null = null
   zoomYStartValue: number | null = null
@@ -59,12 +67,11 @@ export class DetailGraphStore extends VxModule {
   private maxBuffer: number = 182 // ~ half a year
   private bufferRatio: number = 0.5
 
-  // One week in the past, as elegant as ever
-  startTime: Date = new Date(new Date().setDate(new Date().getDate() - 7))
-  endTime: Date = new Date()
-
   beginYScaleAtZero: boolean = false
   dayEquidistantGraph: boolean = true
+  //  <!--</editor-fold>-->
+
+  // <!--<editor-fold desc="ACTIONS">-->
 
   /**
    * Fetches the data necessary to display the data points
@@ -200,11 +207,104 @@ export class DetailGraphStore extends VxModule {
       })
     }
   }
+  //  <!--</editor-fold>-->
+
+  // <!--<editor-fold desc="MUTATIONS">-->
+  @mutation
+  setDetailGraph(graph: DetailDataPoint[]): void {
+    this._detailGraph = graph
+  }
+  //  <!--</editor-fold>-->
+
+  // <!--<editor-fold desc="GET / SET TIME">-->
+
+  get startTime(): Date {
+    console.log('start: ' + this._startTime.getHours())
+    return this._startTime
+  }
+
+  set startTime(time: Date) {
+    if (!(time.getHours() !== 0)) {
+      time.setHours(0, 0, 0, 0) // last midnight
+    }
+    this._startTime = time
+  }
+
+  get endTime(): Date {
+    console.log('end: ' + this._startTime.getHours())
+    return this._endTime
+  }
+
+  set endTime(time: Date) {
+    console.log(time.getHours())
+    if (!(time.getHours() !== 0)) {
+      time.setHours(24, 0, 0, 0) // next midnight
+    }
+    this._endTime = time
+  }
 
   get duration(): number {
     const timeDiff = this.endTime.getTime() - this.startTime.getTime()
 
     return Math.ceil(timeDiff / (1000 * 3600 * 24))
+  }
+
+  /**
+   * Returns the boundaries of the buffered timespan that is used when fetchin a
+   * new detail graph. The buffered timespan extends the timespan implied
+   * by start and end date to allow for panning a little outside the graph
+   * boundaries without having to wait for a new graph to be fetched
+   *
+   * @type {startTime: Date, endTime: Date}
+   */
+  get bufferedTimespan(): { startTime: Date; endTime: Date } {
+    let buffer: number = 0
+    if (this.duration <= this.minToBuffer) {
+      buffer = this.minBuffer
+    } else if (this.duration >= this.maxToBuffer) {
+      buffer = this.maxBuffer
+    } else {
+      buffer = this.duration * this.bufferRatio
+    }
+    const bufferMillis = buffer * 1000 * 60 * 60 * 24 // ms * minutes * hours * days
+
+    const bufferedStartTime = new Date(
+      this.startTime.getTime() - bufferMillis / 2
+    )
+    const bufferedEndTime = new Date(this.endTime.getTime() + bufferMillis / 2)
+
+    return { startTime: bufferedStartTime, endTime: bufferedEndTime }
+  }
+  //  <!--</editor-fold>-->
+
+  // <!--<editor-fold desc="GET / SET DIMENSIONS">-->
+
+  /**
+   * Returns all selected dimensions.
+   *
+   * @readonly
+   * @type {Dimension[]}
+   * @memberof detailGraphStore
+   */
+  get selectedDimensions(): Dimension[] {
+    return this._selectedDimensions
+  }
+
+  /**
+   * Sets the selected dimensions.
+   *
+   * @memberof detailGraphStore
+   */
+  set selectedDimensions(dimensions: Dimension[]) {
+    dimensions.forEach(it => {
+      if (!it) {
+        throw new Error('UNDEFINED OR NULL!')
+      }
+      if (!this.colorIndexMap.has(it)) {
+        this.colorIndexMap.set(it, this.firstFreeColorIndex++)
+      }
+    })
+    this._selectedDimensions = dimensions
   }
 
   /**
@@ -246,85 +346,9 @@ export class DetailGraphStore extends VxModule {
 
     return resultString.slice(0, resultString.length - 2)
   }
+  //  <!--</editor-fold>-->
 
-  @mutation
-  setDetailGraph(graph: DetailDataPoint[]): void {
-    this._detailGraph = graph
-  }
-
-  /**
-   * Returns a permanent link to the current detail graph state
-   */
-  get permanentLink(): (options?: PermanentLinkOptions) => string {
-    return options => {
-      const orUndefined = (it: any) => (it ? '' + it : undefined)
-      const orElse = (it: any, subst: any) => (it ? '' + it : '' + subst)
-      function respectOptions<T>(
-        name: keyof PermanentLinkOptions,
-        value: T
-      ): T | undefined {
-        if (!options || options[name]) {
-          return value
-        }
-        return undefined
-      }
-
-      const route = router.resolve({
-        name: 'repo-detail',
-        params: { id: this.selectedRepoId },
-        query: {
-          zoomYStart: respectOptions(
-            'includeYZoom',
-            orUndefined(this.zoomYStartValue)
-          ),
-          zoomYEnd: respectOptions(
-            'includeYZoom',
-            orUndefined(this.zoomYEndValue)
-          ),
-          zoomXStart:
-            options && options.includeXZoom
-              ? orElse(this.zoomXStartValue, this.startTime.getTime())
-              : orUndefined(this.startTime.getTime()),
-          zoomXEnd:
-            options && options.includeXZoom
-              ? orElse(this.zoomXEndValue, this.endTime.getTime())
-              : orUndefined(this.endTime.getTime()),
-          dimensions: respectOptions('includeDimensions', this.dimensionString),
-          dayEquidistant: this.dayEquidistantGraph ? 'true' : undefined
-        }
-      })
-
-      return location.origin + route.href
-    }
-  }
-
-  /**
-   * Returns the boundaries of the buffered timespan that is used when fetchin a
-   * new detail graph. The buffered timespan extends the timespan implied
-   * by start and end date to allow for panning a little outside the graph
-   * boundaries without having to wait for a new graph to be fetched
-   *
-   * @type {startTime: Date, endTime: Date}
-   */
-  get bufferedTimespan(): { startTime: Date; endTime: Date } {
-    let buffer: number = 0
-    if (this.duration <= this.minToBuffer) {
-      buffer = this.minBuffer
-    } else if (this.duration >= this.maxToBuffer) {
-      buffer = this.maxBuffer
-    } else {
-      buffer = this.duration * this.bufferRatio
-    }
-    const bufferMillis = buffer * 1000 * 60 * 60 * 24 // ms * minutes * hours * days
-
-    const bufferedStartTime = new Date(
-      this.startTime.getTime() - bufferMillis / 2
-    )
-    const bufferedEndTime = new Date(this.endTime.getTime() + bufferMillis / 2)
-
-    return { startTime: bufferedStartTime, endTime: bufferedEndTime }
-  }
-
+  // <!--<editor-fold desc="GET / SET GRAPH">-->
   /**
    * Returns the locally stored data for a repo detail graph
    *
@@ -364,34 +388,6 @@ export class DetailGraphStore extends VxModule {
       }
     }
     return visibleDataPoints
-  }
-
-  /**
-   * Returns all selected dimensions.
-   *
-   * @readonly
-   * @type {Dimension[]}
-   * @memberof detailGraphStore
-   */
-  get selectedDimensions(): Dimension[] {
-    return this._selectedDimensions
-  }
-
-  /**
-   * Sets the selected dimensions.
-   *
-   * @memberof detailGraphStore
-   */
-  set selectedDimensions(dimensions: Dimension[]) {
-    dimensions.forEach(it => {
-      if (!it) {
-        throw new Error('UNDEFINED OR NULL!')
-      }
-      if (!this.colorIndexMap.has(it)) {
-        this.colorIndexMap.set(it, this.firstFreeColorIndex++)
-      }
-    })
-    this._selectedDimensions = dimensions
   }
 
   /**
@@ -438,4 +434,54 @@ export class DetailGraphStore extends VxModule {
   get colorIndex(): (dimension: DimensionId) => number | undefined {
     return dimension => this.colorIndexMap.get(dimension)
   }
+  //  <!--</editor-fold>-->
+
+  // <!--<editor-fold desc="GET / SET PERMANENT LINK">-->
+
+  /**
+   * Returns a permanent link to the current detail graph state
+   */
+  get permanentLink(): (options?: PermanentLinkOptions) => string {
+    return options => {
+      const orUndefined = (it: any) => (it ? '' + it : undefined)
+      const orElse = (it: any, subst: any) => (it ? '' + it : '' + subst)
+      function respectOptions<T>(
+        name: keyof PermanentLinkOptions,
+        value: T
+      ): T | undefined {
+        if (!options || options[name]) {
+          return value
+        }
+        return undefined
+      }
+
+      const route = router.resolve({
+        name: 'repo-detail',
+        params: { id: this.selectedRepoId },
+        query: {
+          zoomYStart: respectOptions(
+            'includeYZoom',
+            orUndefined(this.zoomYStartValue)
+          ),
+          zoomYEnd: respectOptions(
+            'includeYZoom',
+            orUndefined(this.zoomYEndValue)
+          ),
+          zoomXStart:
+            options && options.includeXZoom
+              ? orElse(this.zoomXStartValue, this.startTime.getTime())
+              : orUndefined(this.startTime.getTime()),
+          zoomXEnd:
+            options && options.includeXZoom
+              ? orElse(this.zoomXEndValue, this.endTime.getTime())
+              : orUndefined(this.endTime.getTime()),
+          dimensions: respectOptions('includeDimensions', this.dimensionString),
+          dayEquidistant: this.dayEquidistantGraph ? 'true' : undefined
+        }
+      })
+
+      return location.origin + route.href
+    }
+  }
+  //  <!--</editor-fold>-->
 }

--- a/frontend/src/views/RepoDetail.vue
+++ b/frontend/src/views/RepoDetail.vue
@@ -39,7 +39,11 @@
               :beginYAtZero="yStartsAtZero"
               :dayEquidistant="dayEquidistantGraphSelected"
               :wheelEvent="mouseWheelOnGraph"
-            ></component>
+            >
+            </component>
+            <v-overlay :value="showOverlay" :absolute="true" opacity="1">
+              {{ overlayMsg }}
+            </v-overlay>
           </v-card-text>
         </v-card>
       </v-col>
@@ -291,6 +295,10 @@ export default class RepoDetail extends Vue {
   private today = new Date().toISOString().substr(0, 10)
 
   private graphPlaceholderHeight: number = 100
+
+  private showOverlay: boolean = false
+  private overlayMsg: string = 'hi'
+
   private useMatrixSelector: boolean = false
 
   /**
@@ -452,8 +460,11 @@ export default class RepoDetail extends Vue {
   @Watch('id')
   @Watch('selectedDimensions')
   private async retrieveGraphData(): Promise<void> {
-    if (this.stopAfterStart()) {
+    console.log(vxm.detailGraphModule.detailGraph)
+    if (this.stopAfterStart() && this.selectedDimensions.length !== 0) {
       this.selectedGraphComponent = GraphPlaceholder
+
+      this.showOverlay = false
 
       if (this.$refs.graphComponent) {
         this.graphPlaceholderHeight = (this.$refs
@@ -467,6 +478,16 @@ export default class RepoDetail extends Vue {
       if (correctSeries) {
         this.selectedGraphComponent = correctSeries.component
       }
+      if (vxm.detailGraphModule.detailGraph.length === 0) {
+        this.showOverlay = true
+        this.overlayMsg =
+          'There are no commits within the specified time period that have been benchmarked with these metrics.'
+      } else {
+        this.showOverlay = false
+      }
+    } else if (this.selectedDimensions.length === 0) {
+      this.showOverlay = true
+      this.overlayMsg = 'No data available.Please select benchmark and metric.'
     }
   }
 

--- a/frontend/src/views/RepoDetail.vue
+++ b/frontend/src/views/RepoDetail.vue
@@ -460,7 +460,6 @@ export default class RepoDetail extends Vue {
   @Watch('id')
   @Watch('selectedDimensions')
   private async retrieveGraphData(): Promise<void> {
-    console.log(vxm.detailGraphModule.detailGraph)
     if (this.stopAfterStart() && this.selectedDimensions.length !== 0) {
       this.selectedGraphComponent = GraphPlaceholder
 


### PR DESCRIPTION
This PR changes a few things about both detail graph types. 
Most importantly, the graphs now only display whole days (midnight to midnight).  This also fixes #192 , because it prevents commits from being "cut off".
If VelCom would show an empty graph because no metrics are selected or there are no commits in the selected time span, it now shows a neat overlay instead, similar to the one on the comparison graph.