### PR TITLE
Temporarily disable !bench permission checks

### DIFF
--- a/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/github/GithubPrInteractor.java
+++ b/backend/backend/src/main/java/de/aaaaaaah/velcom/backend/listener/github/GithubPrInteractor.java
@@ -271,6 +271,9 @@ public class GithubPrInteractor {
 
 		Set<String> usersWithWritePermission = new HashSet<>();
 		for (String username : usernames) {
+			// HACK: Temporarily disable permission checks
+			usersWithWritePermission.add(username);
+
 			LOGGER.debug("Checking if {} has write permissions", username);
 			URI url = UriBuilder.fromUri("https://api.github.com/")
 				.path("repos")


### PR DESCRIPTION
Since the migration to a fork-based workflow, most people no longer have write permission, yet still want to benchmark their stuff. Until a more secure alternative can be implemented, this commit disables permission checks for the !bench command entirely.