### PR TITLE
Format Github message with root locale

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/github/GithubPrInteractor.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/github/GithubPrInteractor.java
@@ -48,6 +48,7 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -647,8 +648,8 @@ public class GithubPrInteractor {
 					prefix,
 					diff.getDimension().getBenchmark(),
 					diff.getDimension().getMetric(),
-					diff.getReldiff().map(d -> String.format("%.0f%%", d * 100)).orElse("-"),
-					diff.getStddevDiff().map(d -> String.format("(%.1f σ)", d)).orElse(null)
+					diff.getReldiff().map(d -> String.format(Locale.ROOT, "%.0f%%", d * 100)).orElse("-"),
+					diff.getStddevDiff().map(d -> String.format(Locale.ROOT, "(%.1f σ)", d)).orElse(null)
 				);
 			})
 			.forEach(lines::add);


### PR DESCRIPTION
Otherwise the system locale might have a different decimal separator, failing tests or causing inconsistencies:
![image](https://user-images.githubusercontent.com/20284688/137499979-80555592-5e29-4476-b5f9-be39a0c9937e.png)
