### PR TITLE
Do not deploy the runner artifact in github actions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -157,8 +157,6 @@ jobs:
       CD_USER: ${{ secrets.CD_USER }}
       SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-      AAAAAAAH_CD_RUNNER_URL: ${{ secrets.AAAAAAAH_CD_RUNNER_URL }}
-      AAAAAAAH_CD_RUNNER_PORT: ${{ secrets.AAAAAAAH_CD_RUNNER_PORT }}
 
     steps:
       - uses: actions/checkout@v2

--- a/scripts/deploy-aaaaaaah/deploy.sh
+++ b/scripts/deploy-aaaaaaah/deploy.sh
@@ -12,16 +12,6 @@ function executeOnServer() {
     ssh -p "$CD_PORT" "$CD_USER@$CD_URL" "$1"
 }
 
-function executeOnRunner() {
-    echo "Executing on runner: '$1'"
-    ssh -p "$AAAAAAAH_CD_RUNNER_PORT" "$CD_USER@$AAAAAAAH_CD_RUNNER_URL" "$1"
-}
-
-function copyToRunner() {
-    echo "Copying to runner: '$1' to '$2'"
-    scp -P "$AAAAAAAH_CD_RUNNER_PORT" "$1" "$CD_USER@$AAAAAAAH_CD_RUNNER_URL:$2"
-}
-
 function setup() {
     ##
     ## Create the SSH directory and give it the right permissions
@@ -71,9 +61,3 @@ executeOnServer "sudo /home/velcom/update-docker-image.sh"
 
 # Restart the docker container :)
 executeOnServer "sudo systemctl restart velcom.service"
-
-# Push artifact to runner
-copyToRunner "runner.jar" "/home/velcom/velcom_runner/runner.jar"
-
-# Restart runner
-executeOnRunner "sudo /home/velcom/velcom_runner/restart_runner.sh"


### PR DESCRIPTION
The runner CD was broken after I restructured my infrastructure. This PR removes the outdated deployment scripts.

Closes #290 