### PR TITLE
Fix date selection dialogs in detail graph

### DIFF
--- a/frontend/src/components/graphs/helper/GraphTimespanControls.vue
+++ b/frontend/src/components/graphs/helper/GraphTimespanControls.vue
@@ -124,14 +124,8 @@ export default class GraphTimespanControls extends Vue {
       value: this.startTimeString,
       role: 'start',
       opened: false,
-      saveFunction: (field: TimeField, value: string) => {
-        this.saveMenu(field.ref, value)
-        this.$emit('update:startTime', new Date(value))
-        this.$emit('reload-graph-data')
-      },
-      allowedDates: (value: string) => {
-        return new Date(value) <= this.endTime
-      },
+      saveFunction: this.saveStartTime,
+      allowedDates: this.allowedDatesStart,
       rules: []
     },
     {
@@ -139,14 +133,8 @@ export default class GraphTimespanControls extends Vue {
       value: this.endTimeString,
       role: 'end',
       opened: false,
-      saveFunction: (field: TimeField, value: string) => {
-        this.saveMenu(field.ref, value)
-        this.$emit('update:endTime', new Date(value))
-        this.$emit('reload-graph-data')
-      },
-      allowedDates: (value: string) => {
-        return new Date(value) >= this.startTime
-      },
+      saveFunction: this.saveEndTime,
+      allowedDates: this.allowedDatesEnd,
       rules: [this.ruleStopAfterStart]
     }
   ]
@@ -160,6 +148,27 @@ export default class GraphTimespanControls extends Vue {
   private readonly startTime!: Date
   // <!--</editor-fold>-->
 
+  // <!--<editor-fold desc="Save helpers to bind to correct this">-->
+  private allowedDatesStart(dateString: string) {
+    return new Date(dateString) <= this.endTime
+  }
+
+  private allowedDatesEnd(dateString: string) {
+    return new Date(dateString) >= this.startTime
+  }
+
+  private saveStartTime(field: TimeField, value: string) {
+    this.saveMenu(field.ref, value)
+    this.$emit('update:startTime', new Date(value))
+    this.$emit('reload-graph-data')
+  }
+
+  private saveEndTime(field: TimeField, value: string) {
+    this.saveMenu(field.ref, value)
+    this.$emit('update:endTime', new Date(value))
+    this.$emit('reload-graph-data')
+  }
+
   private saveMenu(ref: string, value: string) {
     let field: any
     const readRef = this.$refs[ref]
@@ -171,6 +180,7 @@ export default class GraphTimespanControls extends Vue {
     }
     field.save(value)
   }
+  // <!--</editor-fold>-->
 
   // <!--<editor-fold desc="Duration">-->
   private get duration(): number {

--- a/frontend/src/store/modules/comparisonGraphStore.ts
+++ b/frontend/src/store/modules/comparisonGraphStore.ts
@@ -186,10 +186,6 @@ export class ComparisonGraphStore extends VxModule {
     }
   }
 
-  get selectedBranchesForRepo(): (repoId: RepoId) => string[] {
-    return repoId => this._selectedBranches[repoId] || []
-  }
-
   get selectedBranches(): Map<RepoId, string[]> {
     const map: Map<RepoId, string[]> = new Map()
     Object.keys(this._selectedBranches)

--- a/frontend/src/store/modules/repoStore.ts
+++ b/frontend/src/store/modules/repoStore.ts
@@ -173,23 +173,6 @@ export class RepoStore extends VxModule {
     }
   }
 
-  get occuringBenchmarks(): (selectedRepos: RepoId[]) => string[] {
-    return (selectedRepos: string[]) => {
-      const benchmarks = Object.values(this.repos)
-        .filter(repo => selectedRepos.includes(repo.id))
-        .flatMap(repo => repo.dimensions)
-        .map(dimension => dimension.benchmark)
-        .reduce(
-          (benchmarks, newBenchmark) => benchmarks.add(newBenchmark),
-          new Set<string>()
-        )
-
-      return Array.from(benchmarks).sort((a, b) =>
-        a.localeCompare(b, undefined, { sensitivity: 'base' })
-      )
-    }
-  }
-
   get metricsForBenchmark(): (benchmark: string) => string[] {
     return (benchmark: string) => {
       const metrics = Object.values(this.repos)

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -322,12 +322,6 @@ export class RunResultSuccess {
   constructor(measurements: Measurement[]) {
     this.measurements = measurements
   }
-
-  public resultForDimension(dimension: DimensionId): Measurement | undefined {
-    return this.measurements.find(measurement => {
-      return dimensionIdEquals(measurement.dimension, dimension)
-    })
-  }
 }
 export type RunResult =
   | RunResultScriptError


### PR DESCRIPTION
The last dependency upgrades apparently subtly changed how `this` is bound in Vue components and this PR removes the (based on grep) last usage of arrow functions in instance fields.