### PR TITLE
Include default items per page setting in options

### DIFF
--- a/frontend/src/components/comparison/RunComparisonTable.vue
+++ b/frontend/src/components/comparison/RunComparisonTable.vue
@@ -3,6 +3,7 @@
     :headers="headers"
     :items="items"
     :items-per-page="200"
+    :footer-props="{ itemsPerPageOptions: [5, 25, 100, 200, 500, -1] }"
     multi-sort
     dense
     class="compare-table"

--- a/frontend/src/components/rundetail/MeasurementsDisplay.vue
+++ b/frontend/src/components/rundetail/MeasurementsDisplay.vue
@@ -30,6 +30,7 @@
       :headers="headers"
       :items="items"
       :items-per-page="200"
+      :footer-props="{ itemsPerPageOptions: [5, 25, 100, 200, 500, -1] }"
       class="measurement-table"
       @click:row="rowClicked"
     >


### PR DESCRIPTION
Previously, as noted by @Garmelon, the tables for the run comparison and measurement showed 200 rows, but the row selection checkbox was stuck at 5:
<img width="227" alt="grafik" src="https://github.com/IPDSnelting/velcom/assets/20284688/4bba9ab5-8a11-447a-acba-eb3d9f27ab04">

The cause for this odd behaviour is that the available options do not include the new default set in a PR a while ago, disallowing it to be selected. An easy fix is to just set the possible options and include the default :)
<img width="239" alt="grafik" src="https://github.com/IPDSnelting/velcom/assets/20284688/19a9d306-cec1-4dbd-af40-56777b2c9e0c">


Feel free to bikeshed the possible options.