### PR TITLE
Fix frontend persistence in minified production builds

### DIFF
--- a/frontend/src/store/persistence.ts
+++ b/frontend/src/store/persistence.ts
@@ -34,9 +34,15 @@ export const persistenceLocalStorage = new VuexPersistence<Partial<RootState>>({
       colorModule: ColorStore.toPlainObject(state.colorModule),
       repoModule: RepoStore.toPlainObject(state.repoModule)
     }
-    storage!.setItem(key, toJson(persistable))
 
-    storage!.setItem(STORAGE_VERSION_KEY, STORAGE_VERSION_CURRENT)
+    try {
+      storage!.setItem(key, toJson(persistable))
+      storage!.setItem(STORAGE_VERSION_KEY, STORAGE_VERSION_CURRENT)
+    } catch (e) {
+      console.warn('Unable to save session data', e)
+      // Ignore the store on error. This is nicer than displaying a white
+      // page and rendering VelCom unusable.
+    }
   },
   restoreState: (key, storage) => {
     const data = storage!.getItem(key)
@@ -45,7 +51,14 @@ export const persistenceLocalStorage = new VuexPersistence<Partial<RootState>>({
       return {}
     }
 
-    return fromJson(data)
+    try {
+      return fromJson(data)
+    } catch (e) {
+      console.warn('Unable to restore local data', e)
+      // Discard local state on error. This is nicer than displaying a white
+      // page and rendering VelCom unusable.
+      return {}
+    }
   }
 })
 
@@ -65,8 +78,14 @@ export const persistenceSessionStorage = new VuexPersistence<
       )
     }
 
-    storage!.setItem(key, toJson(persistable))
-    storage!.setItem(STORAGE_VERSION_KEY, STORAGE_VERSION_CURRENT)
+    try {
+      storage!.setItem(key, toJson(persistable))
+      storage!.setItem(STORAGE_VERSION_KEY, STORAGE_VERSION_CURRENT)
+    } catch (e) {
+      console.warn('Unable to save session data', e)
+      // Ignore the store on error. This is nicer than displaying a white
+      // page and rendering VelCom unusable.
+    }
   },
   restoreState: (key, storage) => {
     const data = storage!.getItem(key)
@@ -74,7 +93,14 @@ export const persistenceSessionStorage = new VuexPersistence<
       return {}
     }
 
-    return fromJson(data)
+    try {
+      return fromJson(data)
+    } catch (e) {
+      console.warn('Unable to restore session data', e)
+      // Discard local state on error. This is nicer than displaying a white
+      // page and rendering VelCom unusable.
+      return {}
+    }
   }
 })
 

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -1,6 +1,8 @@
 import { Flavor } from '@/util/FlavorTypes'
 
 export class RepoBranch {
+  static readonly SERIALIZED_NAME = 'RepoBranch'
+
   readonly name: string
   readonly tracked: boolean
   readonly lastCommit: CommitHash
@@ -14,6 +16,8 @@ export class RepoBranch {
 
 export type RepoId = Flavor<string, 'repo_id'>
 export class Repo {
+  static readonly SERIALIZED_NAME = 'Repo'
+
   readonly id: RepoId
   name: string
   branches: RepoBranch[]
@@ -62,6 +66,8 @@ export function dimensionIdToString(dimensionId: DimensionId): string {
 }
 
 export class Dimension {
+  static readonly SERIALIZED_NAME = 'Dimension'
+
   readonly benchmark: string
   readonly metric: string
   readonly unit: string
@@ -508,6 +514,8 @@ export type AttributedDatapoint = {
 }
 
 export class DetailDataPoint extends GraphDataPoint {
+  static readonly SERIALIZED_NAME = 'DetailDataPoint'
+
   readonly hash: CommitHash
   readonly repoId: RepoId
   readonly uid: string
@@ -557,6 +565,8 @@ export class DetailDataPoint extends GraphDataPoint {
 }
 
 export class ComparisonDataPoint extends GraphDataPoint {
+  static readonly SERIALIZED_NAME = 'ComparisonDataPoint'
+
   readonly positionTime: Date
   readonly committerTime: Date
   readonly hash: string

--- a/frontend/src/util/Serialisation.ts
+++ b/frontend/src/util/Serialisation.ts
@@ -8,7 +8,7 @@ import {
 
 const mappers: { [key: string]: any } = {
   Map: (entries: any[]) => new Map(entries),
-  DetailDataPoint: (rawPoint: DetailDataPoint) =>
+  [DetailDataPoint.SERIALIZED_NAME]: (rawPoint: DetailDataPoint) =>
     new DetailDataPoint(
       rawPoint.repoId,
       rawPoint.hash,
@@ -19,7 +19,7 @@ const mappers: { [key: string]: any } = {
       rawPoint.summary,
       rawPoint.values
     ),
-  ComparisonDataPoint: (rawPoint: ComparisonDataPoint) =>
+  [ComparisonDataPoint.SERIALIZED_NAME]: (rawPoint: ComparisonDataPoint) =>
     new ComparisonDataPoint(
       rawPoint.committerTime,
       rawPoint.positionTime,
@@ -30,16 +30,16 @@ const mappers: { [key: string]: any } = {
       rawPoint.summary,
       rawPoint.author
     ),
-  Dimension: (rawDimension: Dimension) =>
+  [Dimension.SERIALIZED_NAME]: (rawDimension: Dimension) =>
     new Dimension(
       rawDimension.benchmark,
       rawDimension.metric,
       rawDimension.unit,
       rawDimension.interpretation
     ),
-  RepoBranch: (rawBranch: RepoBranch) =>
+  [RepoBranch.SERIALIZED_NAME]: (rawBranch: RepoBranch) =>
     new RepoBranch(rawBranch.name, rawBranch.tracked, rawBranch.lastCommit),
-  Repo: (rawRepo: Repo) =>
+  [Repo.SERIALIZED_NAME]: (rawRepo: Repo) =>
     new Repo(
       rawRepo.id,
       rawRepo.name,
@@ -93,12 +93,19 @@ export function toJson(object: unknown): string {
       return value
     }
 
-    if (value.constructor === Object) {
+    const constructor = value.constructor
+    if (constructor === Object) {
       return value
     }
 
+    if (!Object.prototype.hasOwnProperty.call(constructor, 'SERIALIZED_NAME')) {
+      throw new Error(
+        'Constructor has no SERIALIZED_NAME property: ' + value.constructor.name
+      )
+    }
+
     return {
-      __datatype: value.constructor.name,
+      __datatype: constructor.SERIALIZED_NAME,
       val: Object.assign({}, value)
     }
   })


### PR DESCRIPTION
The previous implementation relied on `constructor.name`, which is mangled by terser in production builds, completely breaking
deserialization.

Just using the minified names is also broken, as they might conflict.
This leaves us with two main options:
- Disable minification
- Somehow store the name in a way terser won't touch

This PR implements option two: The serialized name is explicitly stored in a static class property.