### PR TITLE
Speed up repo deletion

### DIFF
--- a/backend/backend/src/main/resources/db/migration/V11__speed_up_repo_deletion.sql
+++ b/backend/backend/src/main/resources/db/migration/V11__speed_up_repo_deletion.sql
@@ -1,0 +1,5 @@
+CREATE INDEX idx_commit_relationship_parent
+ON commit_relationship(repo_id, parent_hash);
+
+CREATE INDEX idx_measurement_rid
+ON measurement(run_id);


### PR DESCRIPTION
By adding a few strategically placed indices, deleting a large repo now takes seconds rather than minutes.