### PR TITLE
GitHub Bot

### DIFF
--- a/backend/backend/pom.xml
+++ b/backend/backend/pom.xml
@@ -261,7 +261,6 @@
       <scope>provided</scope>
     </dependency>
 
-
     <!--NEEDED FOR DROPWIZARD (NO LONGER INCLUDED IN THE JDK)-->
     <dependency>
       <artifactId>jakarta.xml.bind-api</artifactId>

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/GlobalConfig.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/GlobalConfig.java
@@ -22,6 +22,8 @@ public class GlobalConfig extends Configuration {
 	private String webAdminToken;
 	@NotEmpty
 	private String benchmarkRepoRemoteUrl;
+	@NotEmpty
+	private String frontendUrl;
 	private long pollInterval = 10 * 60;
 	private long vacuumInterval = 25 * 60 * 60;
 
@@ -90,6 +92,21 @@ public class GlobalConfig extends Configuration {
 
 	public void setBenchmarkRepoRemoteUrl(String benchmarkRepoRemoteUrl) {
 		this.benchmarkRepoRemoteUrl = benchmarkRepoRemoteUrl;
+	}
+
+	/**
+	 * @return the base url the frontend can be reached under, including a trailing slash
+	 */
+	public String getFrontendUrl() {
+		if (frontendUrl.endsWith("/")) {
+			return frontendUrl;
+		} else {
+			return frontendUrl + "/";
+		}
+	}
+
+	public void setFrontendUrl(String frontendUrl) {
+		this.frontendUrl = frontendUrl;
 	}
 
 	/**

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/RunnerAwareServerFactory.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/RunnerAwareServerFactory.java
@@ -67,7 +67,7 @@ public class RunnerAwareServerFactory implements ServerFactory {
 
 		server.setHandler(new RoutingHandler(handlerMap));
 
-		LOGGER.info("Registered the websocket servlet");
+		LOGGER.debug("Registered the websocket servlet");
 
 		return server;
 	}

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/ServerMain.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/ServerMain.java
@@ -163,8 +163,17 @@ public class ServerMain extends Application<GlobalConfig> {
 			runComparator);
 
 		// Listener
-		Listener listener = new Listener(databaseStorage, repoStorage, repoAccess, benchRepo, queue,
-			configuration.getPollInterval(), configuration.getVacuumInterval());
+		Listener listener = new Listener(
+			databaseStorage,
+			repoStorage,
+			commitAccess,
+			repoAccess,
+			benchRepo,
+			queue,
+			configuration.getPollInterval(),
+			configuration.getVacuumInterval(),
+			configuration.getFrontendUrl()
+		);
 
 		// Dispatcher
 		Dispatcher dispatcher = new Dispatcher(

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/repoaccess/entities/Repo.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/repoaccess/entities/Repo.java
@@ -1,7 +1,12 @@
 package de.aaaaaaah.velcom.backend.access.repoaccess.entities;
 
+import java.time.Instant;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 
 /**
  * The information velcom knows about a repository it tracks.
@@ -11,11 +16,24 @@ public class Repo {
 	private final RepoId id;
 	private final String name;
 	private final RemoteUrl remoteUrl;
+	@Nullable
+	private final String githubAccessToken;
+	@Nullable
+	private final Instant githubCommentCutoff;
 
-	public Repo(RepoId id, String name, RemoteUrl remoteUrl) {
+	public Repo(RepoId id, String name, RemoteUrl remoteUrl, @Nullable String githubAccessToken,
+		@Nullable Instant githubCommentCutoff) {
+
+		if ((githubAccessToken == null) != (githubCommentCutoff == null)) {
+			throw new IllegalArgumentException(
+				"githubAccessToken and githubCommentCutoff must either both be present or both be null");
+		}
+
 		this.id = id;
 		this.name = name;
 		this.remoteUrl = remoteUrl;
+		this.githubAccessToken = githubAccessToken;
+		this.githubCommentCutoff = githubCommentCutoff;
 	}
 
 	public RepoId getId() {
@@ -42,6 +60,26 @@ public class Repo {
 		return remoteUrl.getUrl();
 	}
 
+	public Optional<String> getGithubRepoName() {
+		String remoteUrl = getRemoteUrlAsString();
+		Pattern pattern = Pattern.compile("github.com[:/]([^/]+/[^/.]+)(\\.git)?");
+		Matcher matcher = pattern.matcher(remoteUrl);
+		if (matcher.find()) {
+			return Optional.of(matcher.group(1));
+		} else {
+			return Optional.empty();
+		}
+	}
+
+	public Optional<GithubInfo> getGithubInfo() {
+		Optional<String> repoName = getGithubRepoName();
+		if (repoName.isPresent() && githubAccessToken != null && githubCommentCutoff != null) {
+			return Optional.of(new GithubInfo(repoName.get(), githubAccessToken, githubCommentCutoff));
+		} else {
+			return Optional.empty();
+		}
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
@@ -65,6 +103,59 @@ public class Repo {
 			"id=" + id.getIdAsString() +
 			", name='" + name + '\'' +
 			", remoteUrl='" + remoteUrl.getUrl() + '\'' +
+			", githubCommentCutoff=" + githubCommentCutoff +
 			'}';
+	}
+
+	public static class GithubInfo {
+
+		private final String repoName;
+		private final String accessToken;
+		private final Instant commentCutoff;
+
+		public GithubInfo(String repoName, String accessToken, Instant commentCutoff) {
+			this.repoName = repoName;
+			this.accessToken = accessToken;
+			this.commentCutoff = commentCutoff;
+		}
+
+		public String getRepoName() {
+			return repoName;
+		}
+
+		public String getAccessToken() {
+			return accessToken;
+		}
+
+		public Instant getCommentCutoff() {
+			return commentCutoff;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			GithubInfo that = (GithubInfo) o;
+			return Objects.equals(repoName, that.repoName) && Objects
+				.equals(accessToken, that.accessToken) && Objects
+				.equals(commentCutoff, that.commentCutoff);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(repoName, accessToken, commentCutoff);
+		}
+
+		@Override
+		public String toString() {
+			return "GithubInfo{" +
+				"repoName='" + repoName + '\'' +
+				", commentCutoff=" + commentCutoff +
+				'}';
+		}
 	}
 }

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/taskaccess/entities/TaskPriority.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/taskaccess/entities/TaskPriority.java
@@ -10,9 +10,10 @@ public enum TaskPriority {
 	 */
 	MANUAL(0),
 	/**
-	 * The task represents an uploaded tar file.
+	 * The task has been created by a user (e. g. from an uploaded tar file or a GitHub command), but
+	 * should not have priority over manually prioritized tasks.
 	 */
-	TAR(1),
+	USER_CREATED(1),
 	/**
 	 * The task represents a commit that has been automatically added to the queue by the listener.
 	 */
@@ -35,7 +36,7 @@ public enum TaskPriority {
 		if (priority <= 0) {
 			return MANUAL;
 		} else if (priority == 1) {
-			return TAR;
+			return USER_CREATED;
 		} else {
 			return LISTENER;
 		}

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/queue/Policy.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/data/queue/Policy.java
@@ -45,7 +45,7 @@ class Policy {
 
 		// Tar tasks need to be reversed since they need a FIFO order, not FILO
 		ArrayList<Task> tarTasksTmp = tasksInOrder.stream()
-			.filter(task -> task.getPriority().equals(TaskPriority.TAR))
+			.filter(task -> task.getPriority().equals(TaskPriority.USER_CREATED))
 			.collect(toCollection(ArrayList::new));
 		Collections.reverse(tarTasksTmp);
 		tarTasks = new ArrayDeque<>(tarTasksTmp);

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/SynchronizeCommitsException.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/SynchronizeCommitsException.java
@@ -1,0 +1,7 @@
+package de.aaaaaaah.velcom.backend.listener;
+
+public class SynchronizeCommitsException extends Exception {
+
+	public SynchronizeCommitsException() {
+	}
+}

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/commits/DbUpdateException.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/commits/DbUpdateException.java
@@ -1,4 +1,4 @@
-package de.aaaaaaah.velcom.backend.listener.dbupdate;
+package de.aaaaaaah.velcom.backend.listener.commits;
 
 /**
  * An exception thrown when the {@link DbUpdater} failed to update the database for a repo.

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/commits/DbUpdater.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/commits/DbUpdater.java
@@ -1,4 +1,4 @@
-package de.aaaaaaah.velcom.backend.listener.dbupdate;
+package de.aaaaaaah.velcom.backend.listener.commits;
 
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/github/FinishedGithubCommand.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/github/FinishedGithubCommand.java
@@ -1,0 +1,38 @@
+package de.aaaaaaah.velcom.backend.listener.github;
+
+import de.aaaaaaah.velcom.backend.access.benchmarkaccess.entities.RunId;
+import de.aaaaaaah.velcom.backend.access.committaccess.entities.CommitHash;
+import de.aaaaaaah.velcom.backend.access.repoaccess.entities.BranchName;
+
+public class FinishedGithubCommand {
+
+	private final long pr;
+	private final BranchName targetBranch;
+	private final CommitHash commitHash;
+	private final RunId runId;
+
+	public FinishedGithubCommand(long pr, BranchName targetBranch, CommitHash commitHash,
+		RunId runId) {
+
+		this.pr = pr;
+		this.targetBranch = targetBranch;
+		this.commitHash = commitHash;
+		this.runId = runId;
+	}
+
+	public long getPr() {
+		return pr;
+	}
+
+	public BranchName getTargetBranch() {
+		return targetBranch;
+	}
+
+	public CommitHash getCommitHash() {
+		return commitHash;
+	}
+
+	public RunId getRunId() {
+		return runId;
+	}
+}

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/github/GithubCommand.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/github/GithubCommand.java
@@ -1,0 +1,96 @@
+package de.aaaaaaah.velcom.backend.listener.github;
+
+import de.aaaaaaah.velcom.backend.access.committaccess.entities.CommitHash;
+import de.aaaaaaah.velcom.backend.access.repoaccess.entities.BranchName;
+import de.aaaaaaah.velcom.backend.access.repoaccess.entities.RepoId;
+import java.util.Objects;
+
+public class GithubCommand {
+
+	private static final int TRIES = 5;
+
+	private final RepoId repoId;
+	private final long pr;
+	private final BranchName targetBranch;
+	private final long comment;
+	private final CommitHash commitHash;
+	private final GithubCommandState state;
+	private final int triesLeft;
+
+	public GithubCommand(RepoId repoId, long pr, BranchName targetBranch, long comment,
+		CommitHash commitHash, GithubCommandState state, int triesLeft) {
+
+		this.repoId = repoId;
+		this.pr = pr;
+		this.targetBranch = targetBranch;
+		this.comment = comment;
+		this.commitHash = commitHash;
+		this.state = state;
+		this.triesLeft = triesLeft;
+	}
+
+	public GithubCommand(RepoId repoId, long pr, BranchName targetBranch, long comment,
+		CommitHash commitHash) {
+
+		this(repoId, pr, targetBranch, comment, commitHash, GithubCommandState.NEW, TRIES);
+	}
+
+	public RepoId getRepoId() {
+		return repoId;
+	}
+
+	public long getPr() {
+		return pr;
+	}
+
+	public BranchName getTargetBranch() {
+		return targetBranch;
+	}
+
+	public long getComment() {
+		return comment;
+	}
+
+	public CommitHash getCommitHash() {
+		return commitHash;
+	}
+
+	public GithubCommandState getState() {
+		return state;
+	}
+
+	public int getTriesLeft() {
+		return triesLeft;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		GithubCommand that = (GithubCommand) o;
+		return pr == that.pr && comment == that.comment && triesLeft == that.triesLeft
+			&& Objects.equals(repoId, that.repoId) && Objects
+			.equals(commitHash, that.commitHash) && state == that.state;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(repoId, pr, comment, commitHash, state, triesLeft);
+	}
+
+	@Override
+	public String toString() {
+		return "GithubCommand{" +
+			"repoId=" + repoId +
+			", pr=" + pr +
+			", comment=" + comment +
+			", commitHash=" + commitHash +
+			", state=" + state +
+			", triesLeft=" + triesLeft +
+			'}';
+	}
+}

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/github/GithubCommandState.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/github/GithubCommandState.java
@@ -1,0 +1,32 @@
+package de.aaaaaaah.velcom.backend.listener.github;
+
+import java.util.List;
+
+public enum GithubCommandState {
+	NEW("NEW"),
+	MARKED_SEEN("MARKED_SEEN"),
+	QUEUED("QUEUED"),
+	ERROR("ERROR");
+
+	private final String textualRepresentation;
+
+	GithubCommandState(String textualRepresentation) {
+		this.textualRepresentation = textualRepresentation;
+	}
+
+	public static GithubCommandState fromTextualRepresentation(String representation)
+		throws IllegalArgumentException {
+
+		for (GithubCommandState state : List.of(NEW, MARKED_SEEN, QUEUED, ERROR)) {
+			if (state.getTextualRepresentation().equals(representation)) {
+				return state;
+			}
+		}
+
+		throw new IllegalArgumentException("\"" + representation + "\" is not a valid command state");
+	}
+
+	public String getTextualRepresentation() {
+		return textualRepresentation;
+	}
+}

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/github/GithubPrInteractor.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/github/GithubPrInteractor.java
@@ -1,0 +1,537 @@
+package de.aaaaaaah.velcom.backend.listener.github;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+import static org.jooq.codegen.db.tables.GithubCommand.GITHUB_COMMAND;
+import static org.jooq.codegen.db.tables.Repo.REPO;
+import static org.jooq.codegen.db.tables.Run.RUN;
+import static org.jooq.codegen.db.tables.Task.TASK;
+import static org.jooq.impl.DSL.select;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import de.aaaaaaah.velcom.backend.access.benchmarkaccess.entities.RunId;
+import de.aaaaaaah.velcom.backend.access.committaccess.CommitReadAccess;
+import de.aaaaaaah.velcom.backend.access.committaccess.entities.CommitHash;
+import de.aaaaaaah.velcom.backend.access.repoaccess.entities.BranchName;
+import de.aaaaaaah.velcom.backend.access.repoaccess.entities.Repo;
+import de.aaaaaaah.velcom.backend.access.repoaccess.entities.Repo.GithubInfo;
+import de.aaaaaaah.velcom.backend.access.repoaccess.entities.RepoId;
+import de.aaaaaaah.velcom.backend.access.taskaccess.entities.TaskPriority;
+import de.aaaaaaah.velcom.backend.data.queue.Queue;
+import de.aaaaaaah.velcom.backend.storage.db.DBWriteAccess;
+import de.aaaaaaah.velcom.backend.storage.db.DatabaseStorage;
+import de.aaaaaaah.velcom.shared.util.Pair;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.UriBuilder;
+import org.jooq.codegen.db.tables.records.GithubCommandRecord;
+import org.jooq.codegen.db.tables.records.RepoRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Interact with the GitHub API to find new !bench commands and respond to existing ones.
+ */
+public class GithubPrInteractor {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(GithubPrInteractor.class);
+
+	private final Repo repo;
+	private final GithubInfo ghInfo;
+	private final DatabaseStorage databaseStorage;
+	private final CommitReadAccess commitAccess;
+	private final Queue queue;
+
+	private final String frontendUrl;
+
+	private final HttpClient client;
+	private final JsonBodyHandler jsonBodyHandler;
+	private final String basicAuthHeader;
+
+	private GithubPrInteractor(Repo repo, GithubInfo ghInfo, DatabaseStorage databaseStorage,
+		CommitReadAccess commitAccess, Queue queue, String frontendUrl) {
+
+		this.repo = repo;
+		this.ghInfo = ghInfo;
+		this.databaseStorage = databaseStorage;
+		this.commitAccess = commitAccess;
+		this.queue = queue;
+
+		this.frontendUrl = frontendUrl;
+
+		client = HttpClient.newHttpClient();
+		jsonBodyHandler = new JsonBodyHandler();
+
+		String authInfo = ":" + ghInfo.getAccessToken();
+		byte[] authInfoBytes = authInfo.getBytes(StandardCharsets.UTF_8);
+		String authInfoBase64 = Base64.getEncoder().encodeToString(authInfoBytes);
+		basicAuthHeader = "Basic " + authInfoBase64;
+	}
+
+	public static Optional<GithubPrInteractor> fromRepo(Repo repo, DatabaseStorage databaseStorage,
+		CommitReadAccess commitAccess, Queue queue, String frontendUrl) {
+
+		Optional<GithubInfo> ghInfoOpt = repo.getGithubInfo();
+		return ghInfoOpt.map(githubInfo -> new GithubPrInteractor(
+			repo,
+			githubInfo,
+			databaseStorage,
+			commitAccess,
+			queue,
+			frontendUrl
+		));
+	}
+
+	private static GithubCommand commandRecordToCommand(GithubCommandRecord record) {
+		return new GithubCommand(
+			RepoId.fromString(record.getRepoId()),
+			record.getPr(),
+			BranchName.fromName(record.getTargetBranch()),
+			record.getComment(),
+			new CommitHash(record.getCommitHash()),
+			GithubCommandState.fromTextualRepresentation(record.getState()),
+			record.getTriesLeft()
+		);
+	}
+
+	private JsonNode getResourceFromUrl(String issueUrl)
+		throws URISyntaxException, IOException, InterruptedException {
+
+		HttpRequest request = HttpRequest.newBuilder(new URI(issueUrl))
+			.header(HttpHeaders.AUTHORIZATION, basicAuthHeader)
+			.header(HttpHeaders.ACCEPT, "application/vnd.github.v3+json")
+			.build();
+		HttpResponse<JsonNode> response = client.send(request, jsonBodyHandler);
+		return response.body();
+	}
+
+	private JsonNode getCommentPage(int page) throws IOException, InterruptedException {
+		URI uri = UriBuilder.fromUri("https://api.github.com/")
+			.path("repos")
+			.path(ghInfo.getRepoName())
+			.path("issues/comments")
+			.queryParam("since", ghInfo.getCommentCutoff().toString())
+			.queryParam("sort", "created")
+			// The direction is important! If we used "asc" instead, we might lose older comments if
+			// comments are updated in-between fetching different pages. With "desc", we instead see some
+			// comments multiple times in the same scenario (and we'll be able to get the comments we
+			// missed on the next run).
+			.queryParam("direction", "desc")
+			.queryParam("page", page)
+			.build();
+		HttpRequest request = HttpRequest.newBuilder(uri)
+			.header(HttpHeaders.AUTHORIZATION, basicAuthHeader)
+			.header(HttpHeaders.ACCEPT, "application/vnd.github.v3+json")
+			.build();
+		HttpResponse<JsonNode> response = client.send(request, jsonBodyHandler);
+		return response.body();
+	}
+
+	private Optional<Instant> findNewCommandCandidates(
+		List<Pair<GithubCommand, String>> commandCandidates)
+		throws IOException, InterruptedException, URISyntaxException {
+
+		Set<Long> seen = new HashSet<>();
+		Instant commentCutoff = ghInfo.getCommentCutoff();
+		Optional<Instant> newCommentCutoff = Optional.empty();
+
+		for (int page = 1; true; page++) {
+			LOGGER.debug("Looking at comment page {}", page);
+			JsonNode comments = getCommentPage(page);
+			if (comments.isEmpty()) {
+				LOGGER.debug("Page {} is empty", page);
+				break; // We've hit the last page
+			}
+
+			for (JsonNode comment : comments) {
+				Instant createdAt = Instant.parse(comment.get("created_at").asText());
+				if (createdAt.isBefore(commentCutoff) || createdAt.equals(commentCutoff)) {
+					// The "since" query parameter only cuts off comments that were updated before the
+					// specified cutoff. However, we don't want to look at any comments *created* before the
+					// cutoff, so we need to do a bit of extra filtering.
+					LOGGER.debug("Ignoring comment created before comment cutoff");
+					continue;
+				}
+
+				if (newCommentCutoff.isEmpty()) {
+					// We know that this comment is the first comment returned by the GitHub API. Since the
+					// comments are sorted by creation time in descending order, we know that this is the
+					// newest comment.
+					newCommentCutoff = Optional.of(createdAt);
+				}
+
+				long commentId = comment.get("id").asLong();
+				if (seen.contains(commentId)) {
+					// New comments may have appeared since we requested the previous page, leading to
+					// comments we've already seen being pushed to this (next) page.
+					LOGGER.debug("Ignoring comment we've already seen");
+					continue;
+				}
+				seen.add(commentId);
+
+				String commentBody = comment.get("body").asText();
+				if (!commentBody.strip().equals("!bench")) {
+					LOGGER.debug("Ignoring comment without command ({})", commentBody);
+					continue; // Not a command, just a normal comment
+				}
+
+				JsonNode issue = getResourceFromUrl(comment.get("issue_url").asText());
+				if (!issue.has("pull_request")) {
+					LOGGER.debug("Ignoring issue comment ({})", commentBody);
+					continue; // Not a PR, just a normal issue
+				}
+
+				JsonNode pr = getResourceFromUrl(issue.get("pull_request").get("url").asText());
+
+				long prNumber = pr.get("number").asLong();
+				BranchName targetBranch = BranchName.fromName(pr.get("base").get("ref").asText());
+				CommitHash commitHash = new CommitHash(pr.get("head").get("sha").asText());
+				GithubCommand command = new GithubCommand(repo.getId(), prNumber, targetBranch, commentId,
+					commitHash);
+				String username = comment.get("user").get("login").asText();
+				commandCandidates.add(new Pair<>(command, username));
+				LOGGER.debug("Found command for pr #{} ({}, by {})", prNumber, commentBody, username);
+			}
+		}
+
+		return newCommentCutoff;
+	}
+
+	private List<GithubCommand> keepOnlyAuthorizedCandidates(
+		List<Pair<GithubCommand, String>> commandCandidates) throws IOException, InterruptedException {
+		Set<String> usernames = commandCandidates.stream()
+			.map(Pair::getSecond)
+			.collect(toSet());
+
+		Set<String> usersWithWritePermission = new HashSet<>();
+		for (String username : usernames) {
+			LOGGER.debug("Checking if {} has write permissions", username);
+			URI url = UriBuilder.fromUri("https://api.github.com/")
+				.path("repos")
+				.path(ghInfo.getRepoName())
+				.path("collaborators")
+				.path(username)
+				.path("permission")
+				.build();
+			HttpRequest request = HttpRequest.newBuilder(url)
+				.header(HttpHeaders.AUTHORIZATION, basicAuthHeader)
+				.header(HttpHeaders.ACCEPT, "application/vnd.github.v3+json")
+				.build();
+			HttpResponse<JsonNode> response = client.send(request, jsonBodyHandler);
+			if (response.statusCode() != 200) {
+				LOGGER.debug("User {} doesn't have write permissions (not a collaborator)", username);
+				continue;
+			}
+			String permission = response.body().get("permission").asText();
+			if (permission.equals("admin") || permission.equals("write")) {
+				LOGGER.debug("User {} has write permissions ({})", username, permission);
+				usersWithWritePermission.add(username);
+			} else {
+				LOGGER.debug("User {} doesn't have write permissions ({})", username, permission);
+			}
+		}
+
+		return commandCandidates.stream()
+			.filter(pair -> usersWithWritePermission.contains(pair.getSecond()))
+			.map(Pair::getFirst)
+			.collect(toList());
+	}
+
+	public void searchForNewPrCommands()
+		throws IOException, InterruptedException, URISyntaxException {
+
+		LOGGER.debug("Searching for new PR commands");
+
+		List<Pair<GithubCommand, String>> commandCandidates = new ArrayList<>();
+		Optional<Instant> newCommentCutoff = findNewCommandCandidates(commandCandidates);
+		List<GithubCommand> commands = keepOnlyAuthorizedCandidates(commandCandidates);
+
+		if (newCommentCutoff.isEmpty() || commands.isEmpty()) {
+			// If we don't have a new cutoff, definitely haven't found any new commands either
+			return;
+		}
+		Instant newCommentCutoffValue = newCommentCutoff.get();
+
+		databaseStorage.acquireWriteTransaction(db -> {
+			RepoRecord repoRecord = db.dsl()
+				.selectFrom(REPO)
+				.where(REPO.ID.eq(repo.getIdAsString()))
+				.fetchSingle();
+			if (repoRecord.getGithubCommentCutoff() == null) {
+				return; // While we were crawling, GitHub integration has been turned off
+			}
+			repoRecord.setGithubCommentCutoff(newCommentCutoffValue);
+			db.dsl().batchUpdate(repoRecord).execute();
+
+			List<GithubCommandRecord> commandRecords = commands.stream()
+				.map(command -> new GithubCommandRecord(
+					command.getRepoId().getIdAsString(),
+					command.getPr(),
+					command.getTargetBranch().getName(),
+					command.getComment(),
+					command.getCommitHash().getHash(),
+					command.getState().getTextualRepresentation(),
+					command.getTriesLeft()
+				))
+				.collect(toList());
+			db.dsl().batchInsert(commandRecords).execute();
+		});
+	}
+
+	public void markNewPrCommandsAsSeen() throws IOException, InterruptedException {
+		LOGGER.debug("Marking new commands as seen");
+
+		List<GithubCommand> newCommands = databaseStorage.acquireReadTransaction(db -> {
+			return db.dsl()
+				.selectFrom(GITHUB_COMMAND)
+				.where(GITHUB_COMMAND.REPO_ID.eq(repo.getIdAsString()))
+				.and(GITHUB_COMMAND.STATE.eq(GithubCommandState.NEW.getTextualRepresentation()))
+				.stream()
+				.map(GithubPrInteractor::commandRecordToCommand)
+				.collect(toList());
+		});
+
+		for (GithubCommand command : newCommands) {
+			LOGGER.debug("Marking command {} in pr #{}", command.getComment(), command.getPr());
+
+			ObjectNode requestBody = new ObjectMapper().createObjectNode()
+				.put("content", "+1");
+			URI uri = UriBuilder.fromUri("https://api.github.com/")
+				.path("repos")
+				.path(ghInfo.getRepoName())
+				.path("issues/comments")
+				.path(Long.toString(command.getComment()))
+				.path("reactions")
+				.build();
+			HttpRequest request = HttpRequest.newBuilder(uri)
+				.POST(BodyPublishers.ofString(requestBody.toString()))
+				.header(HttpHeaders.AUTHORIZATION, basicAuthHeader)
+				.header(HttpHeaders.ACCEPT, "application/vnd.github.squirrel-girl-preview")
+				.build();
+			HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
+
+			if (response.statusCode() == 200 || response.statusCode() == 201) {
+				databaseStorage.acquireWriteTransaction(db -> {
+					db.dsl()
+						.update(GITHUB_COMMAND)
+						.set(GITHUB_COMMAND.STATE, GithubCommandState.MARKED_SEEN.getTextualRepresentation())
+						.where(GITHUB_COMMAND.REPO_ID.eq(repo.getIdAsString()))
+						.and(GITHUB_COMMAND.COMMENT.eq(command.getComment()))
+						.execute();
+				});
+			} else {
+				LOGGER.warn("Failed to mark: {}", response.body());
+			}
+		}
+	}
+
+	private void markCommandsAsQueued(DBWriteAccess db) {
+		String repoId = repo.getIdAsString();
+		db.dsl()
+			.update(GITHUB_COMMAND)
+			.set(GITHUB_COMMAND.STATE, GithubCommandState.QUEUED.getTextualRepresentation())
+			.where(GITHUB_COMMAND.REPO_ID.eq(repoId))
+			.and(GITHUB_COMMAND.COMMIT_HASH.in(
+				select(TASK.COMMIT_HASH)
+					.from(TASK)
+					.where(TASK.REPO_ID.eq(repoId))
+					.and(TASK.COMMIT_HASH.isNotNull())
+				).or(GITHUB_COMMAND.COMMIT_HASH.in(
+				select(RUN.COMMIT_HASH)
+					.from(RUN)
+					.where(RUN.REPO_ID.eq(repoId))
+					.and(RUN.COMMIT_HASH.isNotNull())
+				))
+			)
+			.execute();
+	}
+
+	public void addNewPrCommandsToQueue() {
+		LOGGER.debug("Adding commits for new commands to queue");
+
+		// 1. Advance all commands for which a task or run exists to QUEUED
+		List<CommitHash> toBeQueued = databaseStorage.acquireWriteTransaction(db -> {
+			markCommandsAsQueued(db);
+
+			return db.dsl()
+				.selectDistinct(GITHUB_COMMAND.COMMIT_HASH)
+				.from(GITHUB_COMMAND)
+				.where(GITHUB_COMMAND.REPO_ID.eq(repo.getIdAsString()))
+				.and(GITHUB_COMMAND.STATE.eq(GithubCommandState.MARKED_SEEN.getTextualRepresentation()))
+				.stream()
+				.map(record -> new CommitHash(record.value1()))
+				.collect(toList());
+		});
+
+		for (CommitHash commitHash : toBeQueued) {
+			LOGGER.debug("Commit {} will be queued", commitHash.getHash());
+		}
+
+		// 2. Try to queue all left-over commands
+		queue.addCommits("GitHub PR command", repo.getId(), toBeQueued, TaskPriority.USER_CREATED);
+
+		// In theory, new commands might be added between steps 1 and 2 or between steps 2 and 3. In
+		// practice however, the only way that might happen is through the listener. Since the listener
+		// ensures that only one update process is running at a time, this should never happen.
+		//
+		// Should the code ever be changed such that this is possible, the worst that could happen is
+		// that new commands' tries are decremented once. That shouldn't really matter since they'll
+		// still have some tries left over. The tries are meant to absorb various kinds of small
+		// failures, which is exactly what would happen.
+
+		databaseStorage.acquireWriteTransaction(db -> {
+			// 3. Same as 1.
+			markCommandsAsQueued(db);
+
+			// 4. Cancel all left-over commands with only 1 try left
+			db.dsl()
+				.update(GITHUB_COMMAND)
+				.set(GITHUB_COMMAND.STATE, GithubCommandState.ERROR.getTextualRepresentation())
+				.where(GITHUB_COMMAND.REPO_ID.eq(repo.getIdAsString()))
+				.and(GITHUB_COMMAND.STATE.eq(GithubCommandState.MARKED_SEEN.getTextualRepresentation()))
+				.and(GITHUB_COMMAND.TRIES_LEFT.le(1))
+				.execute();
+
+			// 5. Subtract 1 from the tries of all left-over commands
+			db.dsl()
+				.update(GITHUB_COMMAND)
+				.set(GITHUB_COMMAND.TRIES_LEFT, GITHUB_COMMAND.TRIES_LEFT.minus(1))
+				.where(GITHUB_COMMAND.REPO_ID.eq(repo.getIdAsString()))
+				.and(GITHUB_COMMAND.STATE.eq(GithubCommandState.MARKED_SEEN.getTextualRepresentation()))
+				.execute();
+		});
+	}
+
+	private HttpResponse<String> createPrComment(long pr, String body)
+		throws IOException, InterruptedException {
+
+		ObjectNode requestBody = new ObjectMapper().createObjectNode()
+			.put("body", body);
+		URI uri = UriBuilder.fromUri("https://api.github.com/")
+			.path("repos")
+			.path(ghInfo.getRepoName())
+			.path("issues")
+			.path(Long.toString(pr))
+			.path("comments")
+			.build();
+		HttpRequest request = HttpRequest.newBuilder(uri)
+			.POST(BodyPublishers.ofString(requestBody.toString()))
+			.header(HttpHeaders.AUTHORIZATION, basicAuthHeader)
+			.header(HttpHeaders.ACCEPT, "application/vnd.github.v3+json")
+			.build();
+		return client.send(request, BodyHandlers.ofString());
+	}
+
+	public void replyToFinishedPrCommands() throws IOException, InterruptedException {
+		LOGGER.debug("Replying to finished commands");
+		String repoId = repo.getIdAsString();
+
+		List<FinishedGithubCommand> replies = databaseStorage.acquireReadTransaction(db -> {
+			return db.dsl()
+				.selectDistinct(GITHUB_COMMAND.PR, GITHUB_COMMAND.TARGET_BRANCH, GITHUB_COMMAND.COMMIT_HASH,
+					RUN.ID)
+				.from(GITHUB_COMMAND)
+				.join(RUN)
+				.on(RUN.COMMIT_HASH.eq(GITHUB_COMMAND.COMMIT_HASH))
+				.where(GITHUB_COMMAND.REPO_ID.eq(repoId))
+				.and(RUN.REPO_ID.eq(repoId))
+				.stream()
+				.map(record -> new FinishedGithubCommand(
+					record.value1(),
+					BranchName.fromName(record.value2()),
+					new CommitHash(record.value3()),
+					RunId.fromString(record.value4())
+				))
+				.collect(toList());
+		});
+
+		for (FinishedGithubCommand reply : replies) {
+			LOGGER
+				.debug("Replying to PR #{} and hash {}", reply.getPr(), reply.getCommitHash().getHash());
+
+			Optional<CommitHash> compareTo = commitAccess
+				.getFirstParentOfBranch(repo.getId(), reply.getTargetBranch(), reply.getCommitHash());
+
+			final String link;
+			link = compareTo.map(
+				commitHash -> frontendUrl + "compare/" + repoId + "/to/" + reply.getRunId().getIdAsString()
+					+ "?hash1=" + commitHash.getHash())
+				.orElseGet(() -> frontendUrl + "run-detail/" + reply.getRunId().getIdAsString());
+
+			String body = "Benchmark of commit " + reply.getCommitHash().getHash() + " complete.\n\n"
+				+ link;
+
+			HttpResponse<String> response = createPrComment(reply.getPr(), body);
+
+			if (response.statusCode() >= 200 && response.statusCode() < 300) {
+				databaseStorage.acquireWriteTransaction(db -> {
+					db.dsl()
+						.deleteFrom(GITHUB_COMMAND)
+						.where(GITHUB_COMMAND.REPO_ID.eq(repoId))
+						.and(GITHUB_COMMAND.PR.eq(reply.getPr()))
+						.and(GITHUB_COMMAND.COMMIT_HASH.eq(reply.getCommitHash().getHash()))
+						.execute();
+				});
+			} else {
+				LOGGER.warn("Failed to reply: {}", response.body());
+			}
+		}
+	}
+
+	public void replyToErroredPrCommands() throws IOException, InterruptedException {
+		LOGGER.debug("Replying to errored commands");
+		String repoId = repo.getIdAsString();
+
+		List<Pair<Long, CommitHash>> replies = databaseStorage.acquireReadTransaction(db -> {
+			return db.dsl()
+				.selectDistinct(GITHUB_COMMAND.PR, GITHUB_COMMAND.COMMIT_HASH)
+				.from(GITHUB_COMMAND)
+				.where(GITHUB_COMMAND.STATE.eq(GithubCommandState.ERROR.getTextualRepresentation()))
+				.stream()
+				.map(record -> new Pair<>(
+					record.value1(),
+					new CommitHash(record.value2())
+				))
+				.collect(toList());
+		});
+
+		for (Pair<Long, CommitHash> reply : replies) {
+			LOGGER.debug("Replying to PR #{} and hash {}", reply.getFirst(), reply.getSecond().getHash());
+
+			String body = "Failed to benchmark commit "
+				+ reply.getSecond().getHash()
+				+ " after multiple tries.";
+			HttpResponse<String> response = createPrComment(reply.getFirst(), body);
+
+			if (response.statusCode() >= 200 && response.statusCode() < 300) {
+				databaseStorage.acquireWriteTransaction(db -> {
+					db.dsl()
+						.deleteFrom(GITHUB_COMMAND)
+						.where(GITHUB_COMMAND.REPO_ID.eq(repoId))
+						.and(GITHUB_COMMAND.PR.eq(reply.getFirst()))
+						.and(GITHUB_COMMAND.COMMIT_HASH.eq(reply.getSecond().getHash()))
+						.execute();
+				});
+			} else {
+				LOGGER.warn("Failed to reply: {}", response.body());
+			}
+		}
+	}
+}

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/github/JsonBodyHandler.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/github/JsonBodyHandler.java
@@ -1,0 +1,28 @@
+package de.aaaaaaah.velcom.backend.listener.github;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.dropwizard.jackson.Jackson;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+import java.net.http.HttpResponse.BodySubscriber;
+import java.net.http.HttpResponse.ResponseInfo;
+import java.nio.charset.StandardCharsets;
+
+public class JsonBodyHandler implements BodyHandler<JsonNode> {
+
+	@Override
+	public BodySubscriber<JsonNode> apply(ResponseInfo responseInfo) {
+		return HttpResponse.BodySubscribers.mapping(
+			HttpResponse.BodySubscribers.ofString(StandardCharsets.UTF_8),
+			s -> {
+				try {
+					return Jackson.newObjectMapper().readTree(s);
+				} catch (IOException e) {
+					throw new UncheckedIOException(e);
+				}
+			}
+		);
+	}
+}

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/AllReposEndpoint.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/AllReposEndpoint.java
@@ -8,11 +8,13 @@ import de.aaaaaaah.velcom.backend.access.dimensionaccess.entities.Dimension;
 import de.aaaaaaah.velcom.backend.access.dimensionaccess.entities.DimensionInfo;
 import de.aaaaaaah.velcom.backend.access.repoaccess.RepoReadAccess;
 import de.aaaaaaah.velcom.backend.access.repoaccess.entities.Repo;
+import de.aaaaaaah.velcom.backend.access.repoaccess.entities.Repo.GithubInfo;
 import de.aaaaaaah.velcom.backend.access.repoaccess.entities.RepoId;
 import de.aaaaaaah.velcom.backend.restapi.jsonobjects.JsonBranch;
 import de.aaaaaaah.velcom.backend.restapi.jsonobjects.JsonDimension;
 import de.aaaaaaah.velcom.backend.restapi.jsonobjects.JsonRepo;
 import io.micrometer.core.annotation.Timed;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -72,7 +74,11 @@ public class AllReposEndpoint {
 					repo.getName(),
 					repo.getRemoteUrl().getUrl(),
 					branches,
-					dimensions
+					dimensions,
+					repo.getGithubInfo()
+						.map(GithubInfo::getCommentCutoff)
+						.map(Instant::getEpochSecond)
+						.orElse(null)
 				);
 			})
 			.collect(toList());

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonRepo.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonRepo.java
@@ -2,6 +2,7 @@ package de.aaaaaaah.velcom.backend.restapi.jsonobjects;
 
 import java.util.List;
 import java.util.UUID;
+import javax.annotation.Nullable;
 
 public class JsonRepo {
 
@@ -10,15 +11,18 @@ public class JsonRepo {
 	private final String remoteUrl;
 	private final List<JsonBranch> branches;
 	private final List<JsonDimension> dimensions;
+	@Nullable
+	private final Long lastGithubUpdate;
 
 	public JsonRepo(UUID id, String name, String remoteUrl, List<JsonBranch> branches,
-		List<JsonDimension> dimensions) {
+		List<JsonDimension> dimensions, @Nullable Long lastGithubUpdate) {
 
 		this.id = id;
 		this.name = name;
 		this.remoteUrl = remoteUrl;
 		this.branches = branches;
 		this.dimensions = dimensions;
+		this.lastGithubUpdate = lastGithubUpdate;
 	}
 
 	public UUID getId() {
@@ -39,5 +43,10 @@ public class JsonRepo {
 
 	public List<JsonDimension> getDimensions() {
 		return dimensions;
+	}
+
+	@Nullable
+	public Long getLastGithubUpdate() {
+		return lastGithubUpdate;
 	}
 }

--- a/backend/backend/src/main/resources/db/migration/V13__add_github_bot_data.sql
+++ b/backend/backend/src/main/resources/db/migration/V13__add_github_bot_data.sql
@@ -1,0 +1,61 @@
+-----------------------------------
+-- Renaming to-be-deleted tables --
+-----------------------------------
+
+ALTER TABLE repo RENAME TO repo_old;
+
+-------------------------
+-- Creating new tables --
+-------------------------
+
+CREATE TABLE repo (
+  id                    CHAR(36) PRIMARY KEY  NOT NULL,
+  name                  TEXT                  NOT NULL,
+  remote_url            TEXT                  NOT NULL,
+  github_auth_token     TEXT,
+  github_comment_cutoff TIMESTAMP,
+
+  CHECK ((github_auth_token IS NULL) == (github_comment_cutoff IS NULL))
+);
+
+CREATE TABLE github_command (
+  repo_id       CHAR(36) NOT NULL,
+  pr            BIGINT   NOT NULL,
+  target_branch TEXT     NOT NULL, -- Slightly redundant, but easy to work with
+  comment       BIGINT   NOT NULL,
+  commit_hash   CHAR(40) NOT NULL,
+  state         TEXT     NOT NULL DEFAULT "NEW",
+  tries_left    INT      NOT NULL,
+
+  PRIMARY KEY (repo_id, comment),
+  FOREIGN KEY (repo_id) REFERENCES repo(id),
+  -- No foreign key for the commit because VelCom might not yet have the commit synchronized when a
+  -- new row is added to this table.
+
+  CHECK (state in ("NEW", "MARKED_SEEN", "QUEUED", "ERROR")),
+  CHECK (tries_left > 0)
+);
+
+------------------------
+-- Filling new tables --
+------------------------
+
+INSERT INTO repo
+SELECT id, name, remote_url, NULL, NULL
+FROM repo_old;
+
+-------------------------
+-- Deleting old tables --
+-------------------------
+
+DROP TABLE repo_old;
+
+-- A little dance to capture all foreign key constraints previously pointing to repo
+ALTER TABLE repo RENAME TO repo_old;
+ALTER TABLE repo_old RENAME TO repo;
+
+-----------------------------------
+-- Ensure foreign keys are valid --
+-----------------------------------
+
+PRAGMA foreign_key_check;

--- a/backend/backend/src/main/resources/example_config.yml
+++ b/backend/backend/src/main/resources/example_config.yml
@@ -53,6 +53,15 @@ webAdminToken: "12345"
 benchmarkRepoRemoteUrl: "https://github.com/IPDSnelting/velcom-unibench.git"
 
 ##
+## The base URL the frontend can be reached under. For example, if the frontend's home page can be
+## reached as "https://example.com/velcom/home", this should be set to "https://example.com/velcom/"
+## (the trailing slash is optional).
+##
+## If you don't use the GitHub !bench command, this option can be safely set to any value.
+##
+frontendUrl: "https://example.com/velcom/"
+
+##
 ## The period in which the tracked repos and bench repo is checked for updates. When new commits are
 ## found, they are added to the queue.
 ##

--- a/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/TestDb.java
+++ b/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/TestDb.java
@@ -102,7 +102,9 @@ public class TestDb {
 		dslContext.batchInsert(new RepoRecord(
 			repoId.getIdAsString(),
 			name,
-			remoteUrl.getUrl()
+			remoteUrl.getUrl(),
+			null,
+			null
 		)).execute();
 	}
 

--- a/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/access/GitCloneTest.java
+++ b/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/access/GitCloneTest.java
@@ -4,9 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.StoredConfig;
 import org.eclipse.jgit.merge.MergeStrategy;
 import org.eclipse.jgit.submodule.SubmoduleWalk;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,11 +44,14 @@ class GitCloneTest {
 
 		// Commit it
 		Git subGit = Git.open(submodulePath.toFile());
+		disableGc(subGit);
 		subGit.add().addFilepattern("test.txt").call();
 		subGit.commit().setMessage("Hey").setAuthor("Aith", "er").call();
 
 		// Add submodule to repo
 		Git repoGit = Git.open(repoPath.toFile());
+		disableGc(repoGit);
+
 		repoGit
 			.submoduleAdd()
 			.setName("Submodule")
@@ -72,6 +77,12 @@ class GitCloneTest {
 		repoGit.commit().setAuthor("Auth", "er").setMessage("Updated submodule").call();
 
 		Git.init().setDirectory(tempDir.resolve("bench_repo").toFile()).call();
+	}
+
+	private void disableGc(Git repoGit) throws IOException {
+		StoredConfig config = repoGit.getRepository().getConfig();
+		config.setInt("gc", null, "auto", 0);
+		config.save();
 	}
 
 	@Test

--- a/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/access/committaccess/CommitReadAccessTest.java
+++ b/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/access/committaccess/CommitReadAccessTest.java
@@ -18,6 +18,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -61,6 +62,9 @@ class CommitReadAccessTest {
 	private static final CommitHash COMM_I_HASH =
 		new CommitHash("e9a98785fabfa10307ee4ab637537a67c86f0e67");
 
+	private static final BranchName BRANCH_T = BranchName.fromName("T");
+	private static final BranchName BRANCH_U = BranchName.fromName("U");
+
 	private CommitReadAccess access;
 
 	@BeforeEach
@@ -95,8 +99,8 @@ class CommitReadAccessTest {
 		testDb.addCommitRel(REPO_ID, COMM_D_HASH, COMM_H_HASH);
 		testDb.addCommitRel(REPO_ID, COMM_F_HASH, COMM_G_HASH);
 		testDb.addCommitRel(REPO_ID, COMM_F_HASH, COMM_I_HASH);
-		testDb.addBranch(REPO_ID, BranchName.fromName("T"), COMM_E_HASH, true);
-		testDb.addBranch(REPO_ID, BranchName.fromName("U"), COMM_G_HASH, false);
+		testDb.addBranch(REPO_ID, BRANCH_T, COMM_E_HASH, true);
+		testDb.addBranch(REPO_ID, BRANCH_U, COMM_G_HASH, false);
 
 		DatabaseStorage databaseStorage = new DatabaseStorage(testDb.closeAndGetJdbcUrl());
 		access = new CommitReadAccess(databaseStorage);
@@ -399,6 +403,47 @@ class CommitReadAccessTest {
 		assertThat(commits.stream()
 			.map(Commit::getHash))
 			.containsExactlyInAnyOrder(COMM_D_HASH);
+	}
+
+	@Test
+	void getFirstParentOfBranch() {
+		assertThat(access.getFirstParentOfBranch(REPO_ID, BRANCH_T, COMM_A_HASH))
+			.isEqualTo(Optional.empty());
+		assertThat(access.getFirstParentOfBranch(REPO_ID, BRANCH_T, COMM_B_HASH))
+			.isEqualTo(Optional.empty());
+		assertThat(access.getFirstParentOfBranch(REPO_ID, BRANCH_T, COMM_C_HASH))
+			.isEqualTo(Optional.empty());
+		assertThat(access.getFirstParentOfBranch(REPO_ID, BRANCH_T, COMM_D_HASH))
+			.isEqualTo(Optional.empty());
+		assertThat(access.getFirstParentOfBranch(REPO_ID, BRANCH_T, COMM_E_HASH))
+			.isEqualTo(Optional.empty());
+		assertThat(access.getFirstParentOfBranch(REPO_ID, BRANCH_T, COMM_F_HASH))
+			.isEqualTo(Optional.empty());
+		assertThat(access.getFirstParentOfBranch(REPO_ID, BRANCH_T, COMM_G_HASH))
+			.isEqualTo(Optional.empty());
+		assertThat(access.getFirstParentOfBranch(REPO_ID, BRANCH_T, COMM_H_HASH))
+			.isEqualTo(Optional.of(COMM_D_HASH));
+		assertThat(access.getFirstParentOfBranch(REPO_ID, BRANCH_T, COMM_I_HASH))
+			.isEqualTo(Optional.empty());
+
+		assertThat(access.getFirstParentOfBranch(REPO_ID, BRANCH_U, COMM_A_HASH))
+			.isEqualTo(Optional.empty());
+		assertThat(access.getFirstParentOfBranch(REPO_ID, BRANCH_U, COMM_B_HASH))
+			.isEqualTo(Optional.empty());
+		assertThat(access.getFirstParentOfBranch(REPO_ID, BRANCH_U, COMM_C_HASH))
+			.isEqualTo(Optional.empty());
+		assertThat(access.getFirstParentOfBranch(REPO_ID, BRANCH_U, COMM_D_HASH))
+			.isEqualTo(Optional.empty());
+		assertThat(access.getFirstParentOfBranch(REPO_ID, BRANCH_U, COMM_E_HASH))
+			.isEqualTo(Optional.of(COMM_D_HASH));
+		assertThat(access.getFirstParentOfBranch(REPO_ID, BRANCH_U, COMM_F_HASH))
+			.isEqualTo(Optional.empty());
+		assertThat(access.getFirstParentOfBranch(REPO_ID, BRANCH_U, COMM_G_HASH))
+			.isEqualTo(Optional.empty());
+		assertThat(access.getFirstParentOfBranch(REPO_ID, BRANCH_U, COMM_H_HASH))
+			.isEqualTo(Optional.of(COMM_D_HASH));
+		assertThat(access.getFirstParentOfBranch(REPO_ID, BRANCH_U, COMM_I_HASH))
+			.isEqualTo(Optional.of(COMM_F_HASH));
 	}
 
 	@Test

--- a/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/access/repoaccess/entities/RepoTest.java
+++ b/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/access/repoaccess/entities/RepoTest.java
@@ -1,0 +1,79 @@
+package de.aaaaaaah.velcom.backend.access.repoaccess.entities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.aaaaaaah.velcom.backend.access.repoaccess.entities.Repo.GithubInfo;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class RepoTest {
+
+	@Test
+	void testIllegalConstructorArguments() {
+		Assertions.assertThrows(IllegalArgumentException.class, () -> new Repo(
+			new RepoId(),
+			"velcom",
+			new RemoteUrl("https://github.com/IPDSnelting/velcom.git"),
+			null,
+			Instant.now()
+		));
+
+		Assertions.assertThrows(IllegalArgumentException.class, () -> new Repo(
+			new RepoId(),
+			"velcom",
+			new RemoteUrl("https://github.com/IPDSnelting/velcom.git"),
+			"bla",
+			null
+		));
+	}
+
+	@Test
+	void testGhRepoName() {
+		Repo repo = new Repo(new RepoId(), "velcom via https",
+			new RemoteUrl("https://github.com/IPDSnelting/velcom.git"), null, null);
+		assertThat(repo.getGithubRepoName()).isEqualTo(Optional.of("IPDSnelting/velcom"));
+
+		repo = new Repo(new RepoId(), "velcom via ssh",
+			new RemoteUrl("git@github.com:IPDSnelting/velcom.git"), null, null);
+		assertThat(repo.getGithubRepoName()).isEqualTo(Optional.of("IPDSnelting/velcom"));
+
+		repo = new Repo(new RepoId(), "velcom via gitlab(!?)",
+			new RemoteUrl("https://gitlab.com/IPDSnelting/velcom.git"), null, null);
+		assertThat(repo.getGithubRepoName()).isEmpty();
+	}
+
+	@Test
+	void testGhInfo() {
+		Instant now = Instant.now();
+
+		Repo repo = new Repo(
+			new RepoId(),
+			"velcom",
+			new RemoteUrl("https://github.com/IPDSnelting/velcom.git"),
+			null,
+			null
+		);
+		assertThat(repo.getGithubInfo()).isEmpty();
+
+		repo = new Repo(
+			new RepoId(),
+			"velcom",
+			new RemoteUrl("https://github.com/IPDSnelting/velcom.git"),
+			"token",
+			now
+		);
+		assertThat(repo.getGithubInfo())
+			.isEqualTo(Optional.of(new GithubInfo("IPDSnelting/velcom", "token", now)));
+
+		repo = new Repo(
+			new RepoId(),
+			"velcom via https",
+			new RemoteUrl("https://gitlab.com/IPDSnelting/velcom.git"),
+			"token",
+			now
+		);
+		assertThat(repo.getGithubInfo()).isEmpty();
+	}
+}

--- a/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/data/queue/PolicyTest.java
+++ b/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/data/queue/PolicyTest.java
@@ -87,10 +87,10 @@ class PolicyTest {
 
 	@Test
 	void tarTasksInFifoOrder() {
-		Task task1 = tarTask("task1", TaskPriority.TAR, repo1);
-		Task task2 = tarTask("task2", TaskPriority.TAR, null);
-		Task task3 = tarTask("task3", TaskPriority.TAR, repo2);
-		Task task4 = tarTask("task4", TaskPriority.TAR, repo1);
+		Task task1 = tarTask("task1", TaskPriority.USER_CREATED, repo1);
+		Task task2 = tarTask("task2", TaskPriority.USER_CREATED, null);
+		Task task3 = tarTask("task3", TaskPriority.USER_CREATED, repo2);
+		Task task4 = tarTask("task4", TaskPriority.USER_CREATED, repo1);
 
 		List<Task> tasks = List.of(task3, task2, task4, task1);
 		List<Task> expected = List.of(task1, task2, task3, task4);
@@ -138,8 +138,8 @@ class PolicyTest {
 		Task m1 = comTask("m1", TaskPriority.MANUAL, repo1);
 		Task m2 = tarTask("m2", TaskPriority.MANUAL, null);
 
-		Task t1 = tarTask("t1", TaskPriority.TAR, repo2);
-		Task t2 = tarTask("t2", TaskPriority.TAR, null);
+		Task t1 = tarTask("t1", TaskPriority.USER_CREATED, repo2);
+		Task t2 = tarTask("t2", TaskPriority.USER_CREATED, null);
 
 		Task l1 = comTask("l1", TaskPriority.LISTENER, repo1);
 		Task l2 = comTask("l2", TaskPriority.LISTENER, repo2);

--- a/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonRepoTest.java
+++ b/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonRepoTest.java
@@ -19,7 +19,8 @@ class JsonRepoTest extends SerializingTest {
 				new JsonBranch("untracked", false, "bar"),
 				new JsonBranch("branches", false, "baz")
 			),
-			List.of(new JsonDimension("b", "m", "u", Interpretation.NEUTRAL))
+			List.of(new JsonDimension("b", "m", "u", Interpretation.NEUTRAL)),
+			1596881630L
 		);
 		String json = "{"
 			+ "\"id\": \"24dd4fd3-5c6d-4542-a7a4-b181f37295a6\","
@@ -35,7 +36,8 @@ class JsonRepoTest extends SerializingTest {
 			+ "  \"metric\": \"m\","
 			+ "  \"unit\": \"u\","
 			+ "  \"interpretation\": \"NEUTRAL\""
-			+ "}]"
+			+ "}],"
+			+ "\"last_github_update\": 1596881630"
 			+ "}";
 		serializedEquals(object, json);
 	}

--- a/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/storage/db/DatabaseStorageTest.java
+++ b/backend/backend/src/test/java/de/aaaaaaah/velcom/backend/storage/db/DatabaseStorageTest.java
@@ -28,7 +28,7 @@ class DatabaseStorageTest {
 		String repoName = "test repo";
 		String repoRemoteUrl = "https://github.com/IPDSnelting/velcom.git";
 
-		testDb.db().batchInsert(new RepoRecord(repoId, repoName, repoRemoteUrl)).execute();
+		testDb.db().batchInsert(new RepoRecord(repoId, repoName, repoRemoteUrl, null, null)).execute();
 		DatabaseStorage databaseStorage = new DatabaseStorage(testDb.closeAndGetJdbcUrl());
 
 		// Read without explicit transaction
@@ -71,17 +71,17 @@ class DatabaseStorageTest {
 
 		// Write without explicit transaction
 		try (DBWriteAccess db = databaseStorage.acquireWriteAccess()) {
-			db.dsl().batchInsert(new RepoRecord(repoId1, repoName1, repoRemoteUrl)).execute();
+			db.dsl().batchInsert(new RepoRecord(repoId1, repoName1, repoRemoteUrl, null, null)).execute();
 		}
 
 		// Write transaction, no return value
 		databaseStorage.acquireWriteTransaction(db -> {
-			db.dsl().batchInsert(new RepoRecord(repoId2, repoName2, repoRemoteUrl)).execute();
+			db.dsl().batchInsert(new RepoRecord(repoId2, repoName2, repoRemoteUrl, null, null)).execute();
 		});
 
 		// Write transaction with return value
 		databaseStorage.acquireWriteTransaction(db -> {
-			db.dsl().batchInsert(new RepoRecord(repoId3, repoName3, repoRemoteUrl)).execute();
+			db.dsl().batchInsert(new RepoRecord(repoId3, repoName3, repoRemoteUrl, null, null)).execute();
 			return true;
 		});
 

--- a/docs/public_api.yaml
+++ b/docs/public_api.yaml
@@ -368,8 +368,29 @@ paths:
                 properties:
                   repo:
                     $ref: '#/components/schemas/Repo'
+                  github_commands:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        pr_number:
+                          type: integer
+                        comment_id:
+                          type: integer
+                        status:
+                          type: string
+                          enum:
+                            - NEW
+                            - MARKED_SEEN
+                            - QUEUED
+                            - ERROR
+                      required:
+                        - pr_number
+                        - comment_id
+                        - status
                 required:
                   - repo
+                  - github_commands
         '404':
           description: Not Found
       operationId: get-repo-repoid
@@ -417,6 +438,9 @@ paths:
                   items:
                     type: string
                     minLength: 1
+                github_token:
+                  type: string
+                  description: Set a GitHub auth token to enable GitHub bot functionality. Set this to the empty string to delete the token and disable GitHub bot functionality.
       tags:
         - repo
       description: Modify some parts of an existing repo.
@@ -1318,6 +1342,8 @@ components:
           description: All types of measurements where at least one value exists for this repo
           items:
             $ref: '#/components/schemas/Dimension'
+        last_github_update:
+          $ref: '#/components/schemas/Time'
       required:
         - id
         - name

--- a/frontend/src/components/misc/InlineMinimalRepoDisplay.vue
+++ b/frontend/src/components/misc/InlineMinimalRepoDisplay.vue
@@ -24,7 +24,7 @@ export default class InlineMinimalRepoNameDisplay extends Vue {
   private get repo() {
     return (
       vxm.repoModule.repoById(this.repoId) ||
-      new Repo('Placeholder', 'Not loaded yet :/', [], [], '')
+      new Repo('Placeholder', 'Not loaded yet :/', [], [], '', undefined)
     )
   }
 }

--- a/frontend/src/components/repodetail/GithubBotCommandChips.vue
+++ b/frontend/src/components/repodetail/GithubBotCommandChips.vue
@@ -1,0 +1,89 @@
+<template>
+  <div>
+    <v-tooltip
+      top
+      v-for="(pr, index) in prs"
+      :key="pr.prNumber + '' + pr.sourceCommentId"
+    >
+      <template v-slot:activator="{ on }">
+        <a :href="commentLink(pr)" rel="noopener nofollow" target="_blank">
+          <v-chip
+            outlined
+            label
+            link
+            v-on="on"
+            :class="{ 'ml-2': index > 0 }"
+            :color="color(pr.state)"
+          >
+            For PR #{{ pr.prNumber }}
+            <v-icon right>
+              {{ icon(pr.state) }}
+            </v-icon>
+          </v-chip>
+        </a>
+      </template>
+      {{ description(pr.state) }}
+    </v-tooltip>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import Component from 'vue-class-component'
+import { Prop } from 'vue-property-decorator'
+import {
+  mdiAlertCircleOutline,
+  mdiCheck,
+  mdiCheckAll,
+  mdiCircleSlice6
+} from '@mdi/js'
+import { GithubBotCommand, GithubBotCommandState } from '@/store/types'
+
+type StateData = {
+  color?: string
+  icon: string
+  description: string
+}
+const stateDate: { [key in GithubBotCommandState]: StateData } = {
+  NEW: {
+    icon: mdiCheck,
+    description: 'Command was seen by the Github Bot'
+  },
+  MARKED_SEEN: {
+    icon: mdiCheckAll,
+    description: 'Command was acknowledged by the Github Bot'
+  },
+  QUEUED: {
+    color: 'success',
+    icon: mdiCircleSlice6,
+    description: 'Command is currently in the queue'
+  },
+  ERROR: {
+    color: 'error',
+    icon: mdiAlertCircleOutline,
+    description: 'Error processing command'
+  }
+}
+
+@Component
+export default class GithubBotCommandChips extends Vue {
+  @Prop()
+  private readonly prs!: GithubBotCommand[]
+
+  private description(state: GithubBotCommandState) {
+    return stateDate[state].description
+  }
+
+  private icon(state: GithubBotCommandState) {
+    return stateDate[state].icon
+  }
+
+  private color(state: GithubBotCommandState) {
+    return stateDate[state].color
+  }
+
+  private commentLink(command: GithubBotCommand) {
+    return `https://github.com/IPDSnelting/velcom/pull/${command.prNumber}#issuecomment-${command.sourceCommentId}`
+  }
+}
+</script>

--- a/frontend/src/components/repodetail/GithubTokenConfiguration.vue
+++ b/frontend/src/components/repodetail/GithubTokenConfiguration.vue
@@ -1,0 +1,100 @@
+<template>
+  <v-container class="pa-0" fluid>
+    <v-row no-gutters align="center">
+      <span v-if="tokenState === 'delete'" class="section-header mr-4">
+        TOKEN WILL BE DELETED
+      </span>
+      <span>
+        <v-btn
+          v-if="tokenState === 'unchanged'"
+          @click="tokenState = 'modify'"
+          text
+          outlined
+          class="mr-2"
+          color="primary"
+        >
+          <span v-if="hasToken">Change Github token</span>
+          <span v-else>Set Github token</span>
+        </v-btn>
+        <v-btn
+          v-if="tokenState === 'unchanged' && hasToken"
+          @click="tokenState = 'delete'"
+          text
+          outlined
+          class="mr-2"
+          color="error"
+        >
+          Delete Github token
+        </v-btn>
+        <v-btn
+          v-if="tokenState === 'modify' || tokenState === 'delete'"
+          @click="tokenState = 'unchanged'"
+          text
+          outlined
+          color="error"
+        >
+          <span v-if="tokenState === 'modify' && hasToken">
+            KEEP OLD ACCESS TOKEN
+          </span>
+          <span v-if="tokenState === 'modify' && !hasToken">
+            DON'T SET TOKEN
+          </span>
+          <span v-else>UNDO</span>
+        </v-btn>
+      </span>
+      <v-text-field
+        v-if="tokenState === 'modify'"
+        :rules="[notEmpty]"
+        label="*New Github access token"
+        :value="newToken"
+        @input="setNewToken"
+        dense
+        hide-details="auto"
+        class="ml-4 mt-0 pt-0"
+      ></v-text-field>
+    </v-row>
+  </v-container>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import Component from 'vue-class-component'
+import { Prop } from 'vue-property-decorator'
+
+export type TokenState = 'delete' | 'modify' | 'unchanged'
+
+@Component
+export default class GithubTokenConfiguration extends Vue {
+  private tokenStateImpl: TokenState = 'unchanged'
+
+  @Prop()
+  private readonly hasToken!: string
+
+  @Prop()
+  private readonly newToken!: string
+
+  private get tokenState() {
+    return this.tokenStateImpl
+  }
+
+  private set tokenState(state: TokenState) {
+    this.tokenStateImpl = state
+
+    this.$emit('update:tokenState', state)
+  }
+
+  private setNewToken(token: string) {
+    this.$emit('update:newToken', token)
+  }
+
+  private notEmpty(input: string): boolean | string {
+    return input.trim().length > 0 ? true : 'This field must not be empty'
+  }
+}
+</script>
+
+<style scoped>
+.section-header {
+  font-variant: small-caps;
+}
+</style>

--- a/frontend/src/store/modules/repoStore.ts
+++ b/frontend/src/store/modules/repoStore.ts
@@ -1,9 +1,9 @@
 import { createModule, mutation, action } from 'vuex-class-component'
-import { Repo, RepoId, Dimension } from '@/store/types'
+import { Repo, RepoId, Dimension, GithubBotCommand } from '@/store/types'
 import Vue from 'vue'
 import axios from 'axios'
 import { vxm } from '..'
-import { repoFromJson } from '@/util/json/RepoJsonHelper'
+import { githubCommandFromJson, repoFromJson } from '@/util/json/RepoJsonHelper'
 
 const VxModule = createModule({
   namespaced: 'repoModule',
@@ -81,11 +81,13 @@ export class RepoStore extends VxModule {
     name: string | undefined
     remoteUrl: string | undefined
     trackedBranches: string[] | undefined
+    githubToken: string | undefined
   }): Promise<void> {
     await axios.patch(`/repo/${payload.id}`, {
       name: payload.name,
       remote_url: payload.remoteUrl,
-      tracked_branches: payload.trackedBranches
+      tracked_branches: payload.trackedBranches,
+      github_token: payload.githubToken
     })
     await this.fetchRepoById(payload.id)
   }
@@ -95,6 +97,12 @@ export class RepoStore extends VxModule {
     await axios.post(`/listener/fetch-all`, undefined, {
       snackbarPriority: 2
     })
+  }
+
+  @action
+  async fetchGithubCommands(repoId: string): Promise<GithubBotCommand[]> {
+    const response = await axios.get(`/repo/${repoId}`)
+    return response.data.github_commands.map(githubCommandFromJson)
   }
 
   @mutation

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -23,13 +23,15 @@ export class Repo {
   branches: RepoBranch[]
   dimensions: Dimension[]
   remoteURL: string
+  lastGithubUpdate: Date | undefined
 
   constructor(
     id: RepoId,
     name: string,
     branches: RepoBranch[],
     dimensions: Dimension[],
-    remoteURL: string
+    remoteURL: string,
+    lastGithubUpdate: Date | undefined
   ) {
     this.id = id
     this.name = name
@@ -38,6 +40,7 @@ export class Repo {
     this.branches = branches.sort((a, b) =>
       a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
     )
+    this.lastGithubUpdate = lastGithubUpdate
   }
 
   /**
@@ -724,3 +727,23 @@ export class SearchItemBranch {
 }
 
 export type SearchItem = SearchItemCommit | SearchItemRun | SearchItemBranch
+
+export type GithubCommentId = Flavor<number, 'github_comment_id'>
+export type GithubPrNumber = Flavor<number, 'github_pr_number'>
+export type GithubBotCommandState = 'NEW' | 'MARKED_SEEN' | 'QUEUED' | 'ERROR'
+
+export class GithubBotCommand {
+  readonly state: GithubBotCommandState
+  readonly sourceCommentId: GithubCommentId
+  readonly prNumber: GithubPrNumber
+
+  constructor(
+    state: GithubBotCommandState,
+    sourceCommentId: GithubCommentId,
+    prNumber: GithubPrNumber
+  ) {
+    this.state = state
+    this.sourceCommentId = sourceCommentId
+    this.prNumber = prNumber
+  }
+}

--- a/frontend/src/util/Serialisation.ts
+++ b/frontend/src/util/Serialisation.ts
@@ -45,7 +45,8 @@ const mappers: { [key: string]: any } = {
       rawRepo.name,
       rawRepo.branches,
       rawRepo.dimensions,
-      rawRepo.remoteURL
+      rawRepo.remoteURL,
+      rawRepo.lastGithubUpdate
     )
 }
 

--- a/frontend/src/util/json/RepoJsonHelper.ts
+++ b/frontend/src/util/json/RepoJsonHelper.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import { RepoBranch, Repo, Dimension } from '@/store/types'
+import { RepoBranch, Repo, Dimension, GithubBotCommand } from '@/store/types'
 
 /**
  * Parses a repo json to a Repo object.
@@ -9,12 +9,17 @@ import { RepoBranch, Repo, Dimension } from '@/store/types'
  * @returns {Repo} the repo object
  */
 export function repoFromJson(json: any): Repo {
+  let lastGithubUpdate: Date | undefined
+  if (json.last_github_update !== undefined) {
+    lastGithubUpdate = new Date(json.last_github_update * 1000)
+  }
   return new Repo(
     json.id,
     json.name,
     json.branches.map(repoBranchFromJson),
     json.dimensions.map((it: any) => dimensionFromJson(it)),
-    json.remote_url
+    json.remote_url,
+    lastGithubUpdate
   )
 }
 
@@ -29,4 +34,8 @@ export function dimensionFromJson(json: any): Dimension {
     json.unit,
     json.interpretation
   )
+}
+
+export function githubCommandFromJson(json: any): GithubBotCommand {
+  return new GithubBotCommand(json.status, json.comment_id, json.pr_number)
 }


### PR DESCRIPTION
This PR adds GitHub bot functionality to VelCom. To enable it for a repo, go to its detail page as admin and follow the instructions there. To trigger a benchmark of a PR, add a comment containing only `!bench` on that PR. Only accounts with write access to the repo can use this command, the bot ignores everyone else. Tasks triggered this way have the same queue priority as uploaded tar files - below one-upped tasks but above newly detected commits.

**Required manual changes:**
This PR adds the `frontendUrl` option to the config file (documented in the [example config][1]). It also includes a DB migration, in case you want to make a backup first. Feel free to fast-forward this PR yourself whenever you're ready.

**Details:**
- VelCom assumes that the token is valid. If it isn't, the repo may not be updated correctly.
- If the bot is enabled for a repo, VelCom searches for new commands at the same time as new commits. This search can thus be triggered manually via the "Refetch all repos" button on the queue page.
- Once a comment is detected as a command, the bot reacts with a :+1: before doing anything else with the command.
- The bot will benchmark the PR's commit at the time it detected the command.
- If multiple commands are made for the same PR and commit, the bot may only respond with a single message, although it will still react with :+1: to every single command.
- If one or more runs already exist for a given PR and commit, the bot will post the newest run and *not* re-benchmark. To re-benchmark a commit, you need to use the re-benchmark button in the VelCom UI while logged in as an admin. However, keep in mind that the bot's old link will still point to the old run. To make it post the new link after re-benchmarking, just issue another `!bench` command.

We haven't tested this a lot, especially not at a larger scale, so if you notice any buggy behaviour, let us know.

[1]: https://github.com/IPDSnelting/velcom/blob/04afde90f33408796f1a028fee6257546b492f31/backend/backend/src/main/resources/example_config.yml#L55-L62