### PR TITLE
Fix detail graph loading

### DIFF
--- a/frontend/src/components/graphs/graph/EchartsDetailGraph.vue
+++ b/frontend/src/components/graphs/graph/EchartsDetailGraph.vue
@@ -558,7 +558,7 @@ export default class EchartsDetailGraph extends Vue {
   // <!--</editor-fold>-->
 
   // <!--<editor-fold desc="SERIES GENERATION">-->
-  private findFirstSuccessful = (seriesId: SeriesId) => {
+  private findFirstSuccessful(seriesId: SeriesId) {
     const point = this.datapoints.find(it => it.successful(seriesId))
 
     if (point) {


### PR DESCRIPTION
After a dependency update, the arrow function `findFirstSuccessful` apparently bound to a different "this" - one *before* the component was properly initialized. This was bad, as it did not receive any reactive getters and was reading outdated values.

This PR converts it to a normal function, which properly captures the this context.