### PR TITLE
Document how to upload tars with curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,36 @@ Here are a few links to get started:
 - [CLI readme](cli/README.md)
 - [Benchmark repo specification](docs/bench_repo_specification.md)
 - [Guide to contributing](docs/contributing.md)
+
+## Uploading a tar via curl
+
+If you quickly want to benchmark your current directory from the command line,
+run this command, replacing `VELCOM_ADDRESS` and `ADMIN_PASSWORD` with the
+proper values:
+
+```
+tar -czO . | curl VELCOM_ADDRESS/api/queue/upload/tar \
+  -F 'file=@-;filename=file.tar.gz' \
+  -F description='console upload' \
+  -u admin:ADMIN_PASSWORD
+```
+
+If you want to assign the tar to a specific repository, append this flag to the
+command above, replacing `REPO_ID` with the repo's UUID (can be found on the
+repo detail page):
+
+```
+-F repo_id=REPO_ID
+```
+
+Here is an example with all of the above:
+
+```
+tar -czO . | curl https://velcom.aaaaaaah.de/api/queue/upload/tar \
+  -F 'file=@-;filename=file.tar.gz' \
+  -F description='console upload' \
+  -u admin:12345 \
+  -F repo_id=44bb5c8d-b20d-4bef-bdad-c92767dfa489
+```
+
+For a nicer looking result, pipe the output from `curl` into `jq`.

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/taskaccess/exceptions/TaskCreationException.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/taskaccess/exceptions/TaskCreationException.java
@@ -1,0 +1,16 @@
+package de.aaaaaaah.velcom.backend.access.taskaccess.exceptions;
+
+public class TaskCreationException extends Exception {
+
+	private final boolean ourFault;
+
+	public TaskCreationException(String message, boolean ourFault) {
+		super(message);
+
+		this.ourFault = ourFault;
+	}
+
+	public boolean isOurFault() {
+		return ourFault;
+	}
+}

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/queue/Queue.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/queue/Queue.java
@@ -14,6 +14,7 @@ import de.aaaaaaah.velcom.backend.access.taskaccess.entities.Task;
 import de.aaaaaaah.velcom.backend.access.taskaccess.entities.TaskId;
 import de.aaaaaaah.velcom.backend.access.taskaccess.entities.TaskPriority;
 import de.aaaaaaah.velcom.backend.access.taskaccess.exceptions.NoSuchTaskException;
+import de.aaaaaaah.velcom.backend.access.taskaccess.exceptions.TaskCreationException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -184,10 +185,10 @@ public class Queue {
 	 * @param repoId the id of the repo the tar file should to (or null)
 	 * @param description the tar file's description
 	 * @param inputStream the tar file's contents
-	 * @return the new task or empty if the tar file could not be stored and no task was created
+	 * @return the newly created task
 	 */
-	public Optional<Task> addTar(String author, TaskPriority priority, @Nullable RepoId repoId,
-		String description, InputStream inputStream) {
+	public Task addTar(String author, TaskPriority priority, @Nullable RepoId repoId,
+		String description, InputStream inputStream) throws TaskCreationException {
 
 		return taskAccess.insertTar(author, priority, description, repoId, inputStream);
 	}


### PR DESCRIPTION
Tar files can be uploaded to the queue using only `tar` and `curl`. The server's output is just plain JSON describing the newly created task. This PR documents how to do this in the README.

I could add a separate endpoint that returns formatted text instead of JSON, but that's probably unnecessary.