### PR TITLE
Fix default value of "metrics" argument for "build-docker" script

### DIFF
--- a/scripts/docker/build-docker
+++ b/scripts/docker/build-docker
@@ -81,7 +81,7 @@ def prune():
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("env", help="The file layout to use. Either 'CI' or 'DEV'")
-    parser.add_argument("--metrics", action="store_true", default=True,
+    parser.add_argument("--metrics", action="store_true", default=False,
                         help="Includes aspectj in the docker image to collect more metrics.")
     parser.add_argument("--uid", default=10_000,
                         help="The UID of the user inside the docker image. "


### PR DESCRIPTION
The `build-docker` script had a wrong default value for the `metrics` argument, causing them to be *always* included.

@Kha Removing `--no-metrics` with this patch should work (better).

Feel free to apply the patch yourself and to close this PR.