### PR TITLE
Expand fetched date range in permalinks by a day

### DIFF
--- a/frontend/src/store/modules/detailGraphStore.ts
+++ b/frontend/src/store/modules/detailGraphStore.ts
@@ -173,7 +173,9 @@ export class DetailGraphStore extends VxModule {
     // Anchors to the current date
     extractDate('zoomXEnd', new Date(), value => {
       this.zoomXEndValue = value
-      vxm.detailGraphModule.endTime = new Date(value)
+      const asDate = new Date(value)
+      asDate.setDate(asDate.getDate() + 1)
+      vxm.detailGraphModule.endTime = asDate
     })
     // Anchors to the end date (or the current one if not specified)
     extractDate(
@@ -181,7 +183,9 @@ export class DetailGraphStore extends VxModule {
       new Date(this.zoomXEndValue || new Date().getTime()),
       value => {
         this.zoomXStartValue = value
-        vxm.detailGraphModule.startTime = new Date(value)
+        const asDate = new Date(value)
+        asDate.setDate(asDate.getDate() - 1)
+        vxm.detailGraphModule.startTime = asDate
       }
     )
     extractFloat('zoomYStart', value => {


### PR DESCRIPTION
This ensures the display looks the same even if the day-equidistant graph moved some later commits to be barely visible on the right/left edge. Those commits would not be loaded without expanding the range as they do not belong into the displayed area, they were just moved by the day-equidistant setting.