### PR TITLE
Clarify errors in bench script specification

### DIFF
--- a/docs/bench_repo_specification.md
+++ b/docs/bench_repo_specification.md
@@ -38,9 +38,10 @@ Example:
 
 The script should output its results on `stdout`.
 The result is encoded in JSON.
-Output to `stderr` is shown only while benchmarking (streamed to the task-detail page) and in case of an error.
+Output to `stderr` is shown only while benchmarking (streamed to the
+task-detail page) and in case of a *benchmark script panic* (see below).
 
-### Output format
+### Failure modes
 
 Executing the `bench` script isn't always successful and VelCom groups the
 errors into two categories:
@@ -73,7 +74,7 @@ terminate with a zero exit code:
 * `<error_string>` is a string describing the error.
 
 
-----
+## Output format
 
 If the `bench` script did not crash and the tested revision works well enough
 that measurements could be taken, this format should be used:

--- a/docs/bench_repo_specification.md
+++ b/docs/bench_repo_specification.md
@@ -30,19 +30,41 @@ Example:
 ./bench ../my_little_compiler/
 ```
 
-| Return code | Explanation |
-|-------------|-------------|
-| 0 | No error |
-| 1 | Internal script error |
-| 2 | Incorrect script usage |
+| Return code | Explanation            |
+|-------------|------------------------|
+| 0           | No error               |
+| 1           | Internal script error  |
+| 2           | Incorrect script usage |
 
 The script should output its results on `stdout`.
 The result is encoded in JSON.
-Output to `stderr` is shown only while benchmarking and in case of an error.
+Output to `stderr` is shown only while benchmarking (streamed to the task-detail page) and in case of an error.
 
 ### Output format
 
-If an error occurs that prevented the benchmark script from running successfully, this format should be used:
+Executing the `bench` script isn't always successful and VelCom groups the
+errors into two categories:
+- `bench` script panics, which indicate that the benchmark script itself
+  crashed (i.e. the author of the benchmark repo needs to fix a bug).  
+  Example: The `bench` script suffered a segmentation fault.
+- errors of the benchmarked program, which indicate that the `bench` script
+  worked correctly, but the revision it tested had a critical problem (i.e. the
+  program under test has a problem and needs to be fixed).  
+  Example: The program under test fails to compile and therefore the bench
+  `script` can not test it.
+
+Benchmark script panics are indicated by a non-zero exit code of the `bench`
+script. If this happens, VelCom tries to provide as much information as it can
+in the UI, including the full `stdout`, `stderr`, information about the
+execution environment and maybe a potential cause for the error. Panics always
+take precedence over errors of the benchmarked program: If the `bench` script
+exits with a non-zero exit code, it is *always* treated as a benchmark script
+panic.
+
+
+If instead the program under test suffered a critical failure and the `bench`
+script is not able to test it, it should use the following output format and
+terminate with a zero exit code:
 ```
 {
     "error": <error_string>
@@ -50,7 +72,11 @@ If an error occurs that prevented the benchmark script from running successfully
 ```
 * `<error_string>` is a string describing the error.
 
-Otherwise, this format should be used:
+
+----
+
+If the `bench` script did not crash and the tested revision works well enough
+that measurements could be taken, this format should be used:
 ```
 {
     <benchmark>: {
@@ -113,6 +139,6 @@ A successful run with two successful sets and one failed set of measurements:
 A failed run:
 ```json
 {
-    "error": "Could not find makefile"
+    "error": "Could not find Makefile"
 }
 ```


### PR DESCRIPTION
As discovered in #302, the bench repo specification is a bit light on details about errors, not making a clear distinction between `bench` script panics and errors in the benchmarked program. Due to this is it wasn't always very clear why VelCom chose to present errors in a given way and interpreted/did not interpret the output as a json result.

This PR aims to clarify this in the specification.