### PR TITLE
Ignore curl's exit code in Aaaaaaah deployment

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -142,5 +142,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: "Call deploy script"
-        run: 'curl -H "Authorization: Bearer ${{ secrets.AAAAAAAH_PING_TOKEN }}" ${{ secrets.AAAAAAAH_PING_ENDPOINT }}'
+        run: 'curl -H "Authorization: Bearer ${{ secrets.AAAAAAAH_PING_TOKEN }}" ${{ secrets.AAAAAAAH_PING_ENDPOINT }} || echo "We only need the ping, not the response."'
 


### PR DESCRIPTION
The deployment only needs to *ping* the server behind but that service isn't always *too* kind with what it returns. It drags out the response until it finished re-deploying all changed docker containers which might cause curl to time out. Additionally, as seen in the last run, it might re-deploy the *reverse proxy*, causing the response to get totally lost.

This isn't a problem though, the service will eventually update velcom even if it does not respond kindly.