### PR TITLE
Change order of recent runs

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/benchmarkaccess/BenchmarkReadAccess.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/benchmarkaccess/BenchmarkReadAccess.java
@@ -183,7 +183,9 @@ public class BenchmarkReadAccess {
 	}
 
 	/**
-	 * Get the ids of the most recent runs ordered by their start time.
+	 * Get the ids of the most recent runs ordered by their commit's committer time. Runs with no
+	 * associated commit are ignored. If a commit has multiple runs, they are ordered from new to
+	 * old.
 	 *
 	 * @param skip how many recent runs to skip
 	 * @param amount how many recent runs to collect
@@ -207,7 +209,7 @@ public class BenchmarkReadAccess {
 				.join(KNOWN_COMMIT)
 				.on(KNOWN_COMMIT.REPO_ID.eq(RUN.REPO_ID)
 					.and(KNOWN_COMMIT.HASH.eq(RUN.COMMIT_HASH)))
-				.orderBy(KNOWN_COMMIT.COMMITTER_DATE.desc())
+				.orderBy(KNOWN_COMMIT.COMMITTER_DATE.desc(), RUN.START_TIME.desc())
 				.limit(skip, amount)
 				.stream()
 				.map(Record1::value1)

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/benchmarkaccess/BenchmarkReadAccess.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/benchmarkaccess/BenchmarkReadAccess.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
+import org.jooq.Record1;
 import org.jooq.codegen.db.tables.records.RunRecord;
 
 /**
@@ -201,11 +202,15 @@ public class BenchmarkReadAccess {
 		}
 
 		try (DBReadAccess db = databaseStorage.acquireReadAccess()) {
-			return db.selectFrom(RUN)
-				.orderBy(RUN.START_TIME.desc())
+			return db.select(RUN.ID)
+				.from(RUN)
+				.join(KNOWN_COMMIT)
+				.on(KNOWN_COMMIT.REPO_ID.eq(RUN.REPO_ID)
+					.and(KNOWN_COMMIT.HASH.eq(RUN.COMMIT_HASH)))
+				.orderBy(KNOWN_COMMIT.COMMITTER_DATE.desc())
 				.limit(skip, amount)
 				.stream()
-				.map(RunRecord::getId)
+				.map(Record1::value1)
 				.map(RunId::fromString)
 				.collect(toList());
 		}

--- a/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/TestDb.java
+++ b/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/TestDb.java
@@ -136,10 +136,10 @@ public class TestDb {
 	}
 
 	public void addCommit(RepoId repoId, CommitHash commitHash, boolean reachable, boolean tracked,
-		String message) {
+		String message, Instant authorDate, Instant committerDate) {
 
-		addCommit(repoId, commitHash, reachable, tracked, "author", Instant.now(), "committer",
-			Instant.now(), message);
+		addCommit(repoId, commitHash, reachable, tracked, "author", authorDate, "committer",
+			committerDate, message);
 	}
 
 	public void addCommit(RepoId repoId, CommitHash commitHash) {

--- a/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/access/benchmarkaccess/BenchmarkReadAccessTest.java
+++ b/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/access/benchmarkaccess/BenchmarkReadAccessTest.java
@@ -110,10 +110,14 @@ class BenchmarkReadAccessTest {
 
 		testDb.addRepo(REPO1_ID);
 		testDb.addRepo(REPO2_ID);
-		testDb.addCommit(REPO1_ID, COMMIT1_HASH, true, true, "blad9bla");
-		testDb.addCommit(REPO1_ID, COMMIT2_HASH, true, true, "m2");
-		testDb.addCommit(REPO1_ID, COMMIT3_HASH, true, true, "m3");
-		testDb.addCommit(REPO2_ID, COMMIT4_HASH, true, true, "m4");
+		testDb.addCommit(REPO1_ID, COMMIT1_HASH, true, true, "blad9bla",
+			Instant.ofEpochSecond(1), Instant.ofEpochSecond(1));
+		testDb.addCommit(REPO1_ID, COMMIT2_HASH, true, true, "m2",
+			Instant.ofEpochSecond(2), Instant.ofEpochSecond(2));
+		testDb.addCommit(REPO1_ID, COMMIT3_HASH, true, true, "m3",
+			Instant.ofEpochSecond(3), Instant.ofEpochSecond(3));
+		testDb.addCommit(REPO2_ID, COMMIT4_HASH, true, true, "m4",
+			Instant.ofEpochSecond(4), Instant.ofEpochSecond(4));
 
 		testDb.addRun(RUN1_ID, "a1", "rn1", "ri1", RUN1_START, RUN1_START.plusSeconds(1),
 			Either.ofRight(new TarSource("td1", null)), null);
@@ -172,27 +176,26 @@ class BenchmarkReadAccessTest {
 	void getRecentRuns() {
 		// Run order from old to new: 1, 5, 6, 3, 9, 10, 4, 8, 2, 7
 		// Run order from new to old: 7, 2, 8, 4, 10, 9, 3, 6, 5, 1
+		// Excluding tar runs: 7, 8, 10, 6, 5
+		// Grouped by commits: 10, 8, 7, 6, 5
 
 		assertThat(access.getRecentRunIds(0, 10))
-			.containsExactly(RUN7_ID, RUN2_ID, RUN8_ID, RUN4_ID, RUN10_ID, RUN9_ID, RUN3_ID, RUN6_ID,
-				RUN5_ID, RUN1_ID);
+			.containsExactly(RUN10_ID, RUN8_ID, RUN7_ID, RUN6_ID, RUN5_ID);
 
 		// Get varying amounts at offset 0
 
 		assertThat(access.getRecentRunIds(0, 20))
-			.containsExactly(RUN7_ID, RUN2_ID, RUN8_ID, RUN4_ID, RUN10_ID, RUN9_ID, RUN3_ID, RUN6_ID,
-				RUN5_ID, RUN1_ID);
-		assertThat(access.getRecentRunIds(0, 5))
-			.containsExactly(RUN7_ID, RUN2_ID, RUN8_ID, RUN4_ID, RUN10_ID);
-		assertThat(access.getRecentRunIds(0, 1)).containsExactly(RUN7_ID);
+			.containsExactly(RUN10_ID, RUN8_ID, RUN7_ID, RUN6_ID, RUN5_ID);
+		assertThat(access.getRecentRunIds(0, 3))
+			.containsExactly(RUN10_ID, RUN8_ID, RUN7_ID);
+		assertThat(access.getRecentRunIds(0, 1)).containsExactly(RUN10_ID);
 		assertThat(access.getRecentRunIds(0, 0)).isEmpty();
 
 		// Get varying amounts at varying offsets
 
-		assertThat(access.getRecentRunIds(2, 4)).containsExactly(RUN8_ID, RUN4_ID, RUN10_ID, RUN9_ID);
-		assertThat(access.getRecentRunIds(5, 3)).containsExactly(RUN9_ID, RUN3_ID, RUN6_ID);
-		assertThat(access.getRecentRunIds(8, 8)).containsExactly(RUN5_ID, RUN1_ID);
-		assertThat(access.getRecentRunIds(20, 3)).isEmpty();
+		assertThat(access.getRecentRunIds(2, 4)).containsExactly(RUN7_ID, RUN6_ID, RUN5_ID);
+		assertThat(access.getRecentRunIds(4, 3)).containsExactly(RUN5_ID);
+		assertThat(access.getRecentRunIds(5, 3)).isEmpty();
 
 		// Illegal arguments
 


### PR DESCRIPTION
Recent runs are now ordered by their commit's committer date instead of the run's start time. This means that re-runs of a commit may no longer appear at the top of the list of significant runs.

Tar runs are not included in the recent runs any more.