### PR TITLE
Fix queue issues

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/dbupdate/DbUpdater.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/dbupdate/DbUpdater.java
@@ -95,6 +95,7 @@ public class DbUpdater {
 			jgitCommit.getHashAsString(),
 			false,
 			false,
+			false,
 			jgitCommit.getAuthor(),
 			jgitCommit.getAuthorDate(),
 			jgitCommit.getCommitter(),

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/dbupdate/DbUpdater.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/dbupdate/DbUpdater.java
@@ -211,7 +211,9 @@ public class DbUpdater {
 			+ ")\n"
 			+ "\n"
 			+ "UPDATE known_commit\n"
-			+ "SET tracked = (known_commit.hash IN rec)\n"
+			+ "SET\n"
+			+ "  tracked = (known_commit.hash IN rec),\n"
+			+ "  ever_tracked = ever_tracked OR (known_commit.hash IN rec)\n"
 			+ "WHERE known_commit.repo_id = ?\n" // <-- Binding #2
 			+ "";
 
@@ -255,6 +257,19 @@ public class DbUpdater {
 	/**
 	 * Find all commits that should be tracked (via a recursive query) and add them to the queue (if
 	 * they haven't already been benchmarked yet).
+	 * <p>
+	 * This query only considers commits with the "ever_tracked" flag set to false. It starts at the
+	 * tips of the tracked branches and then finds all connected commits. It always moves from child
+	 * to parent, never from parent to child.
+	 * <p>
+	 * In other words, consider a directed graph of all commits with "ever_tracked" set to false. The
+	 * edges are child-parent relationships (arrows pointing from child to parent). This query finds
+	 * all nodes (i. e. commits) that are reachable from the tips of the tracked branches (should they
+	 * be present in the graph).
+	 * <p>
+	 * The "ever_tracked" flag is used instead of the "tracked" flag to avoid filling the queue with
+	 * old commits when marking a branch tracked in a repo with no tracked branches but lots of
+	 * commits.
 	 *
 	 * @return the hashes of all commits that need to be entered into the queue, sorted by committer
 	 * 	date (or author date in case of ties) in ascending order. These may include commits that are
@@ -276,7 +291,7 @@ public class DbUpdater {
 			+ "    AND known_commit.hash = branch.latest_commit_hash\n"
 			+ "  WHERE branch.repo_id = ?\n" // <-- Binding #1
 			+ "  AND branch.tracked\n"
-			+ "  AND NOT known_commit.tracked\n"
+			+ "  AND NOT known_commit.ever_tracked\n"
 			+ "  \n"
 			+ "  UNION\n"
 			+ "  \n"
@@ -287,7 +302,7 @@ public class DbUpdater {
 			+ "  JOIN untracked\n"
 			+ "    ON untracked.hash = commit_relationship.child_hash\n"
 			+ "  WHERE known_commit.repo_id = ?\n" // <-- Binding #2
-			+ "  AND NOT known_commit.tracked\n"
+			+ "  AND NOT known_commit.ever_tracked\n"
 			+ "),\n"
 			+ "\n"
 			+ "has_result(hash) AS (\n"

--- a/backend/backend/src/main/resources/db/migration/V12__commit_tracking_flags.sql
+++ b/backend/backend/src/main/resources/db/migration/V12__commit_tracking_flags.sql
@@ -1,0 +1,40 @@
+ALTER TABLE known_commit RENAME TO known_commit_old;
+
+CREATE TABLE known_commit (
+  repo_id        CHAR(36)  NOT NULL,
+  hash           CHAR(40)  NOT NULL,
+  reachable      BOOLEAN   NOT NULL, -- Whether this commit is reachable from any branch
+  tracked        BOOLEAN   NOT NULL, -- Whether this commit is reachable from a tracked branch
+  ever_tracked   BOOLEAN   NOT NULL, -- Whether this commit has ever been tracked
+  author         TEXT      NOT NULL,
+  author_date    TIMESTAMP NOT NULL,
+  committer      TEXT      NOT NULL,
+  committer_date TIMESTAMP NOT NULL,
+  message        TEXT      NOT NULL,
+
+  -- "tracked" implies "ever_tracked"
+  CHECK (NOT tracked OR ever_tracked),
+
+  PRIMARY KEY (repo_id, hash),
+  FOREIGN KEY (repo_id) REFERENCES repo (id) ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+INSERT INTO known_commit
+SELECT
+  repo_id,
+  hash,
+  reachable,
+  tracked,
+  tracked,
+  author,
+  author_date,
+  committer,
+  committer_date,
+  message
+FROM known_commit_old;
+
+DROP TABLE known_commit_old;
+
+-- Recapture foreign key references
+ALTER TABLE known_commit RENAME TO known_commit_old;
+ALTER TABLE known_commit_old RENAME TO known_commit;

--- a/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/TestDb.java
+++ b/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/TestDb.java
@@ -120,13 +120,15 @@ public class TestDb {
 	}
 
 	public void addCommit(RepoId repoId, CommitHash commitHash, boolean reachable, boolean tracked,
-		String author, Instant authorDate, String committer, Instant committerDate, String message) {
+		boolean everTracked, String author, Instant authorDate, String committer, Instant committerDate,
+		String message) {
 
 		dslContext.batchInsert(new KnownCommitRecord(
 			repoId.getIdAsString(),
 			commitHash.getHash(),
 			reachable,
 			tracked,
+			everTracked,
 			author,
 			authorDate,
 			committer,
@@ -136,16 +138,16 @@ public class TestDb {
 	}
 
 	public void addCommit(RepoId repoId, CommitHash commitHash, boolean reachable, boolean tracked,
-		String message, Instant authorDate, Instant committerDate) {
+		boolean everTracked, String message, Instant authorDate, Instant committerDate) {
 
-		addCommit(repoId, commitHash, reachable, tracked, "author", authorDate, "committer",
-			committerDate, message);
+		addCommit(repoId, commitHash, reachable, tracked, everTracked, "author", authorDate,
+			"committer", committerDate, message);
 	}
 
 	public void addCommit(RepoId repoId, CommitHash commitHash) {
 
-		addCommit(repoId, commitHash, true, true, "author", Instant.now(), "committer", Instant.now(),
-			"message");
+		addCommit(repoId, commitHash, true, true, true, "author", Instant.now(), "committer",
+			Instant.now(), "message");
 	}
 
 	public void addCommitRel(RepoId repoId, CommitHash parent, CommitHash child) {

--- a/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/access/benchmarkaccess/BenchmarkReadAccessTest.java
+++ b/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/access/benchmarkaccess/BenchmarkReadAccessTest.java
@@ -110,13 +110,13 @@ class BenchmarkReadAccessTest {
 
 		testDb.addRepo(REPO1_ID);
 		testDb.addRepo(REPO2_ID);
-		testDb.addCommit(REPO1_ID, COMMIT1_HASH, true, true, "blad9bla",
+		testDb.addCommit(REPO1_ID, COMMIT1_HASH, true, true, true, "blad9bla",
 			Instant.ofEpochSecond(1), Instant.ofEpochSecond(1));
-		testDb.addCommit(REPO1_ID, COMMIT2_HASH, true, true, "m2",
+		testDb.addCommit(REPO1_ID, COMMIT2_HASH, true, true, true, "m2",
 			Instant.ofEpochSecond(2), Instant.ofEpochSecond(2));
-		testDb.addCommit(REPO1_ID, COMMIT3_HASH, true, true, "m3",
+		testDb.addCommit(REPO1_ID, COMMIT3_HASH, true, true, true, "m3",
 			Instant.ofEpochSecond(3), Instant.ofEpochSecond(3));
-		testDb.addCommit(REPO2_ID, COMMIT4_HASH, true, true, "m4",
+		testDb.addCommit(REPO2_ID, COMMIT4_HASH, true, true, true, "m4",
 			Instant.ofEpochSecond(4), Instant.ofEpochSecond(4));
 
 		testDb.addRun(RUN1_ID, "a1", "rn1", "ri1", RUN1_START, RUN1_START.plusSeconds(1),

--- a/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/access/committaccess/CommitReadAccessTest.java
+++ b/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/access/committaccess/CommitReadAccessTest.java
@@ -68,23 +68,23 @@ class CommitReadAccessTest {
 		TestDb testDb = new TestDb(tempDir);
 
 		testDb.addRepo(REPO_ID);
-		testDb.addCommit(REPO_ID, COMM_A_HASH, true, true,
+		testDb.addCommit(REPO_ID, COMM_A_HASH, true, true, true,
 			"aA", Instant.ofEpochSecond(1600010001), "cA", Instant.ofEpochSecond(1600010002), "A");
-		testDb.addCommit(REPO_ID, COMM_B_HASH, true, true,
+		testDb.addCommit(REPO_ID, COMM_B_HASH, true, true, true,
 			"aB", Instant.ofEpochSecond(1600020001), "cB", Instant.ofEpochSecond(1600020002), "B");
-		testDb.addCommit(REPO_ID, COMM_C_HASH, true, true,
+		testDb.addCommit(REPO_ID, COMM_C_HASH, true, true, true,
 			"aC", Instant.ofEpochSecond(1600030001), "cC", Instant.ofEpochSecond(1600030002), "C");
-		testDb.addCommit(REPO_ID, COMM_D_HASH, true, true,
+		testDb.addCommit(REPO_ID, COMM_D_HASH, true, true, true,
 			"aD", Instant.ofEpochSecond(1600040001), "cD", Instant.ofEpochSecond(1600040002), "D");
-		testDb.addCommit(REPO_ID, COMM_E_HASH, true, true,
+		testDb.addCommit(REPO_ID, COMM_E_HASH, true, true, true,
 			"aE", Instant.ofEpochSecond(1600050001), "cE", Instant.ofEpochSecond(1600050002), "E");
-		testDb.addCommit(REPO_ID, COMM_F_HASH, true, false,
+		testDb.addCommit(REPO_ID, COMM_F_HASH, true, false, true,
 			"aF", Instant.ofEpochSecond(1600060001), "cF", Instant.ofEpochSecond(1600060002), "F");
-		testDb.addCommit(REPO_ID, COMM_G_HASH, true, false,
+		testDb.addCommit(REPO_ID, COMM_G_HASH, true, false, true,
 			"aG", Instant.ofEpochSecond(1600070001), "cG", Instant.ofEpochSecond(1600070002), "G");
-		testDb.addCommit(REPO_ID, COMM_H_HASH, false, false,
+		testDb.addCommit(REPO_ID, COMM_H_HASH, false, false, true,
 			"aH", Instant.ofEpochSecond(1600080001), "cH", Instant.ofEpochSecond(1600080002), "H");
-		testDb.addCommit(REPO_ID, COMM_I_HASH, false, false,
+		testDb.addCommit(REPO_ID, COMM_I_HASH, false, false, true,
 			"aI", Instant.ofEpochSecond(1600090001), "cI", Instant.ofEpochSecond(1600090002), "I");
 		testDb.addCommitRel(REPO_ID, COMM_A_HASH, COMM_B_HASH);
 		testDb.addCommitRel(REPO_ID, COMM_B_HASH, COMM_C_HASH);


### PR DESCRIPTION
Previously, velcom would add a lot of old commits to the queue when a branch is marked as tracked in a repo with no tracked branches. This PR should fix that issue.