### PR TITLE
[meta] Switch to more maintained java 11 docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -117,16 +117,3 @@ jobs:
           docker tag $IMAGE_NAME $IMAGE_ID:latest
           docker push $IMAGE_ID:latest
 
-  # Deploy main branch to velcom.aaaaaaah.de
-  deploy-aaaaaaah:
-    # Ensure build job passes before pushing image.
-    needs: [push-docker-image]
-
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: "Call deploy script"
-        run: 'curl -H "Authorization: Bearer ${{ secrets.AAAAAAAH_PING_TOKEN }}" ${{ secrets.AAAAAAAH_PING_ENDPOINT }} || echo "We only need the ping, not the response."'
-

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '19'
 
       - name: "Build frontend (location independent)"
         run: "./scripts/build-frontend --env production"
       - name: "Upload frontend artifacts (location independent)"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: frontend-artifacts
           path: frontend/dist
@@ -33,11 +33,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
+          distribution: 'temurin'
           java-version: '11'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -48,29 +49,29 @@ jobs:
         run: "./scripts/build-backend"
 
       - name: "Upload backend/backend artifact"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: backend-artifacts
+          name: backend-artifacts-backend
           path: backend/backend/target/backend.jar
       - name: "Upload aspectjweaver artifact"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: aspectjweaver-artifact
           path: backend/backend/target/dependency/aspectjweaver.jar
       - name: "Upload backend/runner artifacts"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: backend-artifacts
+          name: backend-artifacts-runner
           path: backend/runner/target/runner.jar
       - name: Release runner
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: backend/runner/target/runner.jar
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
+
 
   # Push location independent image to GitHub Packages.
   push-docker-image:
@@ -82,19 +83,20 @@ jobs:
 
     steps:
       # SETUP
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: "Download frontend artifacts"
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: frontend-artifacts
           path: dist
-      - name: "Download backend artifact"
-        uses: actions/download-artifact@v2
+      - name: "Download backend artifacts"
+        uses: actions/download-artifact@v4
         with:
-          name: backend-artifacts
+          pattern: backend-artifacts-*
+          merge-multiple: true
       - name: "Download aspectjweaver artifact"
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: aspectjweaver-artifact
 

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,7 +1,7 @@
 # vim: ft=dockerfile
 
 # Base image is java 11
-FROM openjdk:11-slim
+FROM eclipse-temurin:11
 LABEL "velcom-server"="true"
 
 


### PR DESCRIPTION
The current image seems to be broken on my host after an update, due to https://bugs.openjdk.org/browse/JDK-8287073?focusedId=14497312&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14497312.

The correct fix would be to actually update dependencies, but I don't quite have the time for that at this instance.