### PR TITLE
Attempt to fix fd leak

### DIFF
--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/Connection.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/Connection.java
@@ -38,8 +38,8 @@ public class Connection implements WebSocket.Listener, HeartbeatWebsocket {
 	private WebSocket socket;
 	private HeartbeatHandler heartbeatHandler;
 
-	public Connection(TeleBackend teleBackend, URI address, String name, String token)
-		throws ExecutionException, InterruptedException {
+	public Connection(TeleBackend teleBackend, HttpClient httpClient, URI address, String name,
+		String token) throws ExecutionException, InterruptedException {
 
 		stateMachine = new StateMachine<>(new Idle(teleBackend, this));
 		serializer = new Serializer();
@@ -48,8 +48,7 @@ public class Connection implements WebSocket.Listener, HeartbeatWebsocket {
 		closed = false;
 
 		LOGGER.debug("Opening connection to {}", address);
-		HttpClient.newHttpClient()
-			.newWebSocketBuilder()
+		httpClient.newWebSocketBuilder()
 			.header(RunnerConnectionHeader.CONNECT_RUNNER_NAME.getName(), name)
 			.header(RunnerConnectionHeader.CONNECT_RUNNER_TOKEN.getName(), token)
 			.buildAsync(address, this)

--- a/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/TeleBackend.java
+++ b/backend/runner/src/main/java/de/aaaaaaah/velcom/runner/TeleBackend.java
@@ -97,6 +97,7 @@ public class TeleBackend {
 			} catch (ExecutionException | InterruptedException e) {
 				LOGGER.warn("{} - Failed to connect, retrying in {}", address,
 					Delays.RECONNECT_AFTER_FAILED_CONNECTION);
+				System.gc();
 				//noinspection BusyWait
 				Thread.sleep(Delays.RECONNECT_AFTER_FAILED_CONNECTION.toMillis());
 			}


### PR DESCRIPTION
A bug report showed the runner leaking file descriptors when doing lots of
reconnection attempts.

Apparently, HttpClient only cleans itself up if there are no more references to
it. In practice, this means that it only cleans itself up once a few other
objects with references to it have been garbage collected. However, it can take
quite a while for this to happen "naturally".

For each HttpClient or associated WebSocket (I'm not sure which) a few file
descriptors are opened. These are not freed immediately after a connection
attempt fails, but instead only after GC (as described above). When testing with
a reconnection delay of 0.1 seconds, velcom at one point managed to hold over
9,000 file descriptors.

This commit "fixes" the issue by kicking off GC manually via System.gc()
whenever a connection is closed. Another alternative might've been to call
the (private) cleanup methods via reflection, but that would've been even
uglier.

Closes #238.