### PR TITLE
Various frontend fixes and enhancements

### DIFF
--- a/frontend/src/components/CommitBenchmarkActions.vue
+++ b/frontend/src/components/CommitBenchmarkActions.vue
@@ -89,7 +89,7 @@ export default class CommitBenchmarkActions extends Vue {
         icon: this.commitRemoteIcon,
         tooltip: `View this commit on <strong>${this.getRemoteHostname}</strong>`,
         external: true,
-        show: true
+        show: !!this.getRemoteHostname
       }
     ].filter(it => it.show)
   }

--- a/frontend/src/components/InlineMinimalRepoDisplay.vue
+++ b/frontend/src/components/InlineMinimalRepoDisplay.vue
@@ -24,7 +24,7 @@ export default class InlineMinimalRepoNameDisplay extends Vue {
   private get repo() {
     return (
       vxm.repoModule.repoById(this.repoId) ||
-      new Repo('Placeholder', 'Not loaded yet :/', [], [], '', false)
+      new Repo('Placeholder', 'Not loaded yet :/', [], [], '')
     )
   }
 }

--- a/frontend/src/components/comparison/RunComparisonTable.vue
+++ b/frontend/src/components/comparison/RunComparisonTable.vue
@@ -8,9 +8,20 @@
     class="compare-table"
   >
     <template #[`item.difference`]="{ item, value }">
-      <span :style="{ color: item.changeColor }">{{
-        item.formatNumber(value)
-      }}</span>
+      <span :style="{ color: item.changeColor }">
+        {{ item.formatNumber(value) }}
+      </span>
+      <span
+        :style="{
+          color: item.changeColor,
+          width: '6em',
+          opacity: 0.9,
+          'font-size': '0.8rem'
+        }"
+        class="d-inline-block"
+      >
+        {{ item.formatNumber(item.differencePercent * 100) }} %
+      </span>
     </template>
 
     <template
@@ -21,7 +32,9 @@
     </template>
 
     <template #[`header.difference`]="{}">
-      <span class="change-arrow">→</span>
+      <div class="d-flex justify-center">
+        <span class="change-arrow">→</span>
+      </div>
     </template>
   </v-data-table>
 </template>
@@ -50,6 +63,7 @@ class TableItem {
   readonly unit: string
   readonly valueFirst?: number
   readonly difference?: number
+  readonly differencePercent?: number
   readonly valueSecond?: number
   readonly changeColor: string
 
@@ -60,6 +74,7 @@ class TableItem {
     interpretation: DimensionInterpretation,
     valueFirst?: number,
     difference?: number,
+    differencePercent?: number,
     valueSecond?: number
   ) {
     this.benchmark = benchmark
@@ -67,6 +82,7 @@ class TableItem {
     this.unit = unit
     this.valueFirst = valueFirst
     this.difference = difference
+    this.differencePercent = differencePercent
     this.valueSecond = valueSecond
     this.changeColor = this.computeChangeColor(interpretation, difference)
   }
@@ -129,7 +145,7 @@ export default class RunComparisonTable extends Vue {
         value: 'difference',
         sortable: false,
         filterable: false,
-        align: 'center'
+        align: 'end'
       },
       { text: this.second.id, value: 'valueSecond', align: 'left' }
     ]
@@ -156,6 +172,7 @@ export default class RunComparisonTable extends Vue {
           dimension.interpretation,
           this.getValue(this.first, dimension),
           this.getDifference(dimension),
+          this.getDifferencePercent(dimension),
           this.getValue(this.second, dimension)
         )
     )
@@ -174,6 +191,16 @@ export default class RunComparisonTable extends Vue {
     )
     if (difference) {
       return difference.absDiff
+    }
+    return undefined
+  }
+
+  private getDifferencePercent(dimension: Dimension): number | undefined {
+    const difference = this.differences.find(it =>
+      it.dimension.equals(dimension)
+    )
+    if (difference) {
+      return difference.relDiff
     }
     return undefined
   }

--- a/frontend/src/components/dialogs/RepoAddDialog.vue
+++ b/frontend/src/components/dialogs/RepoAddDialog.vue
@@ -21,10 +21,6 @@
               label="*Repository name"
               v-model="repoName"
             ></v-text-field>
-            <v-text-field
-              label="Repository access token"
-              v-model="repoToken"
-            ></v-text-field>
           </v-form>
         </v-card-text>
         <v-card-actions>
@@ -34,8 +30,9 @@
             :loading="addInProgress"
             :disabled="!formValid || addInProgress"
             @click="addRepository"
-            >Add Repository</v-btn
           >
+            Add Repository
+          </v-btn>
           <v-spacer></v-spacer>
           <v-btn color="error" @click="dialogOpen = false">Close</v-btn>
         </v-card-actions>
