### PR TITLE
More runner protocol logging

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/single/state/TeleRunnerState.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/runner/single/state/TeleRunnerState.java
@@ -7,11 +7,15 @@ import de.aaaaaaah.velcom.shared.protocol.serialization.serverbound.ServerBoundP
 import de.aaaaaaah.velcom.shared.protocol.serialization.serverbound.ServerBoundPacketType;
 import de.aaaaaaah.velcom.shared.protocol.statemachine.State;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A state in the tele-runner state machine.
  */
 public class TeleRunnerState implements State {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(TeleRunnerState.class);
 
 	protected final TeleRunner runner;
 	protected final RunnerConnection connection;
@@ -35,6 +39,10 @@ public class TeleRunnerState implements State {
 		// If a packet has been received that could not be deserialized or handled, that is invalid
 		// behaviour.
 		if (newState.isEmpty()) {
+			LOGGER.info(
+				"Runner send a package I couldn't handle in {}. Content: '{}'",
+				getClass().getSimpleName(), text.substring(0, Math.min(text.length(), 100))
+			);
 			connection.close(StatusCode.ILLEGAL_PACKET);
 		}
 

--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/Connection.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/Connection.java
@@ -71,7 +71,11 @@ public class Connection implements WebSocket.Listener, HeartbeatWebsocket {
 
 		serializer.serialize(packet).ifPresentOrElse(
 			str -> socket.sendText(str, true),
-			() -> close(StatusCode.ILLEGAL_PACKET)
+			() -> {
+				LOGGER.warn("Failed to serialize and send packet, closing connection");
+				LOGGER.warn("Packet: {}", packet);
+				close(StatusCode.ILLEGAL_PACKET);
+			}
 		);
 	}
 

--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/TeleBackend.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/TeleBackend.java
@@ -95,7 +95,8 @@ public class TeleBackend {
 				conn.getClosedFuture().get();
 				LOGGER.info("{} - Disconnected, reconnecting immediately", address);
 			} catch (ExecutionException | InterruptedException e) {
-				LOGGER.warn("{} - Failed to connect, retrying soon", address);
+				LOGGER.warn("{} - Failed to connect, retrying in {}", address,
+					Delays.RECONNECT_AFTER_FAILED_CONNECTION);
 				//noinspection BusyWait
 				Thread.sleep(Delays.RECONNECT_AFTER_FAILED_CONNECTION.toMillis());
 			}
@@ -298,6 +299,7 @@ public class TeleBackend {
 		getBenchmarker().ifPresent(benchmarker -> {
 			globalStatus.set(Status.ABORT);
 			benchmarker.abort();
+			LOGGER.warn("The current run was aborted");
 		});
 	}
 

--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/states/RunnerState.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/states/RunnerState.java
@@ -53,6 +53,8 @@ public abstract class RunnerState implements State {
 		// If a packet has been received that could not be deserialized or handled, that is invalid
 		// behaviour.
 		if (newState.isEmpty()) {
+			LOGGER.warn("Received invalid packet, closing connection");
+			LOGGER.warn("Packet: {}", text);
 			connection.close(StatusCode.ILLEGAL_PACKET);
 		}
 

--- a/backend/shared/src/main/java/de/aaaaaaah/velcom/shared/protocol/serialization/serverbound/ServerBoundPacket.java
+++ b/backend/shared/src/main/java/de/aaaaaaah/velcom/shared/protocol/serialization/serverbound/ServerBoundPacket.java
@@ -47,4 +47,12 @@ public class ServerBoundPacket {
 	public int hashCode() {
 		return Objects.hash(type, data);
 	}
+
+	@Override
+	public String toString() {
+		return "ServerBoundPacket{" +
+			"type=" + type +
+			", data=" + data +
+			'}';
+	}
 }

--- a/backend/shared/src/main/java/de/aaaaaaah/velcom/shared/protocol/serialization/serverbound/ServerBoundPacketType.java
+++ b/backend/shared/src/main/java/de/aaaaaaah/velcom/shared/protocol/serialization/serverbound/ServerBoundPacketType.java
@@ -47,4 +47,12 @@ public enum ServerBoundPacketType {
 	public Class<?> getDataClass() {
 		return dataClass;
 	}
+
+	@Override
+	public String toString() {
+		return "ServerBoundPacketType{" +
+			"type='" + type + '\'' +
+			", dataClass=" + dataClass +
+			'}';
+	}
 }


### PR DESCRIPTION
The runner's connection to the backend is sometimes a little unstable. While the protocol is robust enough that this does not matter much, it would be nice if the runner simply stayed connected the entire time.

This PR adds logging for weird packets to help us get to the bottom of the connection instabilities.

- [x] Weird packets
- [x] Aborted tasks