### PR TITLE
Sort series data in status graph alphabetically

### DIFF
--- a/frontend/src/components/graphs/statuscomparison/StatusComparisonGraph.vue
+++ b/frontend/src/components/graphs/statuscomparison/StatusComparisonGraph.vue
@@ -452,21 +452,24 @@ export default class StatusComparisonGraph extends Vue {
       datapoints = data
     }
 
-    const seriesData = this.selectedDimensions.map(dim => {
-      const displayedPoint = datapoints.find(point =>
-        dimensionIdEquals(dim, point.dimension)
-      )
-      if (displayedPoint) return displayedPoint
-      return new DatapointDimensionError(
-        dim,
-        repoId,
-        'Not measured',
-        'NO_MEASUREMENT',
-        this.maxDatapointValue,
-        this.repoColor(repoId),
-        this.themeColor
-      )
-    })
+    const seriesData = this.selectedDimensions
+      .slice()
+      .sort((a, b) => a.toString().localeCompare(b.toString()))
+      .map(dim => {
+        const displayedPoint = datapoints.find(point =>
+          dimensionIdEquals(dim, point.dimension)
+        )
+        if (displayedPoint) return displayedPoint
+        return new DatapointDimensionError(
+          dim,
+          repoId,
+          'Not measured',
+          'NO_MEASUREMENT',
+          this.maxDatapointValue,
+          this.repoColor(repoId),
+          this.themeColor
+        )
+      })
 
     return {
       type: 'bar',


### PR DESCRIPTION
This PR just sorts the dimensions in the status comparison graph alphabetically:
![image](https://user-images.githubusercontent.com/20284688/142158974-c93f8c81-4449-44cb-bb7b-c8f8e3b00e7f.png)