@@ -53,7 +50,6 @@ import { vxm } from '@/store'
 export default class RepoAddDialog extends Vue {
   private remoteUrl: string = ''
   private repoName: string = ''
-  private repoToken: string = ''
 
   private formValid: boolean = false
   private dialogOpen: boolean = false
@@ -68,7 +64,6 @@ export default class RepoAddDialog extends Vue {
     if (opened) {
       this.remoteUrl = ''
       this.repoName = ''
-      this.repoToken = ''
     }
   }
 
@@ -77,8 +72,7 @@ export default class RepoAddDialog extends Vue {
     vxm.repoModule
       .addRepo({
         repoName: this.repoName,
-        remoteUrl: this.remoteUrl,
-        repoToken: this.repoToken.length === 0 ? undefined : this.repoToken
+        remoteUrl: this.remoteUrl
       })
       .then(it => {
         this.$emit('value', it)

--- a/frontend/src/components/dialogs/RepoUpdateDialog.vue
+++ b/frontend/src/components/dialogs/RepoUpdateDialog.vue
@@ -23,61 +23,7 @@
               label="*Repository name"
               v-model="repoName"
             ></v-text-field>
-            <v-container class="pa-0" fluid>
-              <v-row no-gutters align="center">
-                <transition name="fade">
-                  <span
-                    v-if="tokenState === 'delete'"
-                    class="section-header mr-4"
-                    >TOKEN WILL BE DELETED</span
-                  >
-                </transition>
-                <transition name="fade">
-                  <span>
-                    <v-btn
-                      v-if="tokenState === 'unchanged'"
-                      @click="tokenState = 'modify'"
-                      text
-                      outlined
-                      class="mr-2"
-                      color="primary"
-                      >Change token</v-btn
-                    >
-                    <v-btn
-                      v-if="tokenState === 'unchanged'"
-                      @click="tokenState = 'delete'"
-                      text
-                      outlined
-                      class="mr-2"
-                      color="error"
-                      >Delete token</v-btn
-                    >
-                    <v-btn
-                      v-if="tokenState === 'modify' || tokenState === 'delete'"
-                      @click="tokenState = 'unchanged'"
-                      text
-                      outlined
-                      color="error"
-                      >{{
-                        tokenState === 'modify' ? 'KEEP OLD TOKEN' : 'UNDO'
-                      }}</v-btn
-                    >
-                  </span>
-                </transition>
-                <transition name="fade">
-                  <v-text-field
-                    v-if="tokenState === 'modify'"
-                    :rules="[notEmpty]"
-                    label="*New token"
-                    v-model="newToken"
-                    dense
-                    hide-details="auto"
-                    class="ml-4 mt-0 pt-0"
-                  ></v-text-field>
-                </transition>
-              </v-row>
-            </v-container>
-            <div class="section-header mt-8 mb-2">BRANCHES</div>
+            <div class="section-header mb-2">BRANCHES</div>
             <v-data-iterator
               :custom-filter="filterName"
               :search="searchValue"
@@ -157,9 +103,7 @@ export default class RepoUpdateDialog extends Vue {
 
   private remoteUrl: string = ''
   private repoName: string = ''
-  private newToken: string = ''
 
-  private tokenState: 'delete' | 'modify' | 'unchanged' = 'unchanged'
   private itemsPerPage: number = 30
   private itemsPerPageOptions: number[] = [1, 10, 20, 30, 50, 100, -1]
 
@@ -197,8 +141,6 @@ export default class RepoUpdateDialog extends Vue {
   private watchIdUpdates() {
     this.remoteUrl = this.repo.remoteURL
     this.repoName = this.repo.name
-    this.tokenState = 'unchanged'
-    this.newToken = ''
     this.searchValue = ''
 
     this.newTrackedBranches = this.repo.branches
@@ -218,16 +160,8 @@ export default class RepoUpdateDialog extends Vue {
   }
 
   private updateRepo() {
-    let newToken: string | null | undefined
-    if (this.tokenState === 'modify') {
-      newToken = this.newToken
-    } else if (this.tokenState === 'delete') {
-      newToken = null
-    }
-
     vxm.repoModule
       .updateRepo({
-        repoToken: newToken,
         id: this.repoId,
         name: this.repoName,
         remoteUrl: this.remoteUrl,

--- a/frontend/src/components/graphs/comparison/ComparisonGraph.vue
+++ b/frontend/src/components/graphs/comparison/ComparisonGraph.vue
@@ -54,11 +54,8 @@ import {
 import { vxm } from '@/store'
 import GraphDatapointDialog from '@/components/dialogs/GraphDatapointDialog.vue'
 import { Prop } from 'vue-property-decorator'
-import {
-  roundDateDown,
-  roundDateUp
-} from '@/store/modules/comparisonGraphStore'
 import OverscrollToZoom from '@/components/graphs/OverscrollToZoom'
+import { roundDateDown, roundDateUp } from '@/util/TimeUtil'
 
 @Component({
   components: {

--- a/frontend/src/components/graphs/comparison/ComparisonGraph.vue
+++ b/frontend/src/components/graphs/comparison/ComparisonGraph.vue
@@ -36,6 +36,9 @@
           ></graph-datapoint-dialog>
         </template>
       </component>
+      <v-overlay v-if="overlayText" absolute class="ma-0 pa-0" color="black">
+        <span class="text-h6">{{ overlayText }}</span>
+      </v-overlay>
     </v-card-text>
   </v-card>
 </template>
@@ -145,6 +148,16 @@ export default class ComparisonGraph extends Vue {
       }
     }
     return visibleDataPoints
+  }
+
+  private get overlayText() {
+    if (this.seriesInformation.length === 0) {
+      return 'Please select a repo / branch on the left'
+    }
+    if (!vxm.comparisonGraphModule.selectedDimension) {
+      return 'Please select a dimension in the top left'
+    }
+    return null
   }
 
   // <!--<editor-fold desc="Zoom boilerplate">-->

--- a/frontend/src/components/graphs/comparison/ComparisonGraphSettings.vue
+++ b/frontend/src/components/graphs/comparison/ComparisonGraphSettings.vue
@@ -14,7 +14,7 @@
           </v-btn-toggle>
         </v-col>
         <v-spacer></v-spacer>
-        <v-col cols="auto">
+        <v-col cols="auto" >
           <v-btn
             @click="$emit('update:beginYAtZero', !beginYAtZero)"
             color="primary"
@@ -30,7 +30,6 @@
             color="primary"
             outlined
             text
-            class="mr-4"
             @click="
               $emit(
                 'update:dayEquidistantGraphSelected',
@@ -44,6 +43,7 @@
             <span v-else>Enable Day-Equidistant Graph</span>
           </v-btn>
         </v-col>
+        <slot></slot>
       </v-row>
     </v-card-text>
   </v-card>

--- a/frontend/src/components/graphs/comparison/ComparisonGraphSettings.vue
+++ b/frontend/src/components/graphs/comparison/ComparisonGraphSettings.vue
@@ -14,7 +14,7 @@
           </v-btn-toggle>
         </v-col>
         <v-spacer></v-spacer>
-        <v-col cols="auto" >
+        <v-col cols="auto">
           <v-btn
             @click="$emit('update:beginYAtZero', !beginYAtZero)"
             color="primary"

--- a/frontend/src/components/overviews/MultipleRunOverview.vue
+++ b/frontend/src/components/overviews/MultipleRunOverview.vue
@@ -1,31 +1,16 @@
 <template>
-  <v-data-iterator
-    class="full-width"
-    :items="runs"
-    :hide-default-footer="runs.length < defaultItemsPerPage"
-    :items-per-page="defaultItemsPerPage"
-    :footer-props="{ itemsPerPageOptions: itemsPerPageOptions }"
-  >
-    <template v-slot:default="props">
-      <v-row>
-        <v-col
-          cols="12"
-          class="my-1 py-0"
-          v-for="(item, index) in props.items"
-          :key="index"
-        >
-          <run-overview :run="run(item)">
-            <template #content v-if="differences(item)">
-              <run-significance-chips
-                :differences="differences(item)"
-                :run-id="run(item).runId"
-              ></run-significance-chips>
-            </template>
-          </run-overview>
-        </v-col>
-      </v-row>
-    </template>
-  </v-data-iterator>
+  <v-list>
+    <v-list-item v-for="item in runs" :key="run(item).runId" class="my-2">
+      <run-overview :run="run(item)" class="full-width">
+        <template #content v-if="differences(item)">
+          <run-significance-chips
+            :differences="differences(item)"
+            :run-id="run(item).runId"
+          ></run-significance-chips>
+        </template>
+      </run-overview>
+    </v-list-item>
+  </v-list>
 </template>
 
 <script lang="ts">
@@ -52,10 +37,6 @@ export default class MultipleRunOverview extends Vue {
 
   @Prop({ default: 3 })
   private numberOfChanges!: number
-
-  // noinspection JSMismatchedCollectionQueryUpdate
-  private itemsPerPageOptions: number[] = [10, 20, 50, 100, 200, -1]
-  private defaultItemsPerPage: number = 20
 
   private run(
     run: RunDescription | RunDescriptionWithDifferences

--- a/frontend/src/components/overviews/TarOverview.vue
+++ b/frontend/src/components/overviews/TarOverview.vue
@@ -1,6 +1,21 @@
 <template>
   <v-card outlined>
-    <v-card-title> Tar '{{ tarSource.description }}' </v-card-title>
+    <v-card-title>
+      <span v-if="runId === null">Tar '{{ tarSource.description }}'</span>
+      <v-row v-if="runId !== null" justify="space-between">
+        <v-col> Tar '{{ tarSource.description }}' </v-col>
+        <v-col cols="auto">
+          <v-tooltip top>
+            <template #activator="{ on }">
+              <v-btn icon :to="compareRunLocation" v-on="on">
+                <v-icon>{{ compareIcon }}</v-icon>
+              </v-btn>
+            </template>
+            Compare this run with another
+          </v-tooltip>
+        </v-col>
+      </v-row>
+    </v-card-title>
     <v-card-subtitle v-if="tarSource.repoId">
       Attached to
       <inline-minimal-repo-display
@@ -14,8 +29,9 @@
 import Vue from 'vue'
 import Component from 'vue-class-component'
 import { Prop } from 'vue-property-decorator'
-import { TarTaskSource } from '@/store/types'
+import { RunId, TarTaskSource } from '@/store/types'
 import InlineMinimalRepoNameDisplay from '@/components/InlineMinimalRepoDisplay.vue'
+import { mdiScaleBalance } from '@mdi/js'
 
 @Component({
   components: {
@@ -25,5 +41,23 @@ import InlineMinimalRepoNameDisplay from '@/components/InlineMinimalRepoDisplay.
 export default class TarOverview extends Vue {
   @Prop()
   private readonly tarSource!: TarTaskSource
+
+  @Prop({ default: null })
+  private readonly runId!: RunId | null
+
+  private get compareRunLocation() {
+    if (!this.runId) {
+      return null
+    }
+    return {
+      name: 'search',
+      params: {
+        runId: this.runId
+      }
+    }
+  }
+
+  // ICONS
+  private compareIcon = mdiScaleBalance
 }
 </script>

--- a/frontend/src/components/repodetail/RepoBaseInformation.vue
+++ b/frontend/src/components/repodetail/RepoBaseInformation.vue
@@ -97,17 +97,16 @@ export default class RepoBaseInformation extends Vue {
     return vxm.userModule.isAdmin
   }
 
-  private deleteRepository() {
+  private async deleteRepository() {
     const confirmed = window.confirm(
       `Do you really want to delete ${this.repo.name} (${this.repo.id})?`
     )
     if (!confirmed) {
       return
     }
-    vxm.repoModule.deleteRepo(this.repo.id).then(() => {
-      vxm.detailGraphModule.selectedRepoId = ''
-      this.$router.replace({ name: 'repo-detail-frame', params: { id: '' } })
-    })
+    await vxm.repoModule.deleteRepo(this.repo.id)
+    vxm.detailGraphModule.selectedRepoId = ''
+    await this.$router.replace({ name: 'repo-detail', params: { id: '' } })
   }
 
   private comparatorTrackStatus(branchA: RepoBranch, branchB: RepoBranch) {

--- a/frontend/src/components/repodetail/RepoGraph.vue
+++ b/frontend/src/components/repodetail/RepoGraph.vue
@@ -21,7 +21,10 @@
                 </v-btn-toggle>
               </v-col>
               <v-col cols="auto">
-                <share-graph-link-dialog :link-generator="getShareLink" />
+                <share-graph-link-dialog
+                  :link-generator="getShareLink"
+                  data-restriction-label="Include dimensions"
+                />
               </v-col>
             </v-row>
           </v-card-title>

--- a/frontend/src/components/repodetail/RepoGraph.vue
+++ b/frontend/src/components/repodetail/RepoGraph.vue
@@ -21,7 +21,7 @@
                 </v-btn-toggle>
               </v-col>
               <v-col cols="auto">
-                <share-graph-link-dialog />
+                <share-graph-link-dialog :link-generator="getShareLink" />
               </v-col>
             </v-row>
           </v-card-title>
@@ -113,6 +113,7 @@ import {
   availableGraphComponents,
   selectGraphVariant
 } from '@/util/GraphVariantSelection'
+import { PermanentLinkOptions } from '@/store/modules/detailGraphStore'
 
 @Component({
   components: {
@@ -162,6 +163,10 @@ export default class RepoGraphs extends Vue {
     }
     // We do not show an overlay if we have no datapoints as you can load more by zooming out
     return null
+  }
+
+  private getShareLink(options: PermanentLinkOptions) {
+    return vxm.detailGraphModule.permanentLink(options)
   }
 
   @Watch('reloadGraphDataCounter')

--- a/frontend/src/components/repodetail/RepoGraph.vue
+++ b/frontend/src/components/repodetail/RepoGraph.vue
@@ -107,10 +107,6 @@ import { Prop, Watch } from 'vue-property-decorator'
 import { getInnerHeight } from '@/util/MeasurementUtils'
 import { escapeHtml } from '@/util/TextUtils'
 import { formatDate } from '@/util/TimeUtil'
-import {
-  roundDateDown,
-  roundDateUp
-} from '@/store/modules/comparisonGraphStore'
 import GraphDatapointDialog from '@/components/dialogs/GraphDatapointDialog.vue'
 import {
   availableGraphComponents,
@@ -252,7 +248,7 @@ export default class RepoGraphs extends Vue {
 
   // noinspection JSUnusedLocalSymbols
   private set dataRangeMin(date: Date) {
-    vxm.detailGraphModule.startTime = roundDateDown(date)
+    vxm.detailGraphModule.startTime = date
     vxm.detailGraphModule.fetchDetailGraph()
   }
 
@@ -262,7 +258,7 @@ export default class RepoGraphs extends Vue {
 
   // noinspection JSUnusedLocalSymbols
   private set dataRangeMax(date: Date) {
-    vxm.detailGraphModule.endTime = roundDateUp(date)
+    vxm.detailGraphModule.endTime = date
     vxm.detailGraphModule.fetchDetailGraph()
   }
 

--- a/frontend/src/components/rundetail/CommitDetail.vue
+++ b/frontend/src/components/rundetail/CommitDetail.vue
@@ -62,7 +62,7 @@
                 :key="index"
                 justify="space-between"
                 no-gutters
-                class="py-1"
+                class="py-1 my-0"
               >
                 <v-col cols="6" class="pr-4">
                   <div v-if="parent" class="d-flex justify-start">

--- a/frontend/src/components/search/SearchResultBranch.vue
+++ b/frontend/src/components/search/SearchResultBranch.vue
@@ -1,0 +1,87 @@
+<template>
+  <v-card outlined>
+    <v-list-item>
+      <v-icon large>{{ branchIcon }}</v-icon>
+      <v-list-item-content>
+        <v-container fluid class="my-0 py-0">
+          <v-row no-gutters align="center" justify="space-between">
+            <v-col cols="auto" class="flex-shrink-too mr-3">
+              <v-list-item-title>
+                <repo-display :repoId="item.repoId"></repo-display>
+                <span class="mx-2">—</span>
+                <router-link class="concealed-link" :to="commitLinkLocation">
+                  <span class="commit-message">{{ item.name }}</span>
+                </router-link>
+              </v-list-item-title>
+              <v-list-item-subtitle>
+                <span v-if="item.commitSummary">
+                  {{ item.commitSummary }}
+                </span>
+                <span v-else class="font-italic">
+                  Loading data for branch head...
+                </span>
+              </v-list-item-subtitle>
+            </v-col>
+            <v-col cols="auto">
+              <v-container fluid class="ma-0 pa-0">
+                <v-row no-gutters align="center" justify="space-between">
+                  <v-col cols="auto">
+                    <commit-chip :commitHash="item.hash"></commit-chip>
+                  </v-col>
+                  <span class="pl-3">
+                    <slot name="compare-actions" :has-run="hasRun"></slot>
+                  </span>
+                </v-row>
+              </v-container>
+            </v-col>
+          </v-row>
+        </v-container>
+      </v-list-item-content>
+    </v-list-item>
+  </v-card>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import Component from 'vue-class-component'
+import { Prop } from 'vue-property-decorator'
+import { SearchItemBranch } from '@/store/types'
+import { RawLocation } from 'vue-router'
+import CommitChip from '@/components/CommitChip.vue'
+import InlineMinimalRepoDisplay from '@/components/InlineMinimalRepoDisplay.vue'
+import { mdiSourceBranch } from '@mdi/js'
+
+@Component({
+  components: {
+    'repo-display': InlineMinimalRepoDisplay,
+    CommitChip
+  }
+})
+export default class SearchResultBranch extends Vue {
+  @Prop()
+  private readonly item!: SearchItemBranch
+
+  private get commitLinkLocation(): RawLocation {
+    return {
+      name: 'run-detail',
+      params: { first: this.item.repoId, second: this.item.hash }
+    }
+  }
+
+  private get hasRun() {
+    return this.item.runId !== undefined
+  }
+
+  private readonly branchIcon = mdiSourceBranch
+}
+</script>
+
+<style scoped>
+.commit-message {
+  font-style: italic;
+}
+.flex-shrink-too {
+  flex: 1 1 0;
+  min-width: 200px;
+}
+</style>

--- a/frontend/src/components/search/SearchResultList.vue
+++ b/frontend/src/components/search/SearchResultList.vue
@@ -53,11 +53,12 @@
 import Vue from 'vue'
 import Component from 'vue-class-component'
 import { Prop } from 'vue-property-decorator'
-import { SearchItem, SearchItemCommit } from '@/store/types'
+import { SearchItem, SearchItemCommit, SearchItemRun } from '@/store/types'
 import SearchResultCommit from '@/components/search/SearchResultCommit.vue'
 import SearchResultTar from '@/components/search/SearchResultTar.vue'
 import SearchResultRun from '@/components/search/SearchResultRun.vue'
 import { mdiScaleBalance } from '@mdi/js'
+import SearchResultBranch from '@/components/search/SearchResultBranch.vue'
 
 class DisplayedItem {
   readonly id: string
@@ -65,14 +66,17 @@ class DisplayedItem {
   readonly item: SearchItem
 
   constructor(item: SearchItem) {
-    this.id =
-      item instanceof SearchItemCommit ? item.repoId + item.hash : item.id
     this.item = item
 
     if (item instanceof SearchItemCommit) {
       this.type = 'commit'
-    } else {
+      this.id = item.repoId + item.hash
+    } else if (item instanceof SearchItemRun) {
       this.type = item.tarDescription ? 'tar' : 'run'
+      this.id = item.id
+    } else {
+      this.type = 'branch'
+      this.id = item.repoId + item.hash
     }
   }
 }
@@ -80,6 +84,7 @@ class DisplayedItem {
 @Component({
   components: {
     commit: SearchResultCommit,
+    branch: SearchResultBranch,
     tar: SearchResultTar,
     run: SearchResultRun
   }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -23,7 +23,6 @@ Vue.use(VueRouter)
 export type RouteName =
   | 'home'
   | 'repo-comparison'
-  | 'repo-detail-frame'
   | 'repo-detail'
   | 'queue'
   | 'search'
@@ -192,7 +191,7 @@ router.beforeEach((to, from, next) => {
 })
 
 router.beforeEach((to, from, next) => {
-  if (to.name === 'repo-detail-frame' && !to.params['id']) {
+  if (to.name === 'repo-detail' && !to.params['id']) {
     const saved = vxm.detailGraphModule.selectedRepoId
     if (saved) {
       next({ name: 'repo-detail', params: { id: saved } })

--- a/frontend/src/store/modules/comparisonGraphStore.ts
+++ b/frontend/src/store/modules/comparisonGraphStore.ts
@@ -18,6 +18,7 @@ import {
   respectOptions
 } from '@/util/LinkUtils'
 import { Route } from 'vue-router'
+import { roundDateDown, roundDateUp } from '@/util/TimeUtil'
 
 const VxModule = createModule({
   namespaced: 'comparisonGraphModule',
@@ -35,24 +36,6 @@ function defaultStartDate() {
 function defaultEndDate() {
   // Today at midnight / start of tomorrow
   return new Date(new Date().setHours(24, 0, 0, 0))
-}
-
-export function roundDateUp(date: Date): Date {
-  const copy = new Date(date)
-  if (!(date.getHours() !== 0)) {
-    copy.setHours(24, 0, 0, 0) // next midnight
-  }
-  copy.setMinutes(0, 0, 0)
-  return copy
-}
-
-export function roundDateDown(date: Date): Date {
-  const copy = new Date(date)
-  if (!(date.getHours() !== 0)) {
-    copy.setHours(0, 0, 0, 0) // this midnight
-  }
-  copy.setMinutes(0, 0, 0)
-  return copy
 }
 
 function formatRepos(repos: Map<RepoId, string[]>): string {

--- a/frontend/src/store/modules/comparisonGraphStore.ts
+++ b/frontend/src/store/modules/comparisonGraphStore.ts
@@ -12,15 +12,12 @@ import { vxm } from '@/store'
 import router from '@/router'
 import { PermanentLinkOptions } from '@/store/modules/detailGraphStore'
 import {
-  extractDateFromQuery,
-  extractFloatFromQuery,
   orElse,
   orUndefined,
   parseAndSetZoomAndDateRange,
   respectOptions
 } from '@/util/LinkUtils'
 import { Route } from 'vue-router'
-import { dateFromRelative } from '@/util/TimeUtil'
 
 const VxModule = createModule({
   namespaced: 'comparisonGraphModule',

--- a/frontend/src/store/modules/comparisonGraphStore.ts
+++ b/frontend/src/store/modules/comparisonGraphStore.ts
@@ -150,7 +150,7 @@ export class ComparisonGraphStore extends VxModule {
               : orUndefined(this.endTime.getTime()),
           repos: respectOptions(
             options,
-            'includeDimensions',
+            'includeDataRestrictions',
             formatRepos(this.selectedBranches)
           ),
           dayEquidistant: this.dayEquidistantGraphSelected ? 'true' : undefined

--- a/frontend/src/store/modules/comparisonGraphStore.ts
+++ b/frontend/src/store/modules/comparisonGraphStore.ts
@@ -8,6 +8,7 @@ import {
 import Vue from 'vue'
 import axios from 'axios'
 import { comparisonDatapointFromJson } from '@/util/GraphJsonHelper'
+import { vxm } from '@/store'
 
 const VxModule = createModule({
   namespaced: 'comparisonGraphModule',
@@ -124,12 +125,15 @@ export class ComparisonGraphStore extends VxModule {
 
   get selectedBranches(): Map<RepoId, string[]> {
     const map: Map<RepoId, string[]> = new Map()
-    Object.keys(this._selectedBranches).forEach(repoId => {
-      const branches = this._selectedBranches[repoId]
-      if (branches && branches.length > 0) {
-        map.set(repoId, branches)
-      }
-    })
+    Object.keys(this._selectedBranches)
+      // Repos might not exist anymore, as the selected branches are persisted
+      .filter(id => vxm.repoModule.repoById(id) !== undefined)
+      .forEach(repoId => {
+        const branches = this._selectedBranches[repoId]
+        if (branches && branches.length > 0) {
+          map.set(repoId, branches)
+        }
+      })
     return map
   }
 }

--- a/frontend/src/store/modules/detailGraphStore.ts
+++ b/frontend/src/store/modules/detailGraphStore.ts
@@ -16,6 +16,7 @@ import router from '@/router'
 import { Route } from 'vue-router'
 import { dateFromRelative } from '@/util/TimeUtil'
 import { spaceDayEquidistant } from '@/util/DayEquidistantUtil'
+import { orElse, orUndefined, respectOptions } from '@/util/LinkUtils'
 
 const VxModule = createModule({
   namespaced: 'detailGraphModule',
@@ -445,27 +446,17 @@ export class DetailGraphStore extends VxModule {
    */
   get permanentLink(): (options?: PermanentLinkOptions) => string {
     return options => {
-      const orUndefined = (it: any) => (it ? '' + it : undefined)
-      const orElse = (it: any, subst: any) => (it ? '' + it : '' + subst)
-      function respectOptions<T>(
-        name: keyof PermanentLinkOptions,
-        value: T
-      ): T | undefined {
-        if (!options || options[name]) {
-          return value
-        }
-        return undefined
-      }
-
       const route = router.resolve({
         name: 'repo-detail',
         params: { id: this.selectedRepoId },
         query: {
           zoomYStart: respectOptions(
+            options,
             'includeYZoom',
             orUndefined(this.zoomYStartValue)
           ),
           zoomYEnd: respectOptions(
+            options,
             'includeYZoom',
             orUndefined(this.zoomYEndValue)
           ),
@@ -477,7 +468,11 @@ export class DetailGraphStore extends VxModule {
             options && options.includeXZoom
               ? orElse(this.zoomXEndValue, this.endTime.getTime())
               : orUndefined(this.endTime.getTime()),
-          dimensions: respectOptions('includeDimensions', this.dimensionString),
+          dimensions: respectOptions(
+            options,
+            'includeDimensions',
+            this.dimensionString
+          ),
           dayEquidistant: this.dayEquidistantGraph ? 'true' : undefined
         }
       })

--- a/frontend/src/store/modules/detailGraphStore.ts
+++ b/frontend/src/store/modules/detailGraphStore.ts
@@ -26,7 +26,7 @@ const VxModule = createModule({
 export type PermanentLinkOptions = Partial<{
   includeXZoom: boolean
   includeYZoom: boolean
-  includeDimensions: boolean
+  includeDataRestrictions: boolean
 }>
 
 export class DetailGraphStore extends VxModule {
@@ -470,7 +470,7 @@ export class DetailGraphStore extends VxModule {
               : orUndefined(this.endTime.getTime()),
           dimensions: respectOptions(
             options,
-            'includeDimensions',
+            'includeDataRestrictions',
             this.dimensionString
           ),
           dayEquidistant: this.dayEquidistantGraph ? 'true' : undefined

--- a/frontend/src/store/modules/detailGraphStore.ts
+++ b/frontend/src/store/modules/detailGraphStore.ts
@@ -21,6 +21,7 @@ import {
   parseAndSetZoomAndDateRange,
   respectOptions
 } from '@/util/LinkUtils'
+import { roundDateDown, roundDateUp } from '@/util/TimeUtil'
 
 const VxModule = createModule({
   namespaced: 'detailGraphModule',
@@ -146,8 +147,6 @@ export class DetailGraphStore extends VxModule {
       vxm.repoModule.repoById(repoId) ||
       (await vxm.repoModule.fetchRepoById(repoId))
 
-    parseAndSetZoomAndDateRange(link, this)
-
     if (link.query.dayEquidistant === 'true') {
       this.dayEquidistantGraph = true
     }
@@ -163,6 +162,8 @@ export class DetailGraphStore extends VxModule {
         )
       })
     }
+
+    parseAndSetZoomAndDateRange(link, vxm.detailGraphModule)
   }
   //  <!--</editor-fold>-->
 
@@ -180,10 +181,7 @@ export class DetailGraphStore extends VxModule {
   }
 
   set startTime(time: Date) {
-    if (!(time.getHours() !== 0)) {
-      time.setHours(0, 0, 0, 0) // last midnight
-    }
-    this._startTime = time
+    this._startTime = roundDateDown(time)
   }
 
   get endTime(): Date {
@@ -191,10 +189,7 @@ export class DetailGraphStore extends VxModule {
   }
 
   set endTime(time: Date) {
-    if (!(time.getHours() !== 0)) {
-      time.setHours(24, 0, 0, 0) // next midnight
-    }
-    this._endTime = time
+    this._endTime = roundDateUp(time)
   }
 
   get duration(): number {

--- a/frontend/src/store/modules/repoStore.ts
+++ b/frontend/src/store/modules/repoStore.ts
@@ -45,12 +45,10 @@ export class RepoStore extends VxModule {
   async addRepo(payload: {
     repoName: string
     remoteUrl: string
-    repoToken: string | undefined
   }): Promise<Repo> {
     const response = await axios.post('/repo', {
       name: payload.repoName,
-      remote_url: payload.remoteUrl,
-      token: payload.repoToken
+      remote_url: payload.remoteUrl
     })
 
     const repo: Repo = repoFromJson(response.data.repo)

--- a/frontend/src/store/modules/repoStore.ts
+++ b/frontend/src/store/modules/repoStore.ts
@@ -114,7 +114,6 @@ export class RepoStore extends VxModule {
       existing.name = payload.name
       existing.remoteURL = payload.remoteURL
       existing.dimensions = payload.dimensions.slice()
-      existing.hasToken = payload.hasToken
     } else {
       Vue.set(this.repos, payload.id, payload)
       vxm.repoModule.setIndexForRepo(payload.id)

--- a/frontend/src/store/modules/repoStore.ts
+++ b/frontend/src/store/modules/repoStore.ts
@@ -75,20 +75,17 @@ export class RepoStore extends VxModule {
    * Updates a repo.
    * @param payload contains the id, the new name (or undefined if unchanged),
    * the new remote URL (or undefined if unchanged), the new tracked branches
-   * (or undefined if unchanged) and the new repo token (the new token or null
-   * if it should be deleted or undefined if it should be left unchanged)
+   * (or undefined if unchanged)
    */
   @action
   async updateRepo(payload: {
     id: RepoId
     name: string | undefined
-    repoToken: string | undefined | null
     remoteUrl: string | undefined
     trackedBranches: string[] | undefined
   }): Promise<void> {
     await axios.patch(`/repo/${payload.id}`, {
       name: payload.name,
-      token: payload.repoToken,
       remote_url: payload.remoteUrl,
       tracked_branches: payload.trackedBranches
     })

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -696,4 +696,26 @@ export class SearchItemRun {
   }
 }
 
-export type SearchItem = SearchItemCommit | SearchItemRun
+export class SearchItemBranch {
+  readonly repoId: RepoId
+  readonly name: string
+  readonly hash: CommitHash
+  runId?: RunId
+  commitSummary?: string
+
+  constructor(
+    repoId: RepoId,
+    name: string,
+    hash: CommitHash,
+    commitSummary?: string,
+    runId?: RunId
+  ) {
+    this.repoId = repoId
+    this.name = name
+    this.hash = hash
+    this.commitSummary = commitSummary
+    this.runId = runId
+  }
+}
+
+export type SearchItem = SearchItemCommit | SearchItemRun | SearchItemBranch

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -19,15 +19,13 @@ export class Repo {
   branches: RepoBranch[]
   dimensions: Dimension[]
   remoteURL: string
-  hasToken: boolean
 
   constructor(
     id: RepoId,
     name: string,
     branches: RepoBranch[],
     dimensions: Dimension[],
-    remoteURL: string,
-    hasToken: boolean
+    remoteURL: string
   ) {
     this.id = id
     this.name = name
@@ -36,7 +34,6 @@ export class Repo {
     this.branches = branches.sort((a, b) =>
       a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
     )
-    this.hasToken = hasToken
   }
 
   /**

--- a/frontend/src/util/LinkUtils.ts
+++ b/frontend/src/util/LinkUtils.ts
@@ -1,5 +1,12 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { PermanentLinkOptions } from '@/store/modules/detailGraphStore'
+import { dateFromRelative } from '@/util/TimeUtil'
+import { Route } from 'vue-router'
+import { vxm } from '@/store'
+import {
+  roundDateDown,
+  roundDateUp
+} from '@/store/modules/comparisonGraphStore'
 
 /**
  * Converts something to a string or undefined, if it was falsy or undefined.
@@ -37,4 +44,100 @@ export function respectOptions<T>(
     return value
   }
   return undefined
+}
+
+/**
+ * Extracts the query parameter with name "name" from the passed "link" and if
+ * the value is a valid float (not null, and not NaN) it calls action with it.
+ *
+ * @param link the link
+ * @param name the name of the query parameter
+ * @param action the action to execute with it
+ */
+export function extractFloatFromQuery(
+  link: Route,
+  name: string,
+  action: (value: number) => void
+): void {
+  const queryValue = link.query[name]
+  if (queryValue && typeof queryValue === 'string') {
+    if (!isNaN(parseFloat(queryValue))) {
+      action(parseFloat(queryValue))
+    }
+  }
+}
+
+/**
+ * Extracts the query parameter with name "name" from the passed "link" and if
+ * the value is a valid date (a floats or a "relative time string", see
+ * dateFromRelative) it calls action with its relativized form. This form is
+ * obtained by calling "dateFromRelative" with the passed relative date and the
+ * parsed query parameter.
+ *
+ * @param link the link
+ * @param name the name of the query parameter
+ * @param relative the date the parsed parameter is relative to
+ * @param action the action to execute with it
+ */
+export function extractDateFromQuery(
+  link: Route,
+  name: string,
+  relative: Date,
+  action: (value: number) => void
+): void {
+  const queryValue = link.query[name]
+  if (queryValue && typeof queryValue === 'string') {
+    if (queryValue.match(/^([+-])?(\d|\.)+$/)) {
+      action(parseFloat(queryValue))
+      return
+    }
+    const relativeDate = dateFromRelative(queryValue, relative)
+    if (relativeDate) {
+      action(relativeDate.getTime())
+    }
+  }
+}
+
+export type ZoomDateRangeStore = {
+  zoomXStartValue: number | null
+  zoomXEndValue: number | null
+  zoomYStartValue: number | null
+  zoomYEndValue: number | null
+
+  startTime: Date
+  endTime: Date
+}
+
+/**
+ * Parses the zoom and date range (start / end) from a given link and sets the
+ * values on the passed store.
+ *
+ * @param link the link to parse it from
+ * @param store the store to set it on
+ */
+export function parseAndSetZoomAndDateRange(
+  link: Route,
+  store: ZoomDateRangeStore
+) {
+  // Anchors to the current date
+  extractDateFromQuery(link, 'zoomXEnd', new Date(), value => {
+    store.zoomXEndValue = value
+    store.endTime = roundDateUp(new Date(value))
+  })
+  // Anchors to the end date (or the current one if not specified)
+  extractDateFromQuery(
+    link,
+    'zoomXStart',
+    new Date(store.zoomXEndValue || new Date().getTime()),
+    value => {
+      store.zoomXStartValue = value
+      store.startTime = roundDateDown(new Date(value))
+    }
+  )
+  extractFloatFromQuery(link, 'zoomYStart', value => {
+    store.zoomYStartValue = value
+  })
+  extractFloatFromQuery(link, 'zoomYEnd', value => {
+    store.zoomYEndValue = value
+  })
 }

--- a/frontend/src/util/LinkUtils.ts
+++ b/frontend/src/util/LinkUtils.ts
@@ -1,0 +1,40 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import { PermanentLinkOptions } from '@/store/modules/detailGraphStore'
+
+/**
+ * Converts something to a string or undefined, if it was falsy or undefined.
+ *
+ * @param it the object to convert
+ */
+export function orUndefined(it: any): string | undefined {
+  return it ? '' + it : undefined
+}
+
+/**
+ * Converts something to a string or `subst`, if it was falsy or undefined.
+ *
+ * @param it the object to convert
+ * @param subst the alternative to use if it was undefined
+ */
+export function orElse(it: any, subst: any): string {
+  return it ? '' + it : '' + subst
+}
+
+/**
+ * Returns the given value if the option "name" is present in "options",
+ * undefined otherwise.
+ *
+ * @param options the options to use
+ * @param name the name of the option
+ * @param value the value to return if the option is defined
+ */
+export function respectOptions<T>(
+  options: PermanentLinkOptions | undefined,
+  name: keyof PermanentLinkOptions,
+  value: T
+): T | undefined {
+  if (!options || options[name]) {
+    return value
+  }
+  return undefined
+}

--- a/frontend/src/util/LinkUtils.ts
+++ b/frontend/src/util/LinkUtils.ts
@@ -2,7 +2,6 @@
 import { PermanentLinkOptions } from '@/store/modules/detailGraphStore'
 import { dateFromRelative } from '@/util/TimeUtil'
 import { Route } from 'vue-router'
-import { vxm } from '@/store'
 import {
   roundDateDown,
   roundDateUp

--- a/frontend/src/util/LinkUtils.ts
+++ b/frontend/src/util/LinkUtils.ts
@@ -1,11 +1,7 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { PermanentLinkOptions } from '@/store/modules/detailGraphStore'
-import { dateFromRelative } from '@/util/TimeUtil'
+import { dateFromRelative, roundDateDown, roundDateUp } from '@/util/TimeUtil'
 import { Route } from 'vue-router'
-import {
-  roundDateDown,
-  roundDateUp
-} from '@/store/modules/comparisonGraphStore'
 
 /**
  * Converts something to a string or undefined, if it was falsy or undefined.

--- a/frontend/src/util/RepoJsonHelper.ts
+++ b/frontend/src/util/RepoJsonHelper.ts
@@ -14,8 +14,7 @@ export function repoFromJson(json: any): Repo {
     json.name,
     json.branches.map(repoBranchFromJson),
     json.dimensions.map((it: any) => dimensionFromJson(it)),
-    json.remote_url,
-    json.has_token
+    json.remote_url
   )
 }
 

--- a/frontend/src/util/StorePersistenceUtilities.ts
+++ b/frontend/src/util/StorePersistenceUtilities.ts
@@ -39,8 +39,7 @@ function hydrateRepo(repo: Repo) {
     repo.name,
     repo.branches.map(hydrateRepoBranch),
     repo.dimensions.map(hydrateDimension),
-    repo.remoteURL,
-    repo.hasToken
+    repo.remoteURL
   )
 }
 // </editor-fold>

--- a/frontend/src/util/TimeUtil.ts
+++ b/frontend/src/util/TimeUtil.ts
@@ -5,6 +5,7 @@
  * @param {Date} start the start date
  * @param {Date} end the end date
  */
+
 export function formatDurationHuman(start: Date, end: Date): string {
   const [hours, minutes, seconds] = durationToParts(start, end)
   let result = ''
@@ -157,4 +158,38 @@ function leftZeroPad(length: number, input: number) {
     asString = '0' + asString
   }
   return asString
+}
+
+/**
+ * Rounds a date down to midnight (00:00:00:00).
+ *
+ * @param date the date to round down
+ */
+export function roundDateDown(date: Date): Date {
+  const copy = new Date(date)
+  copy.setHours(0, 0, 0, 0) // this midnight
+  return copy
+}
+
+/**
+ * Rounds a date up to the next midnight, iff it is not already at midnight.
+ * This allows you to repeatedly apply the function without any change in output:
+ * "roundDateUp(date) == roundDateUp(roundDateUp(date))"
+ *
+ * @param date the date to round up
+ */
+export function roundDateUp(date: Date): Date {
+  // Do not lift midnight to the next day as roundDateUp calls should be
+  // chainable:
+  // roundDateUp(date) == roundDateUp(roundDateUp(date))
+  if (
+    date.getHours() === 0 &&
+    date.getMinutes() === 0 &&
+    date.getSeconds() === 0
+  ) {
+    return date
+  }
+  const copy = new Date(date)
+  copy.setDate(copy.getDate() + 1)
+  return roundDateDown(copy)
 }

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -10,7 +10,7 @@
               </v-toolbar>
             </v-card-title>
             <v-card-text>
-              <v-container fluid>
+              <v-container fluid class="mt-0 pt-0">
                 <v-row align="baseline" justify="center">
                   <v-col class="mx-0 px-0">
                     <multiple-run-overview
@@ -42,7 +42,7 @@
               <v-toolbar color="toolbarColor" dark>Recent Runs</v-toolbar>
             </v-card-title>
             <v-card-text>
-              <v-container fluid>
+              <v-container fluid class="mt-0 pt-0">
                 <v-row align="baseline" justify="center">
                   <v-col class="mx-0 px-0">
                     <multiple-run-overview

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -18,7 +18,7 @@
                     ></multiple-run-overview>
                   </v-col>
                 </v-row>
-                <v-row align="baseline" justify="end" class="mt-2">
+                <v-row align="baseline" justify="center" class="mt-2">
                   <v-col cols="auto">
                     <v-btn
                       outlined
@@ -50,7 +50,7 @@
                     ></multiple-run-overview>
                   </v-col>
                 </v-row>
-                <v-row align="baseline" justify="end" class="mt-2">
+                <v-row align="baseline" justify="center" class="mt-2">
                   <v-col cols="auto">
                     <v-btn
                       outlined

--- a/frontend/src/views/RepoComparison.vue
+++ b/frontend/src/views/RepoComparison.vue
@@ -161,9 +161,14 @@ export default class RepoComparison extends Vue {
   }
 
   private get selectedRepos(): Repo[] {
-    return Array.from(vxm.comparisonGraphModule.selectedBranches.entries())
-      .filter(([, value]) => value.length > 0)
-      .map(([key]) => vxm.repoModule.repoById(key)!)
+    return (
+      Array.from(vxm.comparisonGraphModule.selectedBranches.entries())
+        .filter(([, value]) => value.length > 0)
+        .map(([key]) => vxm.repoModule.repoById(key))
+        // Repos might not exist anymore, as the selected branches are persisted
+        .filter(it => it !== undefined)
+        .map(it => it!)
+    )
   }
 
   private applyDatapointTransformations(datapoints: ComparisonDataPoint[]) {

--- a/frontend/src/views/RepoComparison.vue
+++ b/frontend/src/views/RepoComparison.vue
@@ -24,7 +24,11 @@
               :begin-y-at-zero.sync="beginYAtZero"
               :graph-component.sync="graphComponent"
               :day-equidistant-graph-selected.sync="dayEquidistantGraphSelected"
-            ></comparison-graph-settings>
+            >
+              <v-col cols="auto">
+                <share-graph-link-dialog :link-generator="getShareLink" />
+              </v-col>
+            </comparison-graph-settings>
           </v-col>
         </v-row>
         <v-row class="mt-0">
@@ -64,9 +68,12 @@ import ComparisonGraphSettings from '@/components/graphs/comparison/ComparisonGr
 import { groupBy, spaceDayEquidistant } from '@/util/DayEquidistantUtil'
 import { availableGraphComponents } from '@/util/GraphVariantSelection'
 import { debounce } from '@/util/Debouncer'
+import ShareGraphLinkDialog from '@/views/ShareGraphLinkDialog.vue'
+import { PermanentLinkOptions } from '@/store/modules/detailGraphStore'
 
 @Component({
   components: {
+    ShareGraphLinkDialog,
     ComparisonGraphSettings,
     ComparisonGraph,
     ComparisonDimensionSelector,
@@ -169,6 +176,10 @@ export default class RepoComparison extends Vue {
         .filter(it => it !== undefined)
         .map(it => it!)
     )
+  }
+
+  private getShareLink(options: PermanentLinkOptions) {
+    return vxm.comparisonGraphModule.permanentLink(options)
   }
 
   private applyDatapointTransformations(datapoints: ComparisonDataPoint[]) {

--- a/frontend/src/views/RepoComparison.vue
+++ b/frontend/src/views/RepoComparison.vue
@@ -26,7 +26,10 @@
               :day-equidistant-graph-selected.sync="dayEquidistantGraphSelected"
             >
               <v-col cols="auto">
-                <share-graph-link-dialog :link-generator="getShareLink" />
+                <share-graph-link-dialog
+                  :link-generator="getShareLink"
+                  data-restriction-label="Include repos and branches"
+                />
               </v-col>
             </comparison-graph-settings>
           </v-col>

--- a/frontend/src/views/RepoComparison.vue
+++ b/frontend/src/views/RepoComparison.vue
@@ -262,9 +262,16 @@ export default class RepoComparison extends Vue {
   }
 
   // noinspection JSUnusedLocalSymbols
-  private mounted() {
+  private async mounted() {
     this.onResized()
     window.addEventListener('resize', this.onResized)
+
+    // They will be fetched on page load anyways, but we *need* to make sure they are already loaded!
+    // Otherwise we might not find our selected dimension
+    if (vxm.repoModule.allRepos.length === 0) {
+      await vxm.repoModule.fetchRepos()
+    }
+    await vxm.comparisonGraphModule.adjustToPermanentLink(this.$route)
   }
 
   // noinspection JSUnusedLocalSymbols

--- a/frontend/src/views/RepoDetailFrame.vue
+++ b/frontend/src/views/RepoDetailFrame.vue
@@ -23,14 +23,11 @@
           </repo-add>
         </v-col>
       </v-row>
-      <v-row no-gutters>
+      <v-row no-gutters v-if="repo">
         <v-col cols="12">
           <v-tabs-items v-model="selectedTab">
             <v-tab-item class="pa-1">
-              <repo-base-information
-                v-if="repo"
-                :repo="repo"
-              ></repo-base-information>
+              <repo-base-information :repo="repo"></repo-base-information>
             </v-tab-item>
             <v-tab-item class="pa-1">
               <repo-graph-view></repo-graph-view>
@@ -112,7 +109,7 @@ export default class RepoDetailFrame extends Vue {
   }
 
   get repoSelected(): boolean {
-    return this.selectedRepo !== null
+    return this.selectedRepo !== null && this.repo !== undefined
   }
 
   mounted(): void {

--- a/frontend/src/views/RunCommitDetailView.vue
+++ b/frontend/src/views/RunCommitDetailView.vue
@@ -22,7 +22,10 @@
     </v-row>
     <v-row v-if="tarSource" justify="center">
       <v-col cols="auto">
-        <tar-overview :tar-source="tarSource"></tar-overview>
+        <tar-overview
+          :tar-source="tarSource"
+          :run-id="runWithDifferences.run.id"
+        ></tar-overview>
       </v-col>
     </v-row>
     <v-row v-if="runWithDifferences">

--- a/frontend/src/views/Search.vue
+++ b/frontend/src/views/Search.vue
@@ -106,8 +106,10 @@ import Component from 'vue-class-component'
 import SearchResultList from '@/components/search/SearchResultList.vue'
 import { vxm } from '@/store'
 import {
+  RepoBranch,
   RepoId,
   SearchItem,
+  SearchItemBranch,
   SearchItemCommit,
   SearchItemRun
 } from '@/store/types'
@@ -116,6 +118,9 @@ import { debounce } from '@/util/Debouncer'
 import { mdiSwapHorizontalBold } from '@mdi/js'
 import { RawLocation } from 'vue-router'
 import RepoSelectionComponent from '@/components/RepoSelectionComponent.vue'
+import { Flavor } from '@/util/FlavorTypes'
+
+type CommitIdentifier = Flavor<string, 'repo_identifier'>
 
 @Component({
   components: { RepoSelectionComponent, SearchResultList }
@@ -128,6 +133,7 @@ export default class Search extends Vue {
   private compareSecond: SearchItem | null = null
   private repoId: RepoId | null = null
   private constrainToRepo = false
+  private branchItems: Map<CommitIdentifier, SearchItemBranch> = new Map()
 
   @Watch('searchQuery')
   private onQueryChange() {
@@ -184,6 +190,9 @@ export default class Search extends Vue {
     if (item instanceof SearchItemCommit) {
       return item.summary
     }
+    if (item instanceof SearchItemBranch) {
+      return item.name
+    }
     return item.tarDescription || item.commitSummary || item.id
   }
 
@@ -214,15 +223,64 @@ export default class Search extends Vue {
     }
   }
 
+  private findBranchItems(): SearchItemBranch[] {
+    if (this.searchQuery.length === 0) {
+      return []
+    }
+
+    const branchMatchesQuery = (branch: RepoBranch) =>
+      branch.name
+        .toLocaleLowerCase()
+        .includes(this.searchQuery.toLocaleLowerCase())
+
+    return this.allRepos
+      .filter(it => !this.constrainToRepo || it.id === this.repoId)
+      .flatMap(repo => {
+        return repo.branches.filter(branchMatchesQuery).map(branch => {
+          const key = branch.lastCommit + repo.id
+          if (this.branchItems.has(key)) {
+            return this.branchItems.get(key)!
+          }
+          const item = new SearchItemBranch(
+            repo.id,
+            branch.name,
+            branch.lastCommit,
+            undefined,
+            undefined
+          )
+          this.branchItems.set(key, item)
+          this.fetchBranchInformation(item)
+
+          return item
+        })
+      })
+  }
+
+  private async fetchBranchInformation(branchItem: SearchItemBranch) {
+    const commit = await vxm.commitDetailComparisonModule.fetchCommit({
+      commitHash: branchItem.hash,
+      repoId: branchItem.repoId
+    })
+    branchItem.commitSummary = commit.summary
+    if (commit.runs.length > 0) {
+      branchItem.runId = commit.runs[0].runId
+    }
+  }
+
+  private setItems(items: SearchItem[]) {
+    this.items = (this.findBranchItems() as SearchItem[]).concat(items)
+  }
+
   private async executeSearch() {
     if (this.searchQuery.length === 0) {
-      this.items = []
+      this.setItems([])
       return
     }
-    this.items = await vxm.runSearchModule.searchRun({
+    const items = await vxm.runSearchModule.searchRun({
       query: this.searchQuery,
       repoId: this.constrainToRepo ? this.repoId || undefined : undefined
     })
+    this.setItems(items)
   }
 
   private mounted() {

--- a/frontend/src/views/ShareGraphLinkDialog.vue
+++ b/frontend/src/views/ShareGraphLinkDialog.vue
@@ -91,6 +91,9 @@ export default class ShareGraphLinkDialog extends Vue {
   @Prop()
   private linkGenerator!: (options: PermanentLinkOptions) => string
 
+  @Prop()
+  private dataRestrictionLabel!: string
+
   private get selectableOptions() {
     return [
       {
@@ -108,10 +111,10 @@ export default class ShareGraphLinkDialog extends Vue {
         key: 'includeYZoom'
       },
       {
-        label: 'Include dimensions',
+        label: this.dataRestrictionLabel,
         selectable: vxm.detailGraphModule.selectedDimensions.length > 0,
         unselectableMessage: "You haven't selected any dimensions",
-        key: 'includeDimensions'
+        key: 'includeDataRestrictions'
       }
     ]
   }

--- a/frontend/src/views/ShareGraphLinkDialog.vue
+++ b/frontend/src/views/ShareGraphLinkDialog.vue
@@ -77,7 +77,6 @@ import { mdiLinkVariantPlus } from '@mdi/js'
 import { copyToClipboard } from '@/util/ClipboardUtils'
 import { PermanentLinkOptions } from '@/store/modules/detailGraphStore'
 import { Prop, Watch } from 'vue-property-decorator'
-import { RawLocation } from 'vue-router'
 
 @Component
 export default class ShareGraphLinkDialog extends Vue {
@@ -86,11 +85,11 @@ export default class ShareGraphLinkDialog extends Vue {
   private options: PermanentLinkOptions = {
     includeYZoom: true,
     includeXZoom: true,
-    includeDimensions: true
+    includeDataRestrictions: true
   }
 
   @Prop()
-  private linkGenerator!: (options: PermanentLinkOptions) => RawLocation
+  private linkGenerator!: (options: PermanentLinkOptions) => string
 
   private get selectableOptions() {
     return [
@@ -129,7 +128,7 @@ export default class ShareGraphLinkDialog extends Vue {
   private onDialogVisibilityChange() {
     if (this.dialogOpen) {
       this.options = {
-        includeDimensions: true,
+        includeDataRestrictions: true,
         includeXZoom: true,
         includeYZoom: true
       }

--- a/frontend/src/views/ShareGraphLinkDialog.vue
+++ b/frontend/src/views/ShareGraphLinkDialog.vue
@@ -76,7 +76,8 @@ import { vxm } from '@/store'
 import { mdiLinkVariantPlus } from '@mdi/js'
 import { copyToClipboard } from '@/util/ClipboardUtils'
 import { PermanentLinkOptions } from '@/store/modules/detailGraphStore'
-import { Watch } from 'vue-property-decorator'
+import { Prop, Watch } from 'vue-property-decorator'
+import { RawLocation } from 'vue-router'
 
 @Component
 export default class ShareGraphLinkDialog extends Vue {
@@ -87,6 +88,9 @@ export default class ShareGraphLinkDialog extends Vue {
     includeXZoom: true,
     includeDimensions: true
   }
+
+  @Prop()
+  private linkGenerator!: (options: PermanentLinkOptions) => RawLocation
 
   private get selectableOptions() {
     return [
@@ -114,7 +118,7 @@ export default class ShareGraphLinkDialog extends Vue {
   }
 
   private get permanentLinkUrl() {
-    return vxm.detailGraphModule.permanentLink(this.options)
+    return this.linkGenerator(this.options)
   }
 
   private copyPermanentLink() {


### PR DESCRIPTION
### About this PR
In the past weeks quite a few frontend changes have accumulated on this poor branch and it is quite clearly overripe.

### Contents
- Fix a few edge cases with repo deletion invalidating the local storage state
- Show a proper 404 page if you navigate to a repo detail page where the correspondig repo doesn't exist
- Remove "View on git{hub, lab}" buttons if we can't parse a proper remote URL for a commit (e.g. for `file://` repos)
- Remove some unneeded padding here and there
- Remove the repo token from the add and update dialogs
- Change the home page to an infinite lazy list (Closes #247)
- Show the percentual difference in the run comparison (Closes #255)
- Add a compare button to TAR detail pages (Closes #254)
- Add a way to search for branches in Voogle
- Permanent links for the comparison graph