### PR TITLE
Allow comparing repos in bar graph without selecting a baseline

### DIFF
--- a/frontend/src/components/graphs/statuscomparison/StatusComparisonGraph.vue
+++ b/frontend/src/components/graphs/statuscomparison/StatusComparisonGraph.vue
@@ -346,7 +346,9 @@ export default class StatusComparisonGraph extends Vue {
           },
           myDecal: {
             show: true,
-            title: this.showDecals ? 'Hide decals' : 'Show decals',
+            title: this.showDecals
+              ? 'Hide pattern in bars'
+              : 'Show pattern in bars',
             icon: mdiDotsHexagon,
             onclick: () => {
               this.showDecals = !this.showDecals

--- a/frontend/src/components/misc/RepoSelectionComponent.vue
+++ b/frontend/src/components/misc/RepoSelectionComponent.vue
@@ -6,6 +6,7 @@
     :value="repoId"
     :label="label"
     :hide-details="rules.length === 0"
+    :clearable="clearable"
     @input="setRepoId"
     item-text="name"
     item-value="id"
@@ -46,6 +47,9 @@ export default class RepoSelectionComponent extends Vue {
 
   @Prop({ default: 'Repository name' })
   private readonly label!: string
+
+  @Prop({ default: false })
+  private readonly clearable!: boolean
 
   private setRepoId(newValue: string) {
     this.$emit('value', newValue)

--- a/frontend/src/views/StatusComparison.vue
+++ b/frontend/src/views/StatusComparison.vue
@@ -10,6 +10,7 @@
           <v-card-text>
             <repo-selection-component
               :repos="possibleBaselineRepos"
+              :clearable="true"
               label="Baseline repository"
               v-model="baselineRepoId"
             ></repo-selection-component>
@@ -168,7 +169,7 @@ export default class StatusComparison extends Vue {
   private get baselineErrorMessage() {
     const baselineRepoId = this.baselineRepoId
     if (baselineRepoId === null) {
-      return 'Please select a baseline in the top left'
+      return null
     }
 
     const baselinePoint = this.data.find(it => it.repoId === baselineRepoId)
@@ -199,7 +200,12 @@ export default class StatusComparison extends Vue {
     if (this.baselineErrorMessage !== null) {
       return null
     }
-    const baselineRepoId = vxm.statusComparisonModule.baselineRepoId!
+    const baselineRepoId = vxm.statusComparisonModule.baselineRepoId
+
+    if (baselineRepoId === null) {
+      return null
+    }
+
     const baselinePoint = this.data.find(it => it.repoId === baselineRepoId)!
     const run = baselinePoint.run!
     const result = run.result as RunResultSuccess


### PR DESCRIPTION
See https://github.com/IPDSnelting/velcom/issues/264#issuecomment-877184030. This PR allows you to interact with the comparison graph while no baseline is selected. This might be helpful if you select actually comparable dimensions of similar magnitude.


https://user-images.githubusercontent.com/20284688/125109663-f060b600-e0e3-11eb-82f4-adc34f337992.mp4

