### PR TITLE
Speed up comparison page

### DIFF
--- a/frontend/src/components/comparison/RunComparisonTable.vue
+++ b/frontend/src/components/comparison/RunComparisonTable.vue
@@ -170,14 +170,12 @@ export default class RunComparisonTable extends Vue {
       this.getDimensionsForRun(this.second)
     )
 
-    const uniqueDimensions: Dimension[] = []
+    const uniqueDimensions: Map<string, Dimension> = new Map()
     allDimensions.forEach(dim => {
-      if (!uniqueDimensions.find(existing => existing.equals(dim))) {
-        uniqueDimensions.push(dim)
-      }
+      uniqueDimensions.set(dim.toString(), dim)
     })
 
-    return uniqueDimensions.map(
+    return Array.from(uniqueDimensions.values()).map(
       dimension =>
         new TableItem(
           dimension.benchmark,

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -318,11 +318,33 @@ export class RunResultVelcomError {
 }
 export class RunResultSuccess {
   readonly measurements: Measurement[]
+  perDimension?: Map<string, Measurement>
 
   constructor(measurements: Measurement[]) {
     this.measurements = measurements
   }
+
+  /**
+   * Returns the measurement for a given dimension from a lazily-populated cache.
+   *
+   * @param dimension the dimension to look up the measurement for
+   */
+  public forDimension(dimension: Dimension): Measurement | undefined {
+    if (this.perDimension === undefined) {
+      this.perDimension = new Map()
+      for (const measurement of this.measurements) {
+        // We only have one measurement per dimension, so this index is safe and won't collide.
+        // Freeze the object as we won't make fine-granular changes to it (we always re-fetch the whole run)
+        this.perDimension.set(
+          measurement.dimension.toString(),
+          Object.freeze(measurement)
+        )
+      }
+    }
+    return this.perDimension!.get(dimension.toString())
+  }
 }
+
 export type RunResult =
   | RunResultScriptError
   | RunResultVelcomError

--- a/frontend/src/views/RunComparison.vue
+++ b/frontend/src/views/RunComparison.vue
@@ -125,12 +125,15 @@ export default class RunComparisonView extends Vue {
   private async fetchData() {
     this.comparison = null
 
-    this.comparison = await vxm.commitDetailComparisonModule.fetchComparison({
-      first: this.first,
-      second: this.second,
-      hash1: this.hash1,
-      hash2: this.hash2
-    })
+    // We don't need reactivity on this object, we only swap it wholesale.
+    this.comparison = Object.freeze(
+      await vxm.commitDetailComparisonModule.fetchComparison({
+        first: this.first,
+        second: this.second,
+        hash1: this.hash1,
+        hash2: this.hash2
+      })
+    )
   }
 
   mounted(): void {


### PR DESCRIPTION
## About
@Garmelon showed me a link (http://speedcenter.informatik.kit.edu/mathlib4/compare/1ed91d01-45f4-45a2-9d05-996d09b28b72/to/b7d05b7c-6dd2-4386-abec-1c376f284bab) which took ~40 seconds to load, freezing the page in the process. This seemed a bit odd and maybe not fully desired…

## Cause
Looking at some [firefox profiles](https://share.firefox.dev/45hOSU8), most of the rendering time was spent finding elements:
![grafik](https://github.com/IPDSnelting/velcom/assets/20284688/92ebaa06-5092-4261-bcdf-c18522f687d4)
The flame graph spans around 40 seconds, with 36 seconds spent in rendering.

This is obviously not ideal and looking at the code, most of the corresponding lines are finding measurement results for a given dimension, because the table first builds a list of all dimensions and then compares them between both runs. This necessitates finding results for both runs given a dimension.

## Fix
I now build two (frozen, because why not and it shaves off a hundred ms or so. It's a bit sad that Vue 2 does not offer the nice helpers Vue 3 brought) lookup caches indexed by dimension. This would be a lot nicer if JS had proper maps and sets, but in a pinch JS objects and stringified keys need to suffice.
I guess I never should have written the naive algorithm, but I also didn't exactly have 4k dimensions in mind when writing it.

## Result
The [new profile](https://share.firefox.dev/3DHrSSG) is a bit more promising:
![grafik](https://github.com/IPDSnelting/velcom/assets/20284688/60e02964-14bd-4c33-924d-6eb7a4cef8fe)
This time, the graph spans an area of 700ms and rendering takes ~120ms. This is much more bearable. I am currently on vacation and accessing the data through a slow internet connection. The page load time for me is now completely dominated by fetching the data from the backend (It takes 1.2 seconds to fetch the data and 200 ms until they are displayed on screen).

## Unrelated
It's also a bit annoying how the table is not wide enough, even though there is enough space on my screen. Maybe we should lift that restriction and allow the table to grow to full width, i.e.
![grafik](https://github.com/IPDSnelting/velcom/assets/20284688/c25b8f13-c96e-48e4-a580-7436a1ae2e3d)
The chips also look a bit odd with such a large amount of metrics (especially as they have long names).