### PR TITLE
Only render run detail component once

### DIFF
--- a/frontend/src/views/RunCommitDetailView.vue
+++ b/frontend/src/views/RunCommitDetailView.vue
@@ -5,7 +5,12 @@
         <v-skeleton-loader type="card"></v-skeleton-loader>
       </v-col>
     </v-row>
-    <v-row v-if="commit">
+    <!--
+        Vue reuses elements on conditional re-render. The run-detail page's render method is relatively heavy though,
+        so we need to prevent Vue reusing its slot for the asynchronously loaded commit row.
+        See https://github.com/IPDSnelting/velcom/pull/342 for more information.
+     -->
+    <v-row v-if="commit" key="commitsource">
       <v-col>
         <commit-detail
           :commit="commit"
@@ -21,7 +26,7 @@
         </commit-detail>
       </v-col>
     </v-row>
-    <v-row v-if="tarSource" justify="center">
+    <v-row v-if="tarSource" justify="center" key="tarsource">
       <v-col cols="auto">
         <tar-overview
           :tar-source="tarSource"
@@ -29,7 +34,7 @@
         ></tar-overview>
       </v-col>
     </v-row>
-    <v-row v-if="runWithDifferences">
+    <v-row v-if="runWithDifferences" key="runwithdiffs">
       <v-col>
         <run-detail
           @navigate-to-detail-graph="navigateToDetailGraph"
@@ -37,7 +42,7 @@
         ></run-detail>
       </v-col>
     </v-row>
-    <v-row v-if="finishedLoading && !runWithDifferences">
+    <v-row v-if="finishedLoading && !runWithDifferences" key="notbenchmarked">
       <v-col>
         <v-card>
           <v-card-title>
@@ -59,10 +64,10 @@
         </v-card>
       </v-col>
     </v-row>
-    <v-row v-if="show404">
+    <v-row v-if="show404" key="404">
       <page-404></page-404>
     </v-row>
-    <v-row v-if="commit && runWithDifferences" no-gutters>
+    <v-row v-if="commit && runWithDifferences" no-gutters key="timeline">
       <v-col>
         <run-timeline
           :selectedRunId="runWithDifferences ? runWithDifferences.run.id : null"


### PR DESCRIPTION
[Vue (intelligently) reuses components when using v-if](https://v2.vuejs.org/v2/guide/conditional.html#Controlling-Reusable-Elements-with-key). In this case, this lead to vue reusing the run-detail row for the commit component once the commit was fetched asynchronously.
This, in turn, triggered a re-render of the run-detail page -- including the relatively expensive measurement table -- into a new row.

Giving either the commit view (or tar) or the run-detail row a unique key prevents this reuse and only renders the table once. This patch adds keys to all rows for good measure, but the other components are relatively inexpensive to recreate and don't matter as much.

It is still a bit unfortunate, that the commit view jumps in afterwards and changes the layout. Its dimension (and whether it exists at all) is not known in advance though, so there isn't much you can do. Moving it below the table is not a *great* idea, as it makes navigation a lot harder. Maybe a skeleton placeholder with an assumed (hardcoded) size would make this not as jarring — but it won't prevent it.