### PR TITLE
Small fixes and adjustments for the GitHub bot

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/repoaccess/entities/Repo.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/repoaccess/entities/Repo.java
@@ -62,10 +62,10 @@ public class Repo {
 
 	public Optional<String> getGithubRepoName() {
 		String remoteUrl = getRemoteUrlAsString();
-		Pattern pattern = Pattern.compile("github.com[:/]([^/]+/[^/.]+)(\\.git)?");
+		Pattern pattern = Pattern.compile("^(https://|git@)github.com[:/]([^/]+/[^/.]+)(\\.git)?$");
 		Matcher matcher = pattern.matcher(remoteUrl);
 		if (matcher.find()) {
-			return Optional.of(matcher.group(1));
+			return Optional.of(matcher.group(2));
 		} else {
 			return Optional.empty();
 		}

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/Listener.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/Listener.java
@@ -11,6 +11,7 @@ import de.aaaaaaah.velcom.backend.access.taskaccess.entities.TaskPriority;
 import de.aaaaaaah.velcom.backend.data.benchrepo.BenchRepo;
 import de.aaaaaaah.velcom.backend.data.queue.Queue;
 import de.aaaaaaah.velcom.backend.listener.commits.DbUpdater;
+import de.aaaaaaah.velcom.backend.listener.github.GithubApiError;
 import de.aaaaaaah.velcom.backend.listener.github.GithubPrInteractor;
 import de.aaaaaaah.velcom.backend.storage.db.DBWriteAccess;
 import de.aaaaaaah.velcom.backend.storage.db.DatabaseStorage;
@@ -180,13 +181,16 @@ public class Listener {
 		try {
 			LOGGER.debug("Updating repo {}", repo.getId());
 			updateRepo(repo);
+		} catch (GithubApiError e) {
+			LOGGER.warn("Failed to update repo {}", repo.getId());
+			LOGGER.warn("{}", e.getMessage());
 		} catch (Exception e) {
 			LOGGER.warn("Failed to update repo {}", repo.getId(), e);
 		}
 	}
 
 	private void updateRepo(Repo repo)
-		throws SynchronizeCommitsException, IOException, InterruptedException, URISyntaxException {
+		throws SynchronizeCommitsException, IOException, InterruptedException, URISyntaxException, GithubApiError {
 
 		Optional<GithubPrInteractor> ghIntOpt = GithubPrInteractor
 			.fromRepo(repo, databaseStorage, commitAccess, queue, frontendUrl);

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/github/GithubApiError.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/github/GithubApiError.java
@@ -1,0 +1,17 @@
+package de.aaaaaaah.velcom.backend.listener.github;
+
+import java.net.URI;
+
+public class GithubApiError extends Exception {
+
+	private final URI url;
+
+	public GithubApiError(String message, URI url) {
+		super("Error while accessing " + url + ": " + message);
+		this.url = url;
+	}
+
+	public URI getUrl() {
+		return url;
+	}
+}

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/github/GithubPrInteractor.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/github/GithubPrInteractor.java
@@ -494,8 +494,11 @@ public class GithubPrInteractor {
 					+ "?hash1=" + commitHash.getHash())
 				.orElseGet(() -> frontendUrl + "run-detail/" + reply.getRunId().getIdAsString());
 
-			String body = "Benchmark of commit " + reply.getCommitHash().getHash() + " complete.\n\n"
-				+ link;
+			String body = "Here are the [benchmark results]("
+				+ link +
+				") of commit "
+				+ reply.getCommitHash().getHash()
+				+ ".";
 
 			HttpResponse<String> response = createPrComment(reply.getPr(), body);
 

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/github/GithubPrInteractor.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/github/GithubPrInteractor.java
@@ -111,18 +111,33 @@ public class GithubPrInteractor {
 		);
 	}
 
-	private JsonNode getResourceFromUrl(String issueUrl)
-		throws URISyntaxException, IOException, InterruptedException {
+	private void checkResponse(HttpResponse<JsonNode> response) throws GithubApiError {
+		if (response.statusCode() < 100 || response.statusCode() >= 300) {
+			JsonNode message = response.body().get("message");
+			if (message == null) {
+				throw new GithubApiError("Something went wrong", response.uri());
+			} else {
+				throw new GithubApiError(message.toString(), response.uri());
+			}
+		}
+	}
 
-		HttpRequest request = HttpRequest.newBuilder(new URI(issueUrl))
+	private JsonNode getResourceFromUrl(String issueUrl)
+		throws URISyntaxException, IOException, InterruptedException, GithubApiError {
+
+		URI uri = new URI(issueUrl);
+		HttpRequest request = HttpRequest.newBuilder(uri)
 			.header(HttpHeaders.AUTHORIZATION, basicAuthHeader)
 			.header(HttpHeaders.ACCEPT, "application/vnd.github.v3+json")
 			.build();
 		HttpResponse<JsonNode> response = client.send(request, jsonBodyHandler);
+		checkResponse(response);
 		return response.body();
 	}
 
-	private JsonNode getCommentPage(int page) throws IOException, InterruptedException {
+	private JsonNode getCommentPage(int page)
+		throws IOException, InterruptedException, GithubApiError {
+
 		URI uri = UriBuilder.fromUri("https://api.github.com/")
 			.path("repos")
 			.path(ghInfo.getRepoName())
@@ -141,12 +156,13 @@ public class GithubPrInteractor {
 			.header(HttpHeaders.ACCEPT, "application/vnd.github.v3+json")
 			.build();
 		HttpResponse<JsonNode> response = client.send(request, jsonBodyHandler);
+		checkResponse(response);
 		return response.body();
 	}
 
 	private Optional<Instant> findNewCommandCandidates(
 		List<Pair<GithubCommand, String>> commandCandidates)
-		throws IOException, InterruptedException, URISyntaxException {
+		throws IOException, InterruptedException, URISyntaxException, GithubApiError {
 
 		Set<Long> seen = new HashSet<>();
 		Instant commentCutoff = ghInfo.getCommentCutoff();
@@ -215,7 +231,9 @@ public class GithubPrInteractor {
 	}
 
 	private List<GithubCommand> keepOnlyAuthorizedCandidates(
-		List<Pair<GithubCommand, String>> commandCandidates) throws IOException, InterruptedException {
+		List<Pair<GithubCommand, String>> commandCandidates)
+		throws IOException, InterruptedException, GithubApiError {
+
 		Set<String> usernames = commandCandidates.stream()
 			.map(Pair::getSecond)
 			.collect(toSet());
@@ -235,6 +253,7 @@ public class GithubPrInteractor {
 				.header(HttpHeaders.ACCEPT, "application/vnd.github.v3+json")
 				.build();
 			HttpResponse<JsonNode> response = client.send(request, jsonBodyHandler);
+			checkResponse(response);
 			if (response.statusCode() != 200) {
 				LOGGER.debug("User {} doesn't have write permissions (not a collaborator)", username);
 				continue;
@@ -255,7 +274,7 @@ public class GithubPrInteractor {
 	}
 
 	public void searchForNewPrCommands()
-		throws IOException, InterruptedException, URISyntaxException {
+		throws IOException, InterruptedException, URISyntaxException, GithubApiError {
 
 		LOGGER.debug("Searching for new PR commands");
 

--- a/frontend/src/components/repodetail/GithubBotCommandChips.vue
+++ b/frontend/src/components/repodetail/GithubBotCommandChips.vue
@@ -86,19 +86,15 @@ export default class GithubBotCommandChips extends Vue {
   }
 
   private commentLink(command: GithubBotCommand) {
-    let url = this.repo.remoteURL
-    if (url.startsWith('https://')) {
-      // https://github.com/IPDSnelting/velcom.git
-      url = url.replace('.git', '')
-    } else if (url.startsWith('git@')) {
-      // git@github.com:IPDSnelting/velcom.git
-      url = url.substring(url.indexOf(':') + 1)
-      url = url.replace('.git', '')
-      url = `https://github.com/${url}`
+    const regex = /^(https:\/\/|git@)github.com[:/]([^/]+\/[^/.]+)(\.git)?$/
+    const match = regex.exec(this.repo.remoteURL)
+
+    if (match === null) {
+      return undefined
     }
-    // Format now:
-    // https://github.com/IPDSnelting/velcom
-    return `${url}/pull/${command.prNumber}#issuecomment-${command.sourceCommentId}`
+
+    const repoName = match[2]
+    return `https://github.com/${repoName}/pull/${command.prNumber}#issuecomment-${command.sourceCommentId}`
   }
 }
 </script>

--- a/frontend/src/components/repodetail/GithubBotCommandChips.vue
+++ b/frontend/src/components/repodetail/GithubBotCommandChips.vue
@@ -37,7 +37,7 @@ import {
   mdiCheckAll,
   mdiCircleSlice6
 } from '@mdi/js'
-import { GithubBotCommand, GithubBotCommandState } from '@/store/types'
+import { GithubBotCommand, GithubBotCommandState, Repo } from '@/store/types'
 
 type StateData = {
   color?: string
@@ -70,6 +70,9 @@ export default class GithubBotCommandChips extends Vue {
   @Prop()
   private readonly prs!: GithubBotCommand[]
 
+  @Prop()
+  private readonly repo!: Repo
+
   private description(state: GithubBotCommandState) {
     return stateDate[state].description
   }
@@ -83,7 +86,19 @@ export default class GithubBotCommandChips extends Vue {
   }
 
   private commentLink(command: GithubBotCommand) {
-    return `https://github.com/IPDSnelting/velcom/pull/${command.prNumber}#issuecomment-${command.sourceCommentId}`
+    let url = this.repo.remoteURL
+    if (url.startsWith('https://')) {
+      // https://github.com/IPDSnelting/velcom.git
+      url = url.replace('.git', '')
+    } else if (url.startsWith('git@')) {
+      // git@github.com:IPDSnelting/velcom.git
+      url = url.substring(url.indexOf(':') + 1)
+      url = url.replace('.git', '')
+      url = `https://github.com/${url}`
+    }
+    // Format now:
+    // https://github.com/IPDSnelting/velcom
+    return `${url}/pull/${command.prNumber}#issuecomment-${command.sourceCommentId}`
   }
 }
 </script>

--- a/frontend/src/components/repodetail/RepoBaseInformation.vue
+++ b/frontend/src/components/repodetail/RepoBaseInformation.vue
@@ -73,6 +73,7 @@
           <v-col cols="9">
             <github-bot-command-chips
               :prs="githubCommands"
+              :repo="repo"
               v-if="hasActiveBot"
             ></github-bot-command-chips>
             <span v-if="hasActiveBot && githubCommands.length === 0">

--- a/frontend/src/components/repodetail/RepoBaseInformation.vue
+++ b/frontend/src/components/repodetail/RepoBaseInformation.vue
@@ -86,7 +86,11 @@
                   On Github, create a new account for the bot if you want to.
                 </li>
                 <li>
-                  On Github, log in to the account you want the bot to use.
+                  On Github, log in to the account you want the bot to use. Note
+                  that the account must have <strong>push</strong> access to the
+                  repository.<br />
+                  VelCom only allows collaborators to trigger benchmarks and
+                  fetching the collaborator status requires push permissions.
                 </li>
                 <li>
                   On GitHub, go to Settings > Developer settings > Personal

--- a/frontend/src/components/repodetail/RepoBaseInformation.vue
+++ b/frontend/src/components/repodetail/RepoBaseInformation.vue
@@ -83,12 +83,19 @@
               No Github bot set up. You can do that by following these steps:
               <ol class="mt-1">
                 <li>
+                  On Github, create a new account for the bot if you want to.
+                </li>
+                <li>
+                  On Github, log in to the account you want the bot to use.
+                </li>
+                <li>
                   On GitHub, go to Settings > Developer settings > Personal
                   access tokens
                 </li>
                 <li>
-                  Generate a new token with the "public_repo" scope (or the
-                  "repo" scope if you want to use it on a private repository)
+                  On Github, generate a new token with the "public_repo" scope
+                  (or the "repo" scope if you want to use it on a private
+                  repository)
                 </li>
                 <li>
                   Use the "Update" button to add the access token to the repo.


### PR DESCRIPTION
## Current contents
- [x] Bot command chips now link to the correct repo instead of VelCom
- [x] Tell the user that they probably want to create a new account for the bot instead of using their own
- [x] Hide link with some markdown
- [x] Better backend error messages
- [ ] Include significant dimensions in comment
