### PR TITLE
Fix HTML double escaping in ANSI colored text

### DIFF
--- a/frontend/src/util/Texts.ts
+++ b/frontend/src/util/Texts.ts
@@ -21,9 +21,9 @@ export function escapeHtml(input: string): string {
  * @param input the input text
  */
 export function safeConvertAnsi(input: string): string {
-  const safeInput = escapeHtml(input)
-
-  return converter.ansi_to_html(safeInput)
+  // The conversion function of ansi_up 5+ sanitizes input by itself, so
+  // just converting it is safe
+  return converter.ansi_to_html(input)
 }
 
 /**


### PR DESCRIPTION
## Problem description
Since version 5 of `ansi_up`, it now properly handles and enables HTML sanitization, which we also perform ourselfs. This results in double-escaping and output like "&lt;error&gt;" instead of "<error>".

## Fix
This patch removes our own escaping and relies on `ansi_up` to do it properly. [Their changelog](https://github.com/drudru/ansi_up/releases/tag/v5.0.0) assures us that this should always:tm: be the case.  
Their escape handling seems a lot less robust than ours but we don't really have much choice and they seem to follow the OWASP guideline [here](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#rule-1-html-encode-before-inserting-untrusted-data-into-html-element-content) at least. For reference, this is what they do:
```ts
    private escape_txt_for_html(txt:string):string
    {
      return txt.replace(/[&<>"']/gm, (str) => {
        if (str === "&")  return "&amp;";
        if (str === "<")  return "&lt;";
        if (str === ">")  return "&gt;";
        if (str === "\"") return "&quot;";
        if (str === "'")  return "&#x27;";
      });
    }
```

### Before
![grafik](https://user-images.githubusercontent.com/20284688/139752348-8ee620df-fe66-4257-ae4f-1a77e676fee4.png)

### After
![grafik](https://user-images.githubusercontent.com/20284688/139752357-170d2670-7435-40d7-bc85-9773f1bb4d4a.png)