### PR TITLE
Fix deletion of dimensions with `/` in the name

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/ServerMain.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/ServerMain.java
@@ -26,7 +26,7 @@ import de.aaaaaaah.velcom.backend.restapi.endpoints.AllReposEndpoint;
 import de.aaaaaaah.velcom.backend.restapi.endpoints.CommitEndpoint;
 import de.aaaaaaah.velcom.backend.restapi.endpoints.CompareEndpoint;
 import de.aaaaaaah.velcom.backend.restapi.endpoints.DebugEndpoint;
-import de.aaaaaaah.velcom.backend.restapi.endpoints.DimensionEndpoint;
+import de.aaaaaaah.velcom.backend.restapi.endpoints.DimensionsEndpoint;
 import de.aaaaaaah.velcom.backend.restapi.endpoints.GraphComparisonEndpoint;
 import de.aaaaaaah.velcom.backend.restapi.endpoints.GraphDetailEndpoint;
 import de.aaaaaaah.velcom.backend.restapi.endpoints.GraphStatusComparisonEndpoint;
@@ -207,7 +207,7 @@ public class ServerMain extends Application<GlobalConfig> {
 			new CompareEndpoint(benchmarkAccess, commitAccess, dimensionAccess, runCache, latestRunCache,
 				runComparator, significanceDetector, significanceFactors),
 			new DebugEndpoint(benchmarkAccess, dispatcher),
-			new DimensionEndpoint(dimensionAccess),
+			new DimensionsEndpoint(dimensionAccess),
 			new GraphComparisonEndpoint(benchmarkAccess, commitAccess, dimensionAccess),
 			new GraphDetailEndpoint(commitAccess, benchmarkAccess, dimensionAccess, repoAccess, runCache,
 				latestRunCache),

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/dimensionaccess/DimensionWriteAccess.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/dimensionaccess/DimensionWriteAccess.java
@@ -5,8 +5,9 @@ import static org.jooq.codegen.db.tables.Dimension.DIMENSION;
 import de.aaaaaaah.velcom.backend.access.caches.AvailableDimensionsCache;
 import de.aaaaaaah.velcom.backend.access.caches.RunCache;
 import de.aaaaaaah.velcom.backend.access.dimensionaccess.entities.Dimension;
-import de.aaaaaaah.velcom.backend.storage.db.DBWriteAccess;
+import de.aaaaaaah.velcom.backend.access.dimensionaccess.exceptions.NoSuchDimensionException;
 import de.aaaaaaah.velcom.backend.storage.db.DatabaseStorage;
+import java.util.Collection;
 
 public class DimensionWriteAccess extends DimensionReadAccess {
 
@@ -22,14 +23,29 @@ public class DimensionWriteAccess extends DimensionReadAccess {
 		this.runCache = runCache;
 	}
 
-	public void deleteDimension(Dimension dimension) {
-		try (DBWriteAccess db = databaseStorage.acquireWriteAccess()) {
-			db.dsl()
-				.deleteFrom(DIMENSION)
-				.where(DIMENSION.BENCHMARK.eq(dimension.getBenchmark()))
-				.and(DIMENSION.METRIC.eq(dimension.getMetric()))
-				.execute();
-		}
+	/**
+	 * Deletes the given dimensions atomically. If any dimension does not exist, <em>nothing</em> is
+	 * deleted and an exception is raised.
+	 *
+	 * @param dimensions the dimensions to delete
+	 * @throws NoSuchDimensionException if a dimension does not exist
+	 */
+	public void deleteDimensions(Collection<Dimension> dimensions) {
+		databaseStorage.acquireWriteTransaction(db -> {
+			// This is not a good idea with most databases, but should be fine with SQLite as it is
+			// in-process.
+			for (Dimension dimension : dimensions) {
+				int affectedRows = db.dsl()
+					.deleteFrom(DIMENSION)
+					.where(DIMENSION.BENCHMARK.eq(dimension.getBenchmark()))
+					.and(DIMENSION.METRIC.eq(dimension.getMetric()))
+					.execute();
+
+				if (affectedRows == 0) {
+					throw new NoSuchDimensionException(dimension);
+				}
+			}
+		});
 
 		availableDimensionsCache.invalidateAll();
 		runCache.invalidateAll();

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/dimensionaccess/exceptions/NoSuchDimensionException.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/access/dimensionaccess/exceptions/NoSuchDimensionException.java
@@ -9,6 +9,11 @@ public class NoSuchDimensionException extends RuntimeException {
 
 	private final Dimension invalidDimension;
 
+	public NoSuchDimensionException(Dimension invalidDimension) {
+		super("no dimension " + invalidDimension);
+		this.invalidDimension = invalidDimension;
+	}
+
 	public NoSuchDimensionException(Throwable t, Dimension invalidDimension) {
 		super("no dimension " + invalidDimension, t);
 		this.invalidDimension = invalidDimension;

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/DimensionsEndpoint.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/endpoints/DimensionsEndpoint.java
@@ -1,26 +1,28 @@
 package de.aaaaaaah.velcom.backend.restapi.endpoints;
 
 import de.aaaaaaah.velcom.backend.access.dimensionaccess.DimensionWriteAccess;
-import de.aaaaaaah.velcom.backend.access.dimensionaccess.entities.Dimension;
 import de.aaaaaaah.velcom.backend.restapi.authentication.Admin;
+import de.aaaaaaah.velcom.backend.restapi.jsonobjects.JsonDimensionId;
 import io.dropwizard.auth.Auth;
 import io.micrometer.core.annotation.Timed;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 /**
  * Endpoint for deleting dimensions.
  */
-@Path("/dimension/{benchmark}/{metric}")
+@Path("/dimensions/")
 @Produces(MediaType.APPLICATION_JSON)
-public class DimensionEndpoint {
+public class DimensionsEndpoint {
 
 	private final DimensionWriteAccess dimensionAccess;
 
-	public DimensionEndpoint(DimensionWriteAccess dimensionAccess) {
+	public DimensionsEndpoint(DimensionWriteAccess dimensionAccess) {
 		this.dimensionAccess = dimensionAccess;
 	}
 
@@ -28,9 +30,13 @@ public class DimensionEndpoint {
 	@Timed(histogram = true)
 	public void delete(
 		@Auth Admin admin,
-		@PathParam("benchmark") String benchmark,
-		@PathParam("metric") String metric
+		@NotNull List<JsonDimensionId> request
 	) {
-		dimensionAccess.deleteDimension(new Dimension(benchmark, metric));
+		dimensionAccess.deleteDimensions(
+			request
+				.stream()
+				.map(JsonDimensionId::toDimension)
+				.collect(Collectors.toList())
+		);
 	}
 }

--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonDimensionId.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/restapi/jsonobjects/JsonDimensionId.java
@@ -1,0 +1,26 @@
+package de.aaaaaaah.velcom.backend.restapi.jsonobjects;
+
+import de.aaaaaaah.velcom.backend.access.dimensionaccess.entities.Dimension;
+
+public class JsonDimensionId {
+
+	private final String benchmark;
+	private final String metric;
+
+	public JsonDimensionId(String benchmark, String metric) {
+		this.benchmark = benchmark;
+		this.metric = metric;
+	}
+
+	public String getBenchmark() {
+		return benchmark;
+	}
+
+	public String getMetric() {
+		return metric;
+	}
+
+	public Dimension toDimension() {
+		return new Dimension(getBenchmark(), getMetric());
+	}
+}

--- a/docs/public_api.yaml
+++ b/docs/public_api.yaml
@@ -1181,6 +1181,22 @@ paths:
       responses:
         '204':
           description: No Content
+        '404':
+          description: 'If any dimension could not be found. If this is returned, *no data* was deleted.'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: A message describing the error
+                  benchmark:
+                    type: string
+                    description: The benchmark part of the dimension that could not be found
+                  metric:
+                    type: string
+                    description: The metric part of the dimension that could not be found
       description: |-
         Deletes all given dimension and all their benchmarks. Does *not* remove empty runs afterwards.
 

--- a/docs/public_api.yaml
+++ b/docs/public_api.yaml
@@ -1173,27 +1173,27 @@ paths:
                   - dimensions
       operationId: get-dimensions
     parameters: []
-  '/dimension/{benchmark}/{metric}':
-    parameters:
-      - schema:
-          type: string
-        name: benchmark
-        in: path
-        required: true
-      - schema:
-          type: string
-        name: metric
-        in: path
-        required: true
+  /dimensions:
+    parameters: []
     delete:
       summary: delete dimension
       operationId: delete-dimensions-benchmark-metric
       responses:
         '204':
           description: No Content
-      description: Delete a dimension and all its benchmarks. Does *not* remove empty runs afterwards.
+      description: |-
+        Deletes all given dimension and all their benchmarks. Does *not* remove empty runs afterwards.
+
+        If any dimension in the request could not be found, the deletion is aborted atomically and *nothing* is deleted.
       security:
         - admin_credentials: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/DimensionId'
 components:
   schemas:
     CommitHash:
@@ -1532,6 +1532,14 @@ components:
         - metric
         - unit
         - interpretation
+    DimensionId:
+      title: DimensionId
+      type: object
+      properties:
+        benchmark:
+          type: string
+        metric:
+          type: string
     DimensionDifference:
       title: DimensionDifference
       type: object

--- a/frontend/src/store/modules/cleanupStore.ts
+++ b/frontend/src/store/modules/cleanupStore.ts
@@ -20,10 +20,11 @@ export class CleanupStore extends VxModule {
 
   @action
   async deleteDimensions(dimensions: Dimension[]): Promise<void> {
-    for (const dimension of dimensions) {
-      const benchmark = encodeURIComponent(dimension.benchmark)
-      const metric = encodeURIComponent(dimension.metric)
-      await axios.delete(`/dimension/${benchmark}/${metric}`)
-    }
+    const dimensionIds = dimensions.map(it => ({
+      metric: it.metric,
+      benchmark: it.benchmark
+    }))
+
+    await axios.delete(`/dimensions`, { data: dimensionIds })
   }
 }


### PR DESCRIPTION
## Problem
Currently deleting dimensions with a `/` in the benchmark or metric name does not work, as the nginx proxy in the docker image *unescapes them* before passing it on to the backend. This is not ideal, as the backend then interprets them as a normal path separator and fails to find a matching endpoint.

## Fix
Rather than trying to get nginx to behave (which seems to be quite involved when applied in a proxy_pass directive) and forcing every user to configure their reverse proxy to preserve unencoded slashes, we just sidestep this by substituting `:s` for `/` and `:c` for `:`. This is quite easy to apply and reverse using `String::replace` and should not be reversed by any proxy layer.

## Considerations
As nginx seems to decode the url, there might be other parameters leading to incorrect interpretation in the backend.