### PR TITLE
Compute run detail difference table entries in linear time

### DIFF
--- a/frontend/src/components/rundetail/MeasurementsDisplay.vue
+++ b/frontend/src/components/rundetail/MeasurementsDisplay.vue
@@ -71,12 +71,12 @@ import Vue from 'vue'
 import Component from 'vue-class-component'
 import { Prop, Watch } from 'vue-property-decorator'
 import {
+  Dimension,
+  DimensionDifference,
+  DimensionInterpretation,
   Measurement,
   MeasurementError,
-  MeasurementSuccess,
-  DimensionInterpretation,
-  DimensionDifference,
-  Dimension
+  MeasurementSuccess
 } from '@/store/types'
 import MeasurementValueDisplay from '@/components/rundetail/MeasurementValueDisplay.vue'
 import { safeConvertAnsi } from '@/util/Texts'
@@ -284,10 +284,22 @@ export default class MeasurementsDisplay extends Vue {
   private differenceForDimension(
     dimension: Dimension
   ): DimensionDifference | undefined {
+    return this.differencesByDimension[dimension.toString()]
+  }
+
+  private get differencesByDimension(): {
+    [asString: string]: DimensionDifference
+  } {
     if (!this.differences) {
-      return undefined
+      return {}
     }
-    return this.differences.find(it => it.dimension.equals(dimension))
+    const differencesByDimension: {
+      [asString: string]: DimensionDifference
+    } = {}
+    this.differences.forEach(it => {
+      differencesByDimension[it.dimension.toString()] = it
+    })
+    return differencesByDimension
   }
 
   private errorToItem(measurementError: MeasurementError): Item {


### PR DESCRIPTION
This reduces the measurement table rendering time by a bit for your 8000 metric usecase:
```
// before
items: 269ms - Timer beendet MeasurementsDisplay.vue:200
// after
items:  21ms - Timer beendet MeasurementsDisplay.vue:200
```

The remaining time is now mostly spent in the framework and rendering AFAICT, but I didn't look too closely.