### PR TITLE
Fix publish workflow for location independent image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -275,7 +275,7 @@ jobs:
     needs: [build-frontend-location-independent, build-backend]
 
     runs-on: ubuntu-latest
-    if: "github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/chore/build-location-independent')"
+    if: "github.event_name == 'push' && github.ref == 'refs/heads/main'"
 
     steps:
       # SETUP
@@ -315,15 +315,7 @@ jobs:
 
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-
-          # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "master" ] && VERSION=latest
+          VERSION=build-location-independent
 
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION


### PR DESCRIPTION
The workflow file used the wrong tag to update the location independent image, overwriting the "main" image instead (used by the Aaaaaaah instance). Apparently nothing broke which is nice, but this PR fixes the image version.

Closes #306 