### PR TITLE
Add one-ups with listener, not manual priority

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/QueueEndpoint.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/QueueEndpoint.java
@@ -191,7 +191,7 @@ public class QueueEndpoint {
 
 		List<CommitHash> hashes = commitReadAccess.getDescendantCommits(repoId, rootHash);
 
-		queue.addCommits(AUTHOR_NAME_ADMIN, repoId, hashes, TaskPriority.MANUAL);
+		queue.addCommits(AUTHOR_NAME_ADMIN, repoId, hashes, TaskPriority.LISTENER);
 
 		List<JsonTask> tasks = queue.getAllTasksInOrder().stream()
 			.filter(it -> it.getRepoId().map(repoId::equals).orElse(false))


### PR DESCRIPTION
One-ups usually add a lot of commits at once. If they're all set to manual priority, this means that newly detected commits from other repos are blocked until the one-ups finish. This is of course not ideal, especially when one-upping large amounts (e. g. thousands) of commits.

This PR changes the priority of one-upped commits to listener priority, meaning they'll be sorted into the round-robin schema.